### PR TITLE
Initial site updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+_site
+Gemfile.lock

--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,7 @@
 
 # theme                  : "minimal-mistakes-jekyll"
 # remote_theme           : "mmistakes/minimal-mistakes"
-minimal_mistakes_skin    : "air" # "air", "aqua", "contrast", "dark", "dirt", "neon", "mint", "plum", "sunrise"
+minimal_mistakes_skin    : "contrast" # "air", "aqua", "contrast", "dark", "dirt", "neon", "mint", "plum", "sunrise"
 mermaid                  : true
 use_math                 : true
 

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -6,10 +6,6 @@ main:
     url: /tutorials/
   - title: "API Documentation"
     url: /doc/main/
-  - title: <i class="fab fa-fw fa-github" aria-hidden="true"></i>GitHub
-    url: https://github.com/StanfordLegion/realm
-  - title: <i class="fab fa-fw fa-youtube" aria-hidden="true"></i>YouTube
-    url: https://www.youtube.com/@stanfordlegion
 sidebar:
   - title: "Getting Started"
     children:

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,16 +1,16 @@
 # main links
 main:
-  - title: "Blog"
-    url: /index.html
-  - title: "Documentation"
+  - title: "Overview"
+    url: /
+  - title: "Tutorials"
+    url: /tutorials/
+  - title: "API Documentation"
     url: /doc/main/
   - title: <i class="fab fa-fw fa-github" aria-hidden="true"></i>GitHub
     url: https://github.com/StanfordLegion/realm
   - title: <i class="fab fa-fw fa-youtube" aria-hidden="true"></i>YouTube
     url: https://www.youtube.com/@stanfordlegion
 sidebar:
-  - title: "Blog"
-    url: /index.html
   - title: "Getting Started"
     children:
       - title: "Quick Start Guide"
@@ -29,9 +29,3 @@ sidebar:
         url: https://github.com/StanfordLegion/realm/issues
       - title: "License"
         url: https://github.com/StanfordLegion/realm/blob/main/LICENSE.txt
-  # - title: "Sample Posts"
-  #   url: /year-archive/
-  # - title: "Sample Collections"
-  #   url: /collection-archive/
-  # - title: "Sitemap"
-  #   url: /sitemap/

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,9 +1,5 @@
 <div class="page__footer-follow">
   <ul class="social-icons">
-    {% if site.data.ui-text[site.locale].follow_label %}
-      <li><strong>{{ site.data.ui-text[site.locale].follow_label }}</strong></li>
-    {% endif %}
-
     {% if site.footer.links %}
       {% for link in site.footer.links %}
         {% if link.label and link.url %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -14,4 +14,4 @@
   </ul>
 </div>
 
-<div class="page__footer-copyright">&copy; {{ site.time | date: '%Y' }} <a href="{{ site.copyright_url | default: site.url }}">{{ site.copyright | default: site.title }}</a>. {{ site.data.ui-text[site.locale].powered_by | default: "Powered by" }} <a href="https://jekyllrb.com" rel="nofollow">Jekyll</a> &amp; <a href="https://mademistakes.com/work/jekyll-themes/minimal-mistakes/" rel="nofollow">Minimal Mistakes</a>.</div>
+<div class="page__footer-copyright">&copy; {{ site.time | date: '%Y' }} <a href="{{ site.copyright_url | default: site.url }}">{{ site.copyright | default: site.title }}</a>.</div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,20 +1,5 @@
 ---
-layout: archive
+layout: single
 ---
 
 {{ content }}
-
-<h3 class="archive__subtitle">{{ site.data.ui-text[site.locale].recent_posts | default: "Recent Posts" }}</h3>
-
-{% if paginator %}
-  {% assign posts = paginator.posts %}
-{% else %}
-  {% assign posts = site.posts %}
-{% endif %}
-
-{% assign entries_layout = page.entries_layout | default: 'list' %}
-<div class="entries-{{ entries_layout }}">
-  {% include documents-collection.html entries=posts type=entries_layout %}
-</div>
-
-{% include paginator.html %}

--- a/index.html
+++ b/index.html
@@ -1,3 +1,0 @@
----
-layout: home
----

--- a/index.md
+++ b/index.md
@@ -1,0 +1,42 @@
+---
+layout: home
+---
+
+# Overview
+
+Realm is a distributed, **event–based tasking runtime** for building
+high-performance applications that span clusters of CPUs, GPUs, and
+other accelerators.
+
+It began life as the low-level substrate underneath the
+[Legion](https://github.com/StanfordLegion/legion) programming system but is
+now maintained as a standalone project for developers who want direct,
+fine-grained control of parallel and heterogeneous machines.
+
+## Why Realm?
+
+* **Asynchronous tasks and events** — Compose applications out of many
+  light-weight tasks connected by events instead of blocking synchronization.
+* **Heterogeneous execution** — Target CPUs, NVIDIA CUDA/HIP GPUs, OpenMP
+  threads, and specialized fabrics with a single API.
+* **Scalable networking** — Integrate GASNet-EX, UCX, MPI or shared memory
+  transports for efficient inter-node communication.
+* **Extensible modules** — Enable/disable features (CUDA, HIP, LLVM JIT, NVTX,
+  PAPI …) at build time with simple CMake flags.
+* **Portable performance** — Realm applications routinely scale from laptops
+  to the world's largest supercomputers.
+
+The runtime follows a *data-flow* execution model: tasks are launched
+asynchronously and start when their pre-condition events trigger. This design
+hides network and device latency, maximizes overlap, and gives programmers
+explicit control over when work becomes runnable.
+
+For a deeper dive see the
+[Realm white-paper](https://cs.stanford.edu/~sjt/pubs/pact14.pdf) published
+at PACT 2014.
+
+## Acknowledgements
+
+Realm is developed and maintained by the Stanford Legion team with significant
+contributions from NVIDIA, Los Alamos, Livermore, Sandia, and many members of
+the broader HPC community.


### PR DESCRIPTION
This PR updates the Github Pages site on the `gh-pages` branch:

* Switch a theme similar to the Legion site
* Remove (some) blog/post related content
* Populate `index.md` with content derived from README.md
* Makes minor tweaks to topnav and footers

The changes are attempted to be split up into granular commits in case some of the changes (e.g. to nav) are not desired. 

---

<img width="700" alt="Screenshot 2025-07-02 at 16 36 37" src="https://github.com/user-attachments/assets/cfeee6e9-810d-4bec-9441-d6ee8706859d" />
