### PR TITLE
Update hello, events, machine tutorials

### DIFF
--- a/tutorials/events/events_basic.cc
+++ b/tutorials/events/events_basic.cc
@@ -13,13 +13,58 @@
  * limitations under the License.
  */
 
+/**
+ * Realm Event Tutorial
+ *
+ * Realm is a fully asynchronous, event-based runtime, and events form the backbone
+ * of Realm’s programming model, describing the dependencies between operations.
+ * Realm operations are deferred by the runtime, which returns an event that triggers
+ * upon completion of the operation. These events are created by the runtime and can
+ * be used as pre- or post-conditions for other operations. Events provide a mechanism
+ * that allows the runtime to efficiently manage asynchronous program execution,
+ * offering opportunities to hide latencies when communications are required.
+ *
+ * All operations accept completion events as preconditions.
+ * All operations must return completion events.
+ *
+ * Realm Event: Optimized distributed data structure
+ * - Fixed-size, no reference counting
+ * - No dependency on application runtime
+ * - Small memory footprint
+ * - Communication/storage needed only for interested nodes
+ *
+ * Realm applications create a huge number of events:
+ *   > 1 million events per processor per node per second
+ *   > 1 billion events per second cluster-wide
+ *
+ * Topics Covered:
+ * - Events Basics
+ * - Creating Events
+ * - Triggering Events
+ * - Creating Control Dependencies
+ *
+ * Events Basics
+ * -------------
+ * Usually, Realm creates Events as part of handling application requests for asynchronous
+ * operations. An Event is a lightweight handle that can be easily transported around the
+ * system. The node that creates an Event owns it, and the space for these handles is
+ * statically divided across all nodes by including the node ID in the upper bits of the
+ * handle. This design ensures that any node can create new handles without the risk of
+ * collision or requiring inter-node communication.
+ *
+ * When a new Event is created, the owning node allocates a data structure to track its
+ * state, which is initially untriggered but will eventually become triggered or poisoned.
+ * The data structure also includes a list of local waiters and remote waiters. Local waiters
+ * are dependent operations on the owner node, and remote waiters are other nodes that are
+ * interested in the Event (event dependencies).
+ */
+
 #include <realm.h>
 #include <realm/cmdline.h>
 
 using namespace Realm;
 
-enum
-{
+enum {
   MAIN_TASK = Processor::TASK_ID_FIRST_AVAILABLE + 0,
   READER_TASK_0,
   READER_TASK_1,
@@ -51,18 +96,95 @@ void main_task(const void *args, size_t arglen, const void *userdata,
                     size_t userlen, Processor p) {
   TaskArgs task_args{.x = 7};
 
+  /**
+   *
+   * Creating Events
+   * ---------------
+   * In this program, we launch several tasks (reader_task_0 and reader_task_1) responsible
+   * for printing an integer value x. Each task launch is a non-blocking asynchronous call
+   * that returns an internal event handle. Once created, the Event handle can be passed around
+   * through task arguments or shared data structures and eventually used as a pre- or post-
+   * condition for operations to be executed on other nodes.
+   *
+   * When a remote node makes the first reference to task_event, it allocates the same data
+   * structure, sets its state to untriggered, and adds the dependent operation to its own
+   * local waiter list. Then, an event subscription active message is sent to the owner node
+   * to indicate that the remote node is interested and should be added to the list of remote
+   * waiters, so it can be informed when task_event triggers. Any additional dependent operations
+   * on a remote node are added to the list of local waiters without requiring communication with
+   * the owner node. When task_event eventually triggers, the owner node notifies all local waiters
+   * and sends an event trigger message to each subscribed node on the list of remote waiters.
+   * If the owner node receives additional subscription messages after it has been triggered,
+   * it immediately responds to the new subscribers with a trigger message as well.
+   *
+   * ---------------------------
+   * A UserEvent is created explicitly by the application. It starts in an
+   * untriggered state and can later be triggered manually by the user. This allows
+   * dynamic construction of control dependencies, enabling other events or tasks to
+   * be conditioned on it. The event handle is small, fixed-size, and efficiently
+   * propagated.
+   */
   UserEvent user_event = UserEvent::create_user_event();
 
   std::vector<Event> events;
+
+
+ /* Creating Control Dependencies
+   * -----------------------------
+   * We demonstrate how to establish a control dependency using events by making reader_task_1
+   * dependent on the completion of reader_task_0. We achieve this by passing reader_event0 to the
+   * task invocation procedure:
+   *
+   *   Event reader_event0 = p.spawn(READER_TASK_0, &task_args, sizeof(TaskArgs), user_event);
+   *   Event reader_event1 = p.spawn(READER_TASK_1, &task_args, sizeof(TaskArgs), reader_event0);
+   *
+   * Often, it is necessary to spawn multiple tasks simultaneously and express a collective wait
+   * using a single event handle. To illustrate this, the program runs num_tasks, stores the events
+   * produced by reader_task_1 into an events vector, and combines them by calling:
+   *
+   *   Event::merge_events(events).wait();
+   */
   for (size_t i = 0; i < ProgramConfig::num_tasks; i++) {
+    /**
+     * READER_TASK_0 runs once user_event is triggered.
+     */
     Event reader_event0 =
         p.spawn(READER_TASK_0, &task_args, sizeof(TaskArgs), user_event);
+
+    /**
+     * READER_TASK_1 depends on READER_TASK_0.
+     * This forms a chain of control dependencies.
+     */
     Event reader_event1 =
         p.spawn(READER_TASK_1, &task_args, sizeof(TaskArgs), reader_event0);
+
     events.push_back(reader_event1);
   }
 
+  /**
+   * Triggering Events
+   * -----------------
+   * An event can be triggered from any node, not necessarily the owner node. One common scenario
+   * in which this happens is with UserEvent. These are created and triggered from the application
+   * code, where we create user_event to start an operation. User events offer greater flexibility
+   * in building the event graph by allowing users to connect different parts of the graph
+   * independently. However, it is important to note that using user events carries the risk of
+   * creating cycles, which can cause the program to hang. Therefore, it is the user’s responsibility
+   * to avoid creating cycles while leveraging user events.
+   *
+   * When a user_event is triggered on a node that does not own it, a trigger message is sent
+   * from the trigger node to the owner node, which then forwards the message to all other
+   * subscribed nodes. If the triggering node has any local waiters, it immediately notifies them
+   * without sending a message back to the owner node. Although triggering a remote event incurs
+   * a latency of at least two active message flight times, it limits the number of active messages
+   * required per event trigger to 2*N - 2, where N is the number of nodes interested in the event.
+   *
+   */
   user_event.trigger();
+
+  /**
+   * Wait for all READER_TASK_1 events to complete.
+   */
   Event::merge_events(events).wait();
 
   log_app.info() << "Completed successfully";
@@ -71,7 +193,6 @@ void main_task(const void *args, size_t arglen, const void *userdata,
 
 int main(int argc, const char **argv) {
   Runtime rt;
-
   rt.init(&argc, (char ***)&argv);
 
   Processor p = Machine::ProcessorQuery(Machine::get_machine())
@@ -81,7 +202,6 @@ int main(int argc, const char **argv) {
   if (!p.exists()) {
     p = Machine::ProcessorQuery(Machine::get_machine()).first();
   }
-
   assert(p.exists());
 
   Processor::register_task_by_kind(p.kind(), false /*!global*/, MAIN_TASK,
@@ -102,6 +222,5 @@ int main(int argc, const char **argv) {
   rt.collective_spawn(p, MAIN_TASK, 0, 0);
 
   int ret = rt.wait_for_shutdown();
-
   return ret;
 }

--- a/tutorials/events/events_basic.md
+++ b/tutorials/events/events_basic.md
@@ -1,58 +1,80 @@
----
-title: Events
----
+<!-- omit from toc -->
+# Realm Event Tutorial
 
-## Introduction
-Realm is a fully asynchronous, event-based runtime, and events form
-the backbone of Realm's programming model, describing the dependencies
-between operations. Realm operations are deferred by the runtime,
-which returns an event that triggers upon completion of the operation.
-These events are created by the runtime and can be used as pre- or
-post-conditions for other operations. Events provide a mechanism that
-allows the runtime to efficiently manage asynchronous program
-execution, offering opportunities to hide latencies when
-communications are required.
+Realm is a fully asynchronous, event-based runtime, and events form the
+backbone of Realm’s programming model, describing the dependencies between
+operations. Realm operations are deferred by the runtime, which returns an
+event that triggers upon completion of the operation. These events are
+created by the runtime and can be used as pre- or post-conditions for other
+operations. Events provide a mechanism that allows the runtime to efficiently
+manage asynchronous program execution, offering opportunities to hide latencies
+when communications are required.
 
-In this tutorial, we'll demonstrate how to use events to take 
-advantage of Realm's deferred execution model when writing asynchronous 
-applications.
+- All operations accept completion events as preconditions.
+- All operations must return completion events.
 
-Here is a list of covered topics:
+Realm Event: Optimized distributed data structure
 
-* [Events Basics](#events-basics)
-* [Creating Events](#creating-events)
-* [Triggering Events](#trigerring-events)
-* [Creating Control Dependencies](#creating-control-dependencies)
-* [References](#references)
+- Fixed-size, no reference counting
+- No dependency on application runtime
+- Small memory footprint
+- Communication/storage needed only for interested nodes
 
-## Events Basics
-Usually, Realm creates Events as part of handling application requests
-for asynchronous operations. An Event is a lightweight handle
-that can be easily transported around the system. The node that
-creates an Event owns it, and the space for these handles is statically
-divided across all nodes by including the node ID in the upper bits of
-the handle. This design ensures that any node can create new handles
-without the risk of collision or requiring inter-node communication.
+Realm applications create a huge number of events:
 
-The basic event is implemented as a distributed object and spread
-across one or several nodes. Each node uses the event handle to look up
-their piece of the object as needed. This lookup uses a monotonic data
-structure that allows wait-free queries even when updates are being
-performed.
+- 1 million events per processor per node per second
+- 1 billion events per second cluster-wide
 
-When a new Event is created, the owning node allocates a data
-structure to track its state, which is initially `untriggered` but
-will eventually become triggered or poisoned. The data structure also
-includes a list of `local waiters` and `remote waiters`. Local waiters are
-dependent operations on the owner node, and remote waiters are other nodes
-that are interested in the Event (event dependencies).
+Topics Covered:
 
-## Creating Events
-In this program, we launch several tasks (`reader_task_0` and
-`reader_task_1`) responsible for
-printing an integer value `x`:
+- [Events basics](#events-basics)
+- [Program setup](#program-setup)
+- [Creating events](#creating-events)
+- [Creating control dependencies](#creating-control-dependencies)
+- [Triggering events](#triggering-events)
+- [Main function](#main-function)
+
+## Events basics
+
+Usually, Realm creates Events as part of handling application requests for
+asynchronous operations. An `Event` is a lightweight handle that can be easily
+transported around the system. The node that creates an Event owns it, and the
+space for these handles is statically divided across all nodes by including
+the node ID in the upper bits of the handle. This design ensures that any node
+can create new handles without the risk of collision or requiring inter-node
+communication.
+
+When a new `Event` is created, the owning node allocates a data structure to
+track its state, which is initially untriggered but will eventually become
+triggered or poisoned. The data structure also includes a list of local
+waiters and remote waiters. Local waiters are dependent operations on the
+owner node, and remote waiters are other nodes that are interested in the
+`Event` (event dependencies).
+
+## Program setup
 
 ```c++
+#include <realm.h>
+#include <realm/cmdline.h>
+
+using namespace Realm;
+
+enum {
+  MAIN_TASK = Processor::TASK_ID_FIRST_AVAILABLE + 0,
+  READER_TASK_0,
+  READER_TASK_1,
+};
+
+Logger log_app("app");
+
+namespace ProgramConfig {
+  size_t num_tasks = 1;
+};
+
+struct TaskArgs {
+  int x;
+};
+
 void reader_task_0(const void *args, size_t arglen, const void *userdata,
                    size_t userlen, Processor p) {
   const TaskArgs *task_args = reinterpret_cast<const TaskArgs *>(args);
@@ -64,78 +86,146 @@ void reader_task_1(const void *args, size_t arglen, const void *userdata,
   const TaskArgs *task_args = reinterpret_cast<const TaskArgs *>(args);
   log_app.info() << "reader task 1: proc=" << p << " x=" << task_args->x;
 }
+
+void main_task(const void *args, size_t arglen, const void *userdata,
+                    size_t userlen, Processor p) {
+  TaskArgs task_args{.x = 7};
 ```
 
-Each task launch is a non-blocking  asynchronous call that returns an
-internal event  handle such as `reader_event0` and `reader_event1`.
-Once created, the Event handle can be passed around through 
-task arguments or shared data structures and eventually used as a 
-pre- or post-condition for operations to be executed on other nodes.
+## Creating events
 
-When a remote node makes the first reference to `task_event`, it 
-allocates the same data structure, sets its state to `untriggered`, and
-adds the dependent operation to its own local waiter list. Then, an 
-event subscription active message is sent to the owner node to 
-indicate that the remote node is interested and should be added to 
-the list of remote waiters, so it can be informed when `task_event` 
-triggers. Any additional dependent operations on a remote node are 
-added to the list of local waiters without requiring communication 
-with the owner node. When `task_event` eventually triggers, the owner 
-node notifies all local waiters and sends an event trigger message to 
-each subscribed node on the list of remote waiters. If the owner node 
-receives additional subscription messages after it has been triggered, 
-it immediately responds to the new subscribers with a trigger message 
-as well.
+In this program, we launch several tasks (`reader_task_0` and `reader_task_1`)
+responsible for printing an integer value `x`. Each task launch is a
+non-blocking asynchronous call that returns an internal event handle. Once
+created, the Event handle can be passed around through task arguments or
+shared data structures and eventually used as a pre- or post-condition for
+operations to be executed on other nodes.
 
-## Triggering Events
-An event can be triggered from any node, not necessarily the owner node.
-One common scenario in which this happens is with `UserEvent`. These are
-created and triggered from the application code, where
-we create `user_event` to start an operation:
+When a remote node makes the first reference to `task_event`, it allocates the
+same data structure, sets its state to untriggered, and adds the dependent
+operation to its own local waiter list. Then, an event subscription active
+message is sent to the owner node to indicate that the remote node is
+interested and should be added to the list of remote waiters, so it can be
+informed when task_event triggers. Any additional dependent operations on a
+remote node are added to the list of local waiters without requiring
+communication with the owner node. When `task_event` eventually triggers,
+the owner node notifies all local waiters and sends an event trigger message
+to each subscribed node on the list of remote waiters. If the owner node
+receives additional subscription messages after it has been triggered, it
+immediately responds to the new subscribers with a trigger message as well.
+
+A `UserEvent` is created explicitly by the application. It starts in an
+untriggered state and can later be triggered manually by the user. This allows
+dynamic construction of control dependencies, enabling other events or tasks to
+be conditioned on it. The event handle is small, fixed-size, and efficiently
+propagated.
 
 ```c++
   UserEvent user_event = UserEvent::create_user_event();
+
+  std::vector<Event> events;
 ```
 
+## Creating control dependencies
 
-User events offer greater flexibility in building the event graph by allowing
-users to connect different parts of the graph independently. However, it is
-important to note that using user events carries the risk of creating cycles,
-which can cause the program to hang. Therefore, it is the user's responsibility
-to avoid creating cycles while leveraging user events.
-
-When a `user_event` is triggered on a node that does not own it, a
-trigger message is sent from the trigger node to the owner node, which then
-forwards the message to all other subscribed nodes. If the triggering 
-node has any local waiters, it immediately notifies them without 
-sending a message back to the owner node. Although triggering a remote
-event incurs a latency of at least two active message flight times, it 
-limits the number of active messages required per event trigger to 
-`2*N - 2`, where `N` is the number of nodes interested in the event.
-
-## Creating Control Dependencies
-We will now demonstrate how to establish a control dependency using
-events, by making `reader_task_1` dependent on the completion of
-`reader_task_0`. We achieve this by passing `reader_event0` to the
-task invocation procedure:
+We demonstrate how to establish a control dependency using events by making
+`reader_task_1` dependent on the completion of `reader_task_0`. We achieve
+this by passing `reader_event0` to the `p.spawn` task invocation procedure
+for `READER_TASK_1` below.
 
 ```c++
-  Event reader_event0 =
-      p.spawn(READER_TASK_0, &task_args, sizeof(TaskArgs), user_event);
+  for (size_t i = 0; i < ProgramConfig::num_tasks; i++) {
+    /**
+     * READER_TASK_0 runs once user_event is triggered.
+     */
+    Event reader_event0 =
+        p.spawn(READER_TASK_0, &task_args, sizeof(TaskArgs), user_event);
 
-  Event reader_event1 =
-      p.spawn(READER_TASK_1, &task_args, sizeof(TaskArgs), reader_event0);
+    /**
+     * READER_TASK_1 depends on READER_TASK_0.
+     * This forms a chain of control dependencies.
+     */
+    Event reader_event1 =
+        p.spawn(READER_TASK_1, &task_args, sizeof(TaskArgs), reader_event0);
+
+    events.push_back(reader_event1);
+  }
 ```
 
-Often, it is necessary to spawn multiple tasks simultaneously and 
-express a collective wait using a single event handle. To illustrate 
-this, the program runs `num_tasks`, stores the events produced by
-`reader_task_1` into an `events` vector and combines them by calling:
+Often, it is necessary to spawn multiple tasks simultaneously and express a
+collective wait using a single event handle. To illustrate this, the program
+runs `num_tasks`, stores the events produced by `reader_task_1` into an events
+vector, and combines them by calling `Event::merge_events(events).wait()`.
+
+## Triggering events
+
+An event can be triggered from any node, not necessarily the owner node. One
+common scenario in which this happens is with UserEvent. These are created
+and triggered from the application code, where we create user_event to start
+an operation. User events offer greater flexibility in building the event
+graph by allowing users to connect different parts of the graph independently.
+However, it is important to note that using user events carries the risk of
+creating cycles, which can cause the program to hang. Therefore, it is the
+user’s responsibility to avoid creating cycles while leveraging user events.
+
+When a user_event is triggered on a node that does not own it, a trigger
+message is sent from the trigger node to the owner node, which then forwards
+the message to all other subscribed nodes. If the triggering node has any
+local waiters, it immediately notifies them without sending a message back to
+the owner node. Although triggering a remote event incurs a latency of at
+least two active message flight times, it limits the number of active messages
+required per event trigger to 2*N - 2, where N is the number of nodes
+interested in the event.
 
 ```c++
-Event::merge_events(events).wait()
+  user_event.trigger();
+
+  /**
+   * Wait for all READER_TASK_1 events to complete.
+   */
+  Event::merge_events(events).wait();
+
+  log_app.info() << "Completed successfully";
+  Runtime::get_runtime().shutdown(Event::NO_EVENT, 0 /*success*/);
+}
 ```
 
-## References
-1. [Event header file](https://github.com/StanfordLegion/realm/blob/main/realm/event.h)
-2. [Realm: Performance Portability through Composable Asynchrony](https://legion.stanford.edu/pdfs/treichler_thesis.pdf)
+## Main function
+
+Putting everything together, we define a `main` function to register and launch our tasks:
+
+```c++
+int main(int argc, const char **argv) {
+  Runtime rt;
+  rt.init(&argc, (char ***)&argv);
+
+  Processor p = Machine::ProcessorQuery(Machine::get_machine())
+                    .only_kind(Processor::LOC_PROC)
+                    .first();
+
+  if (!p.exists()) {
+    p = Machine::ProcessorQuery(Machine::get_machine()).first();
+  }
+  assert(p.exists());
+
+  Processor::register_task_by_kind(p.kind(), false /*!global*/, MAIN_TASK,
+                                   CodeDescriptor(main_task),
+                                   ProfilingRequestSet())
+      .external_wait();
+
+  Processor::register_task_by_kind(p.kind(), false /*!global*/, READER_TASK_0,
+                                   CodeDescriptor(reader_task_0),
+                                   ProfilingRequestSet())
+      .external_wait();
+
+  Processor::register_task_by_kind(p.kind(), false /*!global*/, READER_TASK_1,
+                                   CodeDescriptor(reader_task_1),
+                                   ProfilingRequestSet())
+      .external_wait();
+
+  rt.collective_spawn(p, MAIN_TASK, 0, 0);
+
+  int ret = rt.wait_for_shutdown();
+  return ret;
+}
+```

--- a/tutorials/hello_world/hello_world.cc
+++ b/tutorials/hello_world/hello_world.cc
@@ -1,5 +1,5 @@
-
-/* Copyright 2024 NVIDIA Corporation
+/*
+ * Copyright 2024 NVIDIA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,71 +24,123 @@
 
 using namespace Realm;
 
+// Logger instance to capture logs from the application
 Logger log_app("app");
 
-enum {
+/*
+ * Realm Task Identifiers
+ * Realm tasks are assigned unique IDs within a program.
+ * The first available user-defined task ID must be at or above
+ * Processor::TASK_ID_FIRST_AVAILABLE to avoid collisions with internal Realm tasks.
+ */
+enum
+{
   MAIN_TASK = Processor::TASK_ID_FIRST_AVAILABLE + 0,
   HELLO_TASK,
 };
 
-void hello_cpu_task(const void *args, size_t arglen, const void *userdata,
-                    size_t userlen, Processor p) 
+/*
+ * Task Implementations in Realm
+ * Tasks are Realm’s fundamental unit of execution. They are functions that execute
+ * asynchronously on different types of processors. In Realm, tasks are bound to specific
+ * processor types (CPU, GPU, OpenMP, etc.), and their execution is managed by the
+ * runtime.
+ */
+
+void hello_cpu_task(const void *args, size_t arglen, const void *userdata, size_t userlen,
+                    Processor p)
 {
   log_app.print() << "Hello world from CPU!";
 }
 
 #if defined(REALM_USE_CUDA) || defined(REALM_USE_HIP)
-void hello_gpu_task(const void *args, size_t arglen, const void *userdata,
-                    size_t userlen, Processor p) 
+void hello_gpu_task(const void *args, size_t arglen, const void *userdata, size_t userlen,
+                    Processor p)
 {
   log_app.print() << "Hello world from GPU!";
 }
 #endif
 
 #ifdef REALM_USE_OPENMP
-void hello_omp_task(const void *args, size_t arglen, const void *userdata,
-                    size_t userlen, Processor p) 
+void hello_omp_task(const void *args, size_t arglen, const void *userdata, size_t userlen,
+                    Processor p)
 {
-  #pragma omp parallel                   
+#pragma omp parallel
   {
     log_app.print() << "Hello world from OMP thread = " << omp_get_thread_num();
   }
 }
 #endif
 
+/*
+ * launch_task: Dispatches HELLO_TASK to available processors
+ * Realm supports querying machine topology at runtime, enabling dynamic task assignment.
+ * This function finds available CPU, GPU, and OpenMP processors and spawns HELLO_TASK on
+ * them. Realm's event system is used to synchronize completion.
+ */
 inline Event launch_task(Processor cpu)
 {
-  // launch a hello task on CPU
   Event cpu_e = cpu.spawn(HELLO_TASK, NULL, 0);
 
-  // launch a hello task on GPU if it is available
   Processor gpu = Machine::ProcessorQuery(Machine::get_machine())
-    .only_kind(Processor::TOC_PROC).first();
+                      .only_kind(Processor::TOC_PROC)
+                      .first();
   Event gpu_e = Event::NO_EVENT;
-  if (gpu.exists()) {
+  if(gpu.exists()) {
     gpu_e = gpu.spawn(HELLO_TASK, NULL, 0);
   }
 
-  // launch a hello task on OpenMP processor if it is available
   Processor omp = Machine::ProcessorQuery(Machine::get_machine())
-    .only_kind(Processor::OMP_PROC).first();
+                      .only_kind(Processor::OMP_PROC)
+                      .first();
   Event omp_e = Event::NO_EVENT;
-  if (omp.exists()) {
+  if(omp.exists()) {
     omp_e = omp.spawn(HELLO_TASK, NULL, 0);
   }
 
-  Event e = Event::merge_events(cpu_e, gpu_e, omp_e);
-  return e;
+  return Event::merge_events(cpu_e, gpu_e, omp_e);
 }
 
-void main_task(const void *args, size_t arglen, const void *userdata,
-               size_t userlen, Processor p) 
+/*
+ * main_task: Realm's task-based execution entry point
+ * Realm does not enforce a hierarchical task model, so the main task explicitly waits
+ * for all HELLO_TASK instances to finish using events.
+ */
+void main_task(const void *args, size_t arglen, const void *userdata, size_t userlen,
+               Processor p)
 {
   launch_task(p).wait();
 }
 
-int main(int argc, char **argv) 
+/*
+ * main: Realm Runtime Initialization and Task Execution
+ * The main function initializes the Realm runtime, registers tasks, and schedules
+ * execution. Realm enables both single-process and distributed execution models, managed
+ * through runtime API calls.
+ */
+int main(int argc, char **argv)
 {
+  /*
+   * Initializing the Realm Runtime
+   *
+   * Realm follows a decentralized execution model, where each process in a parallel
+   * execution (e.g., launched via `mpirun` or another job launcher) independently
+   * initializes its runtime. This is different from centralized tasking systems where a
+   * master process coordinates execution.
+   *
+   * The function `rt.init(&argc, &argv);` performs the following key operations:
+   *  - Discovers available processors (CPUs, GPUs, OpenMP, etc.).
+   *  - Establishes communication channels between processes.
+   *  - Registers the process within the Realm machine model.
+   *
+   * Command-line arguments are passed so that Realm can handle its own runtime-specific
+   * options, such as enabling debugging or configuring network settings.
+   *
+   * Because every process initializes independently, Realm can be used in both
+   * single-process and distributed environments. However, task launching and
+   * synchronization must be handled accordingly to ensure correct execution.
+   */
+
   Runtime rt;
   rt.init(&argc, &argv);
 
@@ -97,54 +149,85 @@ int main(int argc, char **argv)
   cp.add_option_bool("-coll_spawn", use_collective_spawn);
   bool ok = cp.parse_command_line(argc, const_cast<const char **>(argv));
   assert(ok);
-  
-  Processor::register_task_by_kind(Processor::LOC_PROC, false /*!global*/,
-                                   MAIN_TASK,
-                                   CodeDescriptor(main_task),
-                                   ProfilingRequestSet(),
-                                   0, 0).wait();
-  Processor::register_task_by_kind(Processor::LOC_PROC, false /*!global*/,
-                                   HELLO_TASK,
-                                   CodeDescriptor(hello_cpu_task),
-                                   ProfilingRequestSet(),
-                                   0, 0).wait();
+
+  /*
+   * Task Registration in Realm
+   * Before tasks can be executed, they must be registered with Realm.
+   * Task registration associates a task ID with an implementation and a processor kind.
+   * Unlike traditional threading models, Realm allows multiple task implementations for
+   * different processors, enabling heterogeneous execution.
+   */
+
+  // Registering Tasks: Binding function implementations to processor types
+  Processor::register_task_by_kind(Processor::LOC_PROC, false /*!global*/, MAIN_TASK,
+                                   CodeDescriptor(main_task), ProfilingRequestSet(), 0, 0)
+      .wait();
+  Processor::register_task_by_kind(Processor::LOC_PROC, false /*!global*/, HELLO_TASK,
+                                   CodeDescriptor(hello_cpu_task), ProfilingRequestSet(),
+                                   0, 0)
+      .wait();
 #if defined(REALM_USE_CUDA) || defined(REALM_USE_HIP)
-  Processor::register_task_by_kind(Processor::TOC_PROC, false /*!global*/,
-                                   HELLO_TASK,
-                                   CodeDescriptor(hello_gpu_task),
-                                   ProfilingRequestSet(),
-                                   0, 0).wait();
+  Processor::register_task_by_kind(Processor::TOC_PROC, false /*!global*/, HELLO_TASK,
+                                   CodeDescriptor(hello_gpu_task), ProfilingRequestSet(),
+                                   0, 0)
+      .wait();
 #endif
 #ifdef REALM_USE_OPENMP
-  Processor::register_task_by_kind(Processor::OMP_PROC, false /*!global*/,
-                                   HELLO_TASK,
-                                   CodeDescriptor(hello_omp_task),
-                                   ProfilingRequestSet(),
-                                   0, 0).wait();
+  Processor::register_task_by_kind(Processor::OMP_PROC, false /*!global*/, HELLO_TASK,
+                                   CodeDescriptor(hello_omp_task), ProfilingRequestSet(),
+                                   0, 0)
+      .wait();
 #endif
 
-  // select a processor to run the cpu task
+  // Selecting the first available CPU processor for launching the main task
   Processor p = Machine::ProcessorQuery(Machine::get_machine())
-    .only_kind(Processor::LOC_PROC)
-    .first();
+                    .only_kind(Processor::LOC_PROC)
+                    .first();
   assert(p.exists());
 
-  if (use_collective_spawn) {
+  /*
+   * Launching MAIN_TASK using collective or manual spawning
+   * If collective_spawn is enabled, MAIN_TASK is launched on all processes
+   * simultaneously. Otherwise, process 0 is responsible for launching tasks and
+   * initiating shutdown.
+   */
+  if(use_collective_spawn) {
     Event e = rt.collective_spawn(p, MAIN_TASK, 0, 0);
     rt.shutdown(e);
   } else {
-    // try to get the rank ID
     Processor local_proc = Machine::ProcessorQuery(Machine::get_machine())
-    .only_kind(Processor::LOC_PROC).local_address_space()
-    .first();
-    if (local_proc.address_space() == 0) {
+                               .only_kind(Processor::LOC_PROC)
+                               .local_address_space()
+                               .first();
+    if(local_proc.address_space() == 0) {
       Event e = launch_task(p);
       rt.shutdown(e);
     }
-    // call shutdown(e) here is wrong
   }
 
-  int ret = rt.wait_for_shutdown();
+  /*
+   * Shutting Down the Realm Runtime
+   *
+   * Realm applications must explicitly shut down the runtime when all tasks have
+   * completed. This ensures that all resources are properly released and prevents
+   * processes from hanging.
+   *
+   * The `rt.shutdown(e)` function is used to trigger the shutdown process. It takes an
+   * event `e` as a precondition, meaning the runtime will only shut down once this event
+   * has completed. In our case, this event represents the completion of the MAIN_TASK or
+   * all HELLO_TASKs.
+   *
+   * The `rt.wait_for_shutdown()` function is necessary to ensure that all processes
+   * remain synchronized and do not exit prematurely before the runtime fully shuts down.
+   *
+   * If collective spawning (`rt.collective_spawn()`) is used, then shutdown must be
+   * called on all processes with the same event to ensure consistency.
+   *
+   * When manually managing task launching without collective_spawn, we ensure only rank 0
+   * (the process with `address_space() == 0`) triggers shutdown.
+   */
 
+  // Ensuring all processes wait for the runtime to shut down
+  int ret = rt.wait_for_shutdown();
   return ret;
 }

--- a/tutorials/hello_world/hello_world.md
+++ b/tutorials/hello_world/hello_world.md
@@ -1,161 +1,257 @@
----
-title: Hello World
----
+<!-- omit from toc -->
+# Hello world
 
-The tutorial begins with a simple "hello world" example that showcases the basics.
-You can access the source code, the Makefile and CMakeList.txt for building
-and running the application, in the `tutorial/realm` directory of the repository.
-By going through these tutorial programs in detail, we will demonstrate how to
-effectively use the Realm C++ runtime API.
+The tutorial begins with a simple “hello world” example that showcases the basics. You can access the source code, the Makefile and CMakeList.txt for building and running the application, in the `tutorial/realm` directory of the repository. By going through these tutorial programs in detail, we will demonstrate how to effectively use the Realm C++ runtime API.
 
 Here is a list of covered topics:
 
-* [Realm Namespaces](#realm-namespaces)
-* [Realm Runtime Startup](#realm-runtime-startup)
-* [Registering Realm Tasks](#registering-realm-tasks)
-* [Launching Tasks](#launching-tasks)
-* [Shuting Down Runtime](#shuting-down-runtime)
+- [Realm namespaces](#realm-namespaces)
+- [Program setup](#program-setup)
+  - [Realm task tdentifiers](#realm-task-tdentifiers)
+- [Task implementations in Realm](#task-implementations-in-realm)
+  - [`hello_task`](#hello_task)
+- [Launching tasks](#launching-tasks)
+  - [`launch_task`](#launch_task)
+  - [`main_task`](#main_task)
+- [Realm runtime initialization and task execution](#realm-runtime-initialization-and-task-execution)
+  - [Initializing the Realm runtime](#initializing-the-realm-runtime)
+  - [Task registration](#task-registration)
+  - [Launching the `MAIN_TASK`](#launching-the-main_task)
+  - [Shutting down the Realm runtime](#shutting-down-the-realm-runtime)
 
-## Realm Namespaces
+## Realm namespaces
 
-Each Realm class has its own C++ header file. All classes are
-aggregated in `realm.h` and can be included in an application for
-convenience. Each class definition is placed in a `Realm` namespace to
-avoid naming conflicts.
+Each Realm class has its own C++ header file. All classes are aggregated in realm.h and can be included in an application for convenience. Each class definition is placed in a Realm namespace to avoid naming conflicts.
 
-## Realm Runtime Startup
+## Program setup
 
-The following code illustrates how to initializes a singleton `Runtime` object.
+We start our C++ Realm example with some typical imports:
+
+- `realm.h`
+- `realm/cmdline.h`
+- `realm/network.h`
+
+and also set up the Realm logger instance:
 
 ```c++
-Runtime rt;
-rt.init(&argc, &argv);
+#include "realm.h"
+#include "realm/cmdline.h"
+#include "realm/network.h"
+
+#ifdef REALM_USE_OPENMP
+#include <omp.h>
+#endif
+
+using namespace Realm;
+
+// Logger instance to capture logs from the application
+Logger log_app("app");
 ```
 
-The initialization must be performed by every application process. After
-initialization is complete, the runtime remains mostly idle (except system
-status checks) and waits for the task launches.
+### Realm task tdentifiers
 
-## Registering Realm Tasks
+The first thing we need to do is to set up IDs for the Realm tasks we are going to define.
+Realm tasks are assigned unique IDs within a program, and the first available user-defined task ID must be at or above `Processor::TASK_ID_FIRST_AVAILABLE` to avoid collisions with internal Realm tasks.
 
-A Realm task is an asynchronous operation, which can be defined by a task ID
-and one or more task bodies representing the implementations of the task.
-This tutorial contains two types of tasks: main task and hello world task.
-Therefore, we use an enumeration of two members to store the IDs for each task with which the Realm runtime will associate.
-The first task should always start from or larger than `Processor::TASK_ID_FIRST_AVAILABLE`, because Realm reserve
-some numbers for internal tasks.
+We use an `enum` for this:
 
 ```c++
-enum {
+enum
+{
   MAIN_TASK = Processor::TASK_ID_FIRST_AVAILABLE + 0,
   HELLO_TASK,
 };
 ```
 
-A task can have an implementation on every kind of processor, e.g., CPU, GPU, etc.
-For example, the `main_task` is the CPU implementation of the main task, while
-the `hello_cpu_task`, `hello_gpu_task` and `hello_omp_task` are
-the CPU, GPU and OpenMP implementations of the hello world task, respectively.
-It is worth noting that in Realm, a CPU processor typically refers to a physical CPU core,
-and therefore, the implementation of a CPU task generally is single-threaded.
-A GPU processor has a CUDA/HIP context associated with it,
-which allows it to launch GPU tasks containing CUDA/HIP kernels.
-However, for the sake of simplicity, we do not launch actual CUDA kernels in the GPU task in this tutorial.
+## Task implementations in Realm
 
-A task has to be registered on processors before the Realm runtime can launch it.
-To register a task, the static method `Processor::register_task_by_kind` is used shown as follows.
+Tasks are Realm’s fundamental unit of execution. They are functions that execute
+asynchronously on different types of processors. In Realm, tasks are bound to specific processor types (CPU, GPU, OpenMP, etc.), and their execution is managed by the
+runtime.
+
+### `hello_task`
+
+Here, we actually define the functions for the "hello" tasks we want to run.
+We unconditionally define a CPU variant, but also define GPU and OpenMP variants, in case those features are available on our system:
 
 ```c++
-Processor::register_task_by_kind(Processor::LOC_PROC, false /*!global*/,
-                                 MAIN_TASK,
-                                 CodeDescriptor(main_task),
-                                 ProfilingRequestSet(),
-                                 0, 0).wait();
+void hello_cpu_task(const void *args, size_t arglen, const void *userdata, size_t userlen,
+                    Processor p)
+{
+  log_app.print() << "Hello world from CPU!";
+}
+
+#if defined(REALM_USE_CUDA) || defined(REALM_USE_HIP)
+void hello_gpu_task(const void *args, size_t arglen, const void *userdata, size_t userlen,
+                    Processor p)
+{
+  log_app.print() << "Hello world from GPU!";
+}
+#endif
+
+#ifdef REALM_USE_OPENMP
+void hello_omp_task(const void *args, size_t arglen, const void *userdata, size_t userlen,
+                    Processor p)
+{
+#pragma omp parallel
+  {
+    log_app.print() << "Hello world from OMP thread = " << omp_get_thread_num();
+  }
+}
+#endif
 ```
 
-This function takes several parameters:
+## Launching tasks
 
-- `target_kind` - describes which kind of processor the task will be launched on. We will introduce the processor API in the next example.
-- `global` - if set to true, the task is visible on all nodes. It is noted that in this example, `register_task_by_kind` is called from
-the main function, which is performed by every application process when running with mpirun, thus, it is still visible on all nodes even `global` is false.
-However, when calling `register_task_by_kind` from a single task, we need to set the `global` to true if we need to make it visible on all nodes.
-- `TaskFuncID` - the task ID we defined in the enumeration.
-- `CodeDescriptor` - an object that describes a blob of code as a callable function.
-In this case, the implementation of the `MAIN_TASK` is `main_task`.
-- `user_data` and `user_data_len` - the data passed into the task (the 3rd and 4th paramters of the task implementation).
+Since Realm uses tasks for everything, we also need a task to launch our "hello" tasks using appropriate available resources.
 
-`register_task_by_kind` is an asynchronous function that does not guarantee that task registration is done after it returns.
-For this reason, it returns an `Event` object, allowing us to wait for completion explicitly. The usage of events is introduced in the following tutorials.
-As mentioned before, Realm allows a task to have multiple implementations. When the task is launched, Realm automatically selects the appropriate implementation based on the processor where it is being executed.
+### `launch_task`
 
-## Launching Tasks
-
-Before launching a task, we need to pick a processor. In this example, we select the first CPU core,
-GPU, and OpenMP processor to launch the CPU, GPU and OpenMP tasks, respectively. An example of selecting the first CPU
-core is shown as follows. We will introduce the `Machine` API in the next tutorial.
+The `launch_task` function defined below dispatches `HELLO_TASK` to available processors.
+Realm supports querying machine topology at runtime, enabling dynamic task assignment.
+This function finds available CPU, GPU, and OpenMP processors and spawns `HELLO_TASK` on them.
+Realm's event system is then used to synchronize completion of these different variants.
 
 ```c++
-Processor p = Machine::ProcessorQuery(Machine::get_machine())
-  .only_kind(Processor::LOC_PROC)
-  .first();
-```
+inline Event launch_task(Processor cpu)
+{
+  Event cpu_e = cpu.spawn(HELLO_TASK, NULL, 0);
 
-In the area of high-performance computing, most distributed programs start by invoking a main function across a number of parallel processes
-concurrently, in what is known as the Single-Program-Multiple-Data (SPMD) execution model. To transition from the SPMD-style execution model
-to the task-based model employed by Realm, the `collective_spawn` method is the most expedient way to bridge this gap.
-In this example, the `MAIN_TASK` is launched using the `collective_spawn` method, as seen below:
+  Processor gpu = Machine::ProcessorQuery(Machine::get_machine())
+                      .only_kind(Processor::TOC_PROC)
+                      .first();
+  Event gpu_e = Event::NO_EVENT;
+  if(gpu.exists()) {
+    gpu_e = gpu.spawn(HELLO_TASK, NULL, 0);
+  }
 
-```c++
-Event e = rt.collective_spawn(p, MAIN_TASK, 0, 0);
-```
+  Processor omp = Machine::ProcessorQuery(Machine::get_machine())
+                      .only_kind(Processor::OMP_PROC)
+                      .first();
+  Event omp_e = Event::NO_EVENT;
+  if(omp.exists()) {
+    omp_e = omp.spawn(HELLO_TASK, NULL, 0);
+  }
 
-The main task is not SPMD-style, and now
-the program is transitioned from the SPMD model into the task-based one. Additionally, Realm provides the `collective_spawn_by_kind` method,
-which can be used to launch an SPMD task where each process launches one task.
-
-Within the main task, we use the `spawn` method of the Processor object to launch the `HELLO_TASK` on the selected CPU, GPU and
-OpenMP processor, respectively. An example of spawning the `HELLO_TASK` on the CPU processor is shown below:
-
-```c++
-Event cpu_e = cpu.spawn(HELLO_TASK, NULL, 0);
-```
-
-Like `register_task_by_kind`, the `spawn` and `collective_spawn` are
-also asynchronous functions that return an `Event` object. Then we can either
-invoke the `wait` method to wait for the completion of the task or pass it as the pre-condition of other Realm
-operations. We will introduce more details about Realm events in the following tutorial.
-
-It is worth mentioning that there is no task hierarchy in Realm, so the completion of a Realm task does not imply that all its sub-tasks
-have also been completed. If the cumulative property is needed, users need to implement it explicitly. For example, to ensure that all
-`HELLO_TASK` are completed before exiting the `MAIN_TASK`, the `wait` method is used.
-
-```c++
-launch_task(p).wait();
-```
-
-## Launching Tasks without Using collective_spawn
-
-The `HELLO_TASK` can also be launched from the main function without using the `collective_spawn`.
-To achieve it, we need to mimic the `collective_spawn` behavior by explicitly picking a process, such as the rank 0,
-to launch the hello world tasks using the `spawn` method.
-
-```c++
-Processor local_proc = Machine::ProcessorQuery(Machine::get_machine())
-  .only_kind(Processor::LOC_PROC).local_address_space()
-  .first();
-if (local_proc.address_space() == 0) {
-  Event e = launch_task(p);
-  rt.shutdown(e);
+  return Event::merge_events(cpu_e, gpu_e, omp_e);
 }
 ```
 
-However, it is generally recommended to use `collective_spawn` to launch a main task and then `spawn` tasks within it.
+### `main_task`
 
-## Shutting Down Runtime
+For convenience, we also define a `main_rask` as Realm's task-based execution entry point.
+Realm does not enforce a hierarchical task model, so the main task explicitly waits
+for all `HELLO_TASK` instances to finish, by using events.
 
-At the end of a Realm program, it is necessary to shut down the runtime using the `shutdown` and `wait_for_shutdown` methods.
-In this example, we instruct the runtime to initiate `shutdown` as soon as the `MAIN_TASK` or all `Hello_Task` are finished, respectively.
-While the `wait_for_shutdown` method must be called by all processes, it is not necessary for `shutdown`.
-However, if the `shutdown` method is called from all processes, the pre-conditional event must be identical across all processes.
-Therefore, in this program, the `shutdown` is called from all processes when using the `collective_spawn`, but only on rank 0 without
-`collective_spawn`.
+```c++
+void main_task(const void *args, size_t arglen, const void *userdata, size_t userlen,
+               Processor p)
+{
+  launch_task(p).wait();
+}
+```
+
+## Realm runtime initialization and task execution
+
+The standard C++ `main` function initializes the Realm runtime, registers tasks, and schedules execution.
+Realm enables both single-process and distributed execution models, managed through runtime API calls.
+
+```c++
+int main(int argc, char **argv)
+{
+```
+
+### Initializing the Realm runtime
+
+Realm follows a decentralized execution model, where each process in a parallel execution (e.g., launched via `mpirun` or another job launcher) independently initializes its runtime. This is different from centralized tasking systems where a master process coordinates execution.
+
+- The function `rt.init(&argc, &argv);` performs the following key operations:
+  - Discovers available processors (CPUs, GPUs, OpenMP, etc.).
+  - Establishes communication channels between processes.
+  - Registers the process within the Realm machine model.
+- Command-line arguments are passed so that Realm can handle its own runtime-specific options, such as enabling debugging or configuring network settings.
+- Because every process initializes independently, Realm can be used in both single-process and distributed environments. However, task launching and synchronization must be handled accordingly to ensure correct execution.
+
+```c++
+  Runtime rt;
+  rt.init(&argc, &argv);
+
+  bool use_collective_spawn = false;
+  CommandLineParser cp;
+  cp.add_option_bool("-coll_spawn", use_collective_spawn);
+  bool ok = cp.parse_command_line(argc, const_cast<const char **>(argv));
+  assert(ok);
+```
+
+### Task registration
+
+Before tasks can be executed, they must be registered with Realm.
+Task registration associates a task ID (that we defined first, up above) with an implementation and a processor kind.
+Unlike traditional threading models, Realm allows multiple task implementations for different processors, enabling heterogeneous execution.
+
+```c++
+  // Registering Tasks: Binding function implementations to processor types
+  Processor::register_task_by_kind(Processor::LOC_PROC, false /*!global*/, MAIN_TASK,
+                                   CodeDescriptor(main_task), ProfilingRequestSet(), 0, 0)
+      .wait();
+  Processor::register_task_by_kind(Processor::LOC_PROC, false /*!global*/, HELLO_TASK,
+                                   CodeDescriptor(hello_cpu_task), ProfilingRequestSet(),
+                                   0, 0)
+      .wait();
+#if defined(REALM_USE_CUDA) || defined(REALM_USE_HIP)
+  Processor::register_task_by_kind(Processor::TOC_PROC, false /*!global*/, HELLO_TASK,
+                                   CodeDescriptor(hello_gpu_task), ProfilingRequestSet(),
+                                   0, 0)
+      .wait();
+#endif
+#ifdef REALM_USE_OPENMP
+  Processor::register_task_by_kind(Processor::OMP_PROC, false /*!global*/, HELLO_TASK,
+                                   CodeDescriptor(hello_omp_task), ProfilingRequestSet(),
+                                   0, 0)
+      .wait();
+#endif
+
+  // Selecting the first available CPU processor for launching the main task
+  Processor p = Machine::ProcessorQuery(Machine::get_machine())
+                    .only_kind(Processor::LOC_PROC)
+                    .first();
+  assert(p.exists());
+```
+
+### Launching the `MAIN_TASK`
+
+The main task can be launched using collective or manual spawning.
+If `collective_spawn` is enabled, then `MAIN_TASK` is launched on all processes simultaneously.
+Otherwise, process 0 is responsible for launching tasks and initiating shutdown.
+
+```c++
+  if(use_collective_spawn) {
+    Event e = rt.collective_spawn(p, MAIN_TASK, 0, 0);
+    rt.shutdown(e);
+  } else {
+    Processor local_proc = Machine::ProcessorQuery(Machine::get_machine())
+                               .only_kind(Processor::LOC_PROC)
+                               .local_address_space()
+                               .first();
+    if(local_proc.address_space() == 0) {
+      Event e = launch_task(p);
+      rt.shutdown(e);
+    }
+  }
+```
+
+### Shutting down the Realm runtime
+
+Realm applications must explicitly shut down the runtime when all tasks have completed. This ensures that all resources are properly released and prevents processes from hanging.
+
+- The `rt.shutdown(e)` function is used to trigger the shutdown process. It takes an event `e` as a precondition, meaning the runtime will only shut down once this event has completed. In our case, this event represents the completion of the `MAIN_TASK` or all `HELLO_TASK` tasks.
+- The `rt.wait_for_shutdown()` function is necessary to ensure that all processes remain synchronized and do not exit prematurely before the runtime fully shuts down.
+- If collective spawning (`rt.collective_spawn()`) is used, then shutdown must be called on all processes with the same event to ensure consistency.
+- When manually managing task launching without collective_spawn, we ensure only rank 0 (the process with `address_space() == 0`) triggers shutdown.
+
+```c++
+  // Ensuring all processes wait for the runtime to shut down
+  int ret = rt.wait_for_shutdown();
+  return ret;
+}
+```

--- a/tutorials/machine_model/machine_model.cc
+++ b/tutorials/machine_model/machine_model.cc
@@ -1,3 +1,4 @@
+
 /* Copyright 2024 NVIDIA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,12 +14,63 @@
  * limitations under the License.
  */
 
+/**
+ * Realm Machine Model Tutorial
+ *
+ * This example illustrates how to query the machine model from Realm.
+ * It outlines various Realm types that define the resources of the
+ * underlying hardware and the affinities between these resources.
+ *
+ * Topics Covered:
+ * - Machine: the top-level abstraction of all computing resources.
+ * - Processor: execution resources that run tasks.
+ * - Memory: data storage locations with specific access properties.
+ * - Affinity: bandwidth/latency relationships between processors and memories.
+ * - ID: Realm object identifiers.
+ *
+ * Why a Machine Model?
+ * --------------------
+ * A machine model describes the structure of hardware resources available
+ * to Realm and enables applications, runtimes, or schedulers to make informed
+ * mapping decisions.
+ *
+ * Realm uses a flat, flexible, graph-based representation:
+ *   - Nodes: Processors and Memories
+ *   - Edges: Affinities (bandwidth and latency hints)
+ *
+ * This model captures real hardware topology more accurately than rigid hierarchies.
+ * For example, NUMA and GPU memory access paths may not align with CPU socket layouts.
+ *
+ * Performance Portability:
+ * Applications can use Realm’s model to remap across different machines
+ * without rewriting core logic, thanks to this abstraction layer.
+ *
+ * Example System Topology:
+ *
+ *   +------+      +------+      +------+      +------+      +-------+
+ *   | x86  |      | x86  |      | x86  |      | x86  |      | CUDA  |
+ *   +------+      +------+      +------+      +------+      +-------+
+ *      |              |              |              |            |
+ *      +--------------+--------------+--------------+------------+
+ *                     |              |              |
+ *                  +------+       +------+       +------+
+ *                  |NUMA1|       |NUMA2|       |  ZC  |  (Zero-Copy Memory)
+ *                  +------+       +------+       +------+
+ *                                                |
+ *                                             +------+
+ *                                             |  FB  | (GPU Framebuffer)
+ *                                             +------+
+ *
+ * This structure represents processors, memory types, and connections (affinities).
+ * Realm can use this model to choose the best path for computation and data movement.
+ */
+
 #include "realm.h"
 #include "realm/cmdline.h"
 #include "realm/id.h"
 #include <assert.h>
 
-using namespace Realm;
+    using namespace Realm;
 
 Logger log_app("app");
 
@@ -27,159 +79,207 @@ enum
   MAIN_TASK = Processor::TASK_ID_FIRST_AVAILABLE + 0,
 };
 
-
-void main_task(const void *args, size_t arglen, 
-               const void *userdata, size_t userlen, Processor)
+/**
+ * The main task is launched on a CPU (LOC_PROC) and performs machine model
+ * inspection by querying available processors and their memory affinities.
+ */
+void main_task(const void *args, size_t arglen, const void *userdata, size_t userlen,
+               Processor)
 {
+
+  /**
+   * MACHINE
+   * -------
+   * A Machine represents all compute nodes an application can occupy.
+   * Use Machine::get_machine() to access this singleton instance.
+   */
   Machine machine = Machine::get_machine();
-  // iterate all processors within the machine.
-  for(Machine::ProcessorQuery::iterator it = Machine::ProcessorQuery(machine).begin(); it; ++it) {
+
+  /**
+   * PROCESSOR
+   * ---------
+   * Any hardware or software entity capable of running a task.
+   * Examples: CPU core (Pthread), CPU socket (OpenMP), GPU (CUDA), Python interpreter.
+   *
+   * Realm enables consistent handling of diverse hardware (CPUs, GPUs, etc.) in
+   * distributed environments. Applications can be (re)mapped to different hardware
+   * targets without rewriting core logic.
+   *
+   * Use Machine::ProcessorQuery to enumerate processors.
+   * The address space shows which node (rank) the processor resides on.
+   */
+  for(Machine::ProcessorQuery::iterator it = Machine::ProcessorQuery(machine).begin(); it;
+      ++it) {
     Processor p = *it;
     ID proc_id = ID(p.id);
-    assert (proc_id.is_processor() || proc_id.is_procgroup());
+
+    /**
+     * ID
+     * --
+     * Realm uses 64-bit IDs to uniquely identify objects (processors, memories, etc).
+     * Use is_processor() or is_procgroup() to verify processor IDs.
+     */
+    assert(proc_id.is_processor() || proc_id.is_procgroup());
+
     Processor::Kind kind = p.kind();
-    switch (kind)
+    switch(kind) {
+    case Processor::LOC_PROC:
     {
-      case Processor::LOC_PROC:
-      {
-        log_app.print("Rank %u, Processor ID " IDFMT " is CPU.", p.address_space(), p.id); 
-        break;
-      }
-      case Processor::TOC_PROC:
-      {
-        log_app.print("Rank %u, Processor ID " IDFMT " is GPU.", p.address_space(), p.id);
-        break;
-      }
-      case Processor::IO_PROC:
-      {
-        log_app.print("Rank %u, Processor ID " IDFMT " is I/O Proc.", p.address_space(), p.id);
-        break;
-      }
-      case Processor::UTIL_PROC:
-      {
-        log_app.print("Rank %u, Processor ID " IDFMT " is utility.", p.address_space(), p.id);
-        break;
-      }
-      default:
-      {
-        log_app.print("Rank %u, Processor " IDFMT " is unknown (kind=%d)", p.address_space(), p.id, p.kind());
-        break;
-      }
+      /** LOC_PROC: latency-optimized core (CPU), specified by -ll:cpu */
+      log_app.print("Rank %u, Processor ID " IDFMT " is CPU.", p.address_space(), p.id);
+      break;
+    }
+    case Processor::TOC_PROC:
+    {
+      /** TOC_PROC: throughput-optimized core (GPU), specified by -ll:gpu */
+      log_app.print("Rank %u, Processor ID " IDFMT " is GPU.", p.address_space(), p.id);
+      break;
+    }
+    case Processor::IO_PROC:
+    {
+      /** IO_PROC: used for file or socket I/O operations, specified by -ll:io */
+      log_app.print("Rank %u, Processor ID " IDFMT " is I/O Proc.", p.address_space(),
+                    p.id);
+      break;
+    }
+    case Processor::UTIL_PROC:
+    {
+      /** UTIL_PROC: utility thread for background Realm work, specified by -ll:util */
+      log_app.print("Rank %u, Processor ID " IDFMT " is utility.", p.address_space(),
+                    p.id);
+      break;
+    }
+    default:
+    {
+      log_app.print("Rank %u, Processor " IDFMT " is unknown (kind=%d)",
+                    p.address_space(), p.id, p.kind());
+      break;
+    }
     }
 
-    // query the memories that have affinity with the processor
+    /**
+     * MEMORY
+     * ------
+     * Memories describe the location of application data
+     * System memory (DRAM), GPU framebuffer memory, NIC-registered (RDMA) memory, flash
+     * storage (e.g., burst buffers), file-backed storage.
+     *
+     * MemoryQuery returns memory objects that have affinity to the given processor.
+     * has_affinity_to(p) filters memories accessible to processor p.
+     */
     log_app.print("Has Affinity with:");
     Machine::MemoryQuery mq = Machine::MemoryQuery(machine).has_affinity_to(p, 0, 0);
+
     for(Machine::MemoryQuery::iterator it = mq.begin(); it; ++it) {
       Memory m = *it;
       ID mem_id = ID(m.id);
-      assert (mem_id.is_memory() || mem_id.is_ib_memory());
+
+      assert(mem_id.is_memory() || mem_id.is_ib_memory());
+
       size_t memory_size_in_kb = m.capacity() >> 10;
+
+      /**
+       * AFFINITY
+       * --------
+       * ProcessorMemoryAffinity describes the connection between a processor and memory.
+       * Includes bandwidth (in MB/s) and latency (in arbitrary units).
+       */
       std::vector<Machine::ProcessorMemoryAffinity> pm_affinity;
-      machine.get_proc_mem_affinity(pm_affinity, p, m, true/*local_only*/);
+      machine.get_proc_mem_affinity(pm_affinity, p, m, true);
       assert(pm_affinity.size() == 1);
+
       unsigned bandwidth = pm_affinity[0].bandwidth;
       unsigned latency = pm_affinity[0].latency;
-      Memory::Kind kind = m.kind();
-      switch (kind)
-      {
-        case Memory::GLOBAL_MEM:
-        {
-          log_app.print("\tGASNet Global Memory ID " IDFMT " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d.", 
-                  m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
-          break;
-        }
-        case Memory::SYSTEM_MEM:
-        {
-          log_app.print("\tSystem Memory ID " IDFMT " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
-                  m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
-          break;
-        }
-        case Memory::REGDMA_MEM:
-        {
-          log_app.print("\tPinned Memory ID " IDFMT " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
-                  m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
-          break;
-        }
-        case Memory::SOCKET_MEM:
-        {
-          log_app.print("\tSocket Memory ID " IDFMT " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
-                  m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
-          break;
-        }
-        case Memory::Z_COPY_MEM:
-        {
-          log_app.print("\tZero-Copy Memory ID " IDFMT " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
-                  m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
-          break;
-        }
-        case Memory::GPU_FB_MEM:
-        {
-          log_app.print("\tGPU Frame Buffer Memory ID " IDFMT " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
-                  m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
-          break;
-        }
-        case Memory::GPU_MANAGED_MEM:
-        {
-          log_app.print("\tGPU Managed Memory ID " IDFMT " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
-                  m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
-          break;
-        }
-        case Memory::GPU_DYNAMIC_MEM:
-        {
-          log_app.print("\tGPU Dynamic-allocated Frame Buffer Memory ID " IDFMT " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
-                  m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
-          break;
-        }
-        case Memory::DISK_MEM:
-        {
-          log_app.print("\tDisk Memory ID " IDFMT " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
-                  m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
-          break;
-        }
-        case Memory::HDF_MEM:
-        {
-          log_app.print("\tHDF Memory ID " IDFMT " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
-                  m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
-          break;
-        }
-        case Memory::FILE_MEM:
-        {
-          log_app.print("\tFile Memory ID " IDFMT " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
-                  m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
-          break;
-        }
-        case Memory::LEVEL3_CACHE:
-        {
-          log_app.print("\tLevel 3 Cache ID " IDFMT " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
-                  m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
-          break;
-        }
-        case Memory::LEVEL2_CACHE:
-        {
-          log_app.print("\tLevel 2 Cache ID " IDFMT " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
-                  m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
-          break;
-        }
-        case Memory::LEVEL1_CACHE:
-        {
-          log_app.print("\tLevel 1 Cache ID " IDFMT " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
-                  m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
-          break;
-        }
-        default:
-        {
-          log_app.print("\tMemory " IDFMT " is unknown (kind=%d).", it->id, it->kind());
-          break;
-        }
+
+      /**
+       * MEMORY KIND
+       * -----------
+       * Realm supports many types of memory:
+       * SYSTEM_MEM, REGDMA_MEM, GPU_FB_MEM, Z_COPY_MEM, etc.
+       * Each has specific usage and visibility traits.
+       */
+      switch(m.kind()) {
+      case Memory::GLOBAL_MEM:
+        log_app.print("\tGASNet Global Memory ID " IDFMT
+                      " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d.",
+                      m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
+        break;
+      case Memory::SYSTEM_MEM:
+        log_app.print("\tSystem Memory ID " IDFMT
+                      " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
+                      m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
+        break;
+      case Memory::REGDMA_MEM:
+        log_app.print("\tPinned Memory ID " IDFMT
+                      " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
+                      m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
+        break;
+      case Memory::SOCKET_MEM:
+        log_app.print("\tSocket Memory ID " IDFMT
+                      " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
+                      m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
+        break;
+      case Memory::Z_COPY_MEM:
+        log_app.print("\tZero-Copy Memory ID " IDFMT
+                      " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
+                      m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
+        break;
+      case Memory::GPU_FB_MEM:
+        log_app.print("\tGPU Frame Buffer Memory ID " IDFMT
+                      " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
+                      m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
+        break;
+      case Memory::GPU_MANAGED_MEM:
+        log_app.print("\tGPU Managed Memory ID " IDFMT
+                      " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
+                      m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
+        break;
+      case Memory::GPU_DYNAMIC_MEM:
+        log_app.print("\tGPU Dynamic-allocated Frame Buffer Memory ID " IDFMT
+                      " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
+                      m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
+        break;
+      case Memory::DISK_MEM:
+        log_app.print("\tDisk Memory ID " IDFMT
+                      " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
+                      m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
+        break;
+      case Memory::HDF_MEM:
+        log_app.print("\tHDF Memory ID " IDFMT
+                      " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
+                      m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
+        break;
+      case Memory::FILE_MEM:
+        log_app.print("\tFile Memory ID " IDFMT
+                      " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
+                      m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
+        break;
+      case Memory::LEVEL3_CACHE:
+        log_app.print("\tLevel 3 Cache ID " IDFMT
+                      " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
+                      m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
+        break;
+      case Memory::LEVEL2_CACHE:
+        log_app.print("\tLevel 2 Cache ID " IDFMT
+                      " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
+                      m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
+        break;
+      case Memory::LEVEL1_CACHE:
+        log_app.print("\tLevel 1 Cache ID " IDFMT
+                      " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
+                      m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
+        break;
+      default:
+        log_app.print("\tMemory " IDFMT " is unknown (kind=%d).", it->id, it->kind());
+        break;
       }
     }
   }
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
   Runtime rt;
-
   rt.init(&argc, (char ***)&argv);
 
   Processor p = Machine::ProcessorQuery(Machine::get_machine())
@@ -188,14 +288,11 @@ int main(int argc, char **argv) {
   assert(p.exists());
 
   Processor::register_task_by_kind(Processor::LOC_PROC, false /*!global*/, MAIN_TASK,
-                                   CodeDescriptor(main_task),
-                                   ProfilingRequestSet()).external_wait();
+                                   CodeDescriptor(main_task), ProfilingRequestSet())
+      .external_wait();
 
   Event e = rt.collective_spawn(p, MAIN_TASK, 0, 0);
-
   rt.shutdown(e);
 
-  int ret = rt.wait_for_shutdown();
-
-  return ret;
+  return rt.wait_for_shutdown();
 }

--- a/tutorials/machine_model/machine_model.md
+++ b/tutorials/machine_model/machine_model.md
@@ -1,142 +1,320 @@
----
-title: Machine Model
----
+<!-- omit from toc -->
+# Realm Machine Model Tutorial
 
+This example illustrates how to query the machine model from Realm.
+It outlines various Realm types that define the resources of the
+underlying hardware and the affinities between these resources.
 
-This example illustrates how to query the machine model from Realm. In addition, it outlines
-various types that Realm uses to define resources of underlying hardware that an application
-occupies, as well as affinities between these resources.
+- [Why a machine model?](#why-a-machine-model)
+  - [Performance portability](#performance-portability)
+  - [Example system topology](#example-system-topology)
+- [Program Setup](#program-setup)
+- [Machine](#machine)
+- [Processor](#processor)
+- [Memory](#memory)
+- [Main function](#main-function)
 
-Here is a list of covered topics:
+## Why a machine model?
 
-* [Machine](#machine)
-* [Processor](#processor)
-* [Memory](#memory)
-* [Affinity](#affinity)
-* [ID](#id)
-* [References](#references)
+A machine model describes the structure of hardware resources available
+to Realm and enables applications, runtimes, or schedulers to make informed
+mapping decisions.
+
+Realm uses a flat, flexible, graph-based representation:
+
+- **Nodes**: Processors and Memories
+- **Edges**: Affinities (bandwidth and latency hints)
+
+This model captures real hardware topology more accurately than rigid hierarchies.
+For example, NUMA and GPU memory access paths may not align with CPU socket layouts.
+
+### Performance portability
+
+Applications can use Realm’s model to remap across different machines
+without rewriting core logic, thanks to this abstraction layer.
+
+### Example system topology
+
+```none
+  +------+      +------+      +------+      +------+      +-------+
+  | x86  |      | x86  |      | x86  |      | x86  |      | CUDA  |
+  +------+      +------+      +------+      +------+      +-------+
+     |              |              |              |            |
+     +--------------+--------------+--------------+------------+
+                    |              |              |
+                 +------+       +------+       +------+
+                 |NUMA1 |       |NUMA2 |       |  ZC  |  (Zero-Copy Memory)
+                 +------+       +------+       +------+
+                                               |
+                                            +------+
+                                            |  FB  | (GPU Framebuffer)
+                                            +------+
+```
+
+This structure represents processors, memory types, and connections (affinities).
+Realm can use this model to choose the best path for computation and data movement.
+
+## Program Setup
+
+```c++
+#include "realm.h"
+#include "realm/cmdline.h"
+#include "realm/id.h"
+#include <assert.h>
+
+using namespace Realm;
+
+Logger log_app("app");
+
+enum
+{
+  MAIN_TASK = Processor::TASK_ID_FIRST_AVAILABLE + 0,
+};
+
+/**
+ * The main task is launched on a CPU (LOC_PROC) and performs machine model
+ * inspection by querying available processors and their memory affinities.
+ */
+void main_task(const void *args, size_t arglen, const void *userdata, size_t userlen,
+               Processor)
+{
+```
 
 ## Machine
 
-In Realm, a Machine is a runtim object that represents all the computer nodes an application can occupy.
-It can be retrieved using the `Machine::get_machine()` function,
-which returns a singleton object.
-Processors, memories of the `Machine`, and affinity information can be queried from the `Machine` object.
+A `Machine` represents all compute nodes an application can occupy.
+Use `Machine::get_machine()` to access this singleton instance.
+
+```c++
+  Machine machine = Machine::get_machine();
+```
 
 ## Processor
 
-A `Processor` is a runtime object that represents any execution resource that can run a task, such as CPU, GPU, etc.
-To retrieve a `Processor`, the `Machine::ProcessorQuery` function can be used. In this example, we use `ProcessorQuery` to iterate over all
-enabled processors and print out their address space and ID (a unique identifier Realm assigns).
+ Any hardware or software entity capable of running a task.
+Examples:
+
+- CPU core (Pthread)
+- CPU socket (OpenMP)
+- GPU (CUDA)
+- Python interpreter.
+
+Realm enables consistent handling of diverse hardware (CPUs, GPUs, etc.) in
+distributed environments. Applications can be (re)mapped to different hardware
+targets without rewriting core logic.
+
+Use `Machine::ProcessorQuery` to enumerate processors.
+The address space shows which node (rank) the processor resides on.
+
+A `Processor` can also be queried by its kind and the runtime supports the following options:
+
+- `LOC_PROC` represents a latency processor,which is usually a CPU core. It can be specified by -ll:cpu.
+- `TOC_PROC` represents a throughput processor (GPU). Currently, Realm supports both NVIDIA and AMD GPUs. It can be specified by -ll:gpu.
+- `UTIL_PROC` represents a CPU processor that is designed for users to run their own background work. It can be specified by -ll:util.
+- `IO_PROC` represents a processor that is used for I/O, which is also a CPU core. It can be specified by -ll:io.
+- `PROC_GROUP` represents a group of processors.
+- `PROC_SET` represents a set of processors for OpenMP/Kokkos etc. It can be specified by -ll:mp_nodes.
+- `OMP_PROC` represents OpenMP thread pool. It can be specified by -ll:ocpu. The number of threads per OMP_PROC can be specified by -ll:othr.
+- `PY_PROC` represents a CPU processor that is used for Python interpreter. It can be specified by -ll:py. Currently, we only support a single `PY_PROC`.
 
 ```c++
-for(Machine::ProcessorQuery::iterator it = Machine::ProcessorQuery(machine).begin(); it; ++it) {
-  ...
-}
+  for(Machine::ProcessorQuery::iterator it = Machine::ProcessorQuery(machine).begin(); it;
+      ++it) {
+    Processor p = *it;
+    ID proc_id = ID(p.id);
+
+    /**
+     * ID
+     * --
+     * Realm uses 64-bit IDs to uniquely identify objects (processors, memories, etc).
+     * Use is_processor() or is_procgroup() to verify processor IDs.
+     */
+    assert(proc_id.is_processor() || proc_id.is_procgroup());
+
+    Processor::Kind kind = p.kind();
+    switch(kind) {
+    case Processor::LOC_PROC:
+    {
+      /** LOC_PROC: latency-optimized core (CPU), specified by -ll:cpu */
+      log_app.print("Rank %u, Processor ID " IDFMT " is CPU.", p.address_space(), p.id);
+      break;
+    }
+    case Processor::TOC_PROC:
+    {
+      /** TOC_PROC: throughput-optimized core (GPU), specified by -ll:gpu */
+      log_app.print("Rank %u, Processor ID " IDFMT " is GPU.", p.address_space(), p.id);
+      break;
+    }
+    case Processor::IO_PROC:
+    {
+      /** IO_PROC: used for file or socket I/O operations, specified by -ll:io */
+      log_app.print("Rank %u, Processor ID " IDFMT " is I/O Proc.", p.address_space(),
+                    p.id);
+      break;
+    }
+    case Processor::UTIL_PROC:
+    {
+      /** UTIL_PROC: utility thread for background Realm work, specified by -ll:util */
+      log_app.print("Rank %u, Processor ID " IDFMT " is utility.", p.address_space(),
+                    p.id);
+      break;
+    }
+    default:
+    {
+      log_app.print("Rank %u, Processor " IDFMT " is unknown (kind=%d)",
+                    p.address_space(), p.id, p.kind());
+      break;
+    }
+  }
 ```
-
-The address space of a Realm resource, such as Processor and Memory (introduced in the next section), indicates the process/rank where it resides.
-
-A `Processor` can also be queried by its `kind` and the runtime supports the following options:
-
-- `LOC_PROC` represents a latency processor,which is usually a CPU core.
-  It can be specified by `-ll:cpu`.
-- `TOC_PROC` represents a throughput processor (GPU).
-  Currently, Realm supports both NVIDIA and AMD GPUs.
-  It can be specified by `-ll:gpu`.
-- `UTIL_PROC` represents a CPU processor that is designed for users to run their own background work.
-  It can be specified by `-ll:util`.
-- `IO_PROC` represents a processor that is used for I/O, which is also a CPU core.
-  It can be specified by `-ll:io`.
-- `PROC_GROUP` represents a group of processors.
-- `PROC_SET` represents a set of processors for OpenMP/Kokkos etc.
-  It can be specified by `-ll:mp_nodes`.
-- `OMP_PROC` represents OpenMP thread pool.
-  It can be specified by `-ll:ocpu`.
-  The number of threads per `OMP_PROC` can be specified by `-ll:othr`.
-- `PY_PROC` represents a CPU processor that is used for Python interpreter.
-  It can be specified by `-ll:py`.
-  Currently, we only support a single `PY_PROC`.
-
-For a list of all the processors kind supported by Realm, please refer to [Full Processor Kind](#full-proc-kind).
 
 ## Memory
 
-`Memory` is used to describe the location of application data. `MemoryQuery` can be used to query
-the `Memory`. For example, a `MemoryQuery` can be created with the condition `has_affinity_to` to return
-all memories that are affixed to the given processor.
+Memories describe the location of application data
+
+- System memory (DRAM)
+- GPU framebuffer memory
+- NIC-registered (RDMA) memory
+- flash storage (e.g., burst buffers)
+- file-backed storage.
+
+`MemoryQuery` returns memory objects that have affinity to the given processor.
+`has_affinity_to(p)` filters memories accessible to processor `p`.
 
 ```c++
-Machine::MemoryQuery mq = Machine::MemoryQuery(machine).has_affinity_to(p, 0, 0);
+    log_app.print("Has Affinity with:");
+    Machine::MemoryQuery mq = Machine::MemoryQuery(machine).has_affinity_to(p, 0, 0);
+
+    for(Machine::MemoryQuery::iterator it = mq.begin(); it; ++it) {
+      Memory m = *it;
+      ID mem_id = ID(m.id);
+
+      assert(mem_id.is_memory() || mem_id.is_ib_memory());
+
+      size_t memory_size_in_kb = m.capacity() >> 10;
+
+      /**
+       * AFFINITY
+       * --------
+       * ProcessorMemoryAffinity describes the connection between a processor and memory.
+       * Includes bandwidth (in MB/s) and latency (in arbitrary units).
+       */
+      std::vector<Machine::ProcessorMemoryAffinity> pm_affinity;
+      machine.get_proc_mem_affinity(pm_affinity, p, m, true);
+      assert(pm_affinity.size() == 1);
+
+      unsigned bandwidth = pm_affinity[0].bandwidth;
+      unsigned latency = pm_affinity[0].latency;
+
+      /**
+       * MEMORY KIND
+       * -----------
+       * Realm supports many types of memory:
+       * SYSTEM_MEM, REGDMA_MEM, GPU_FB_MEM, Z_COPY_MEM, etc.
+       * Each has specific usage and visibility traits.
+       */
+      switch(m.kind()) {
+      case Memory::GLOBAL_MEM:
+        log_app.print("\tGASNet Global Memory ID " IDFMT
+                      " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d.",
+                      m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
+        break;
+      case Memory::SYSTEM_MEM:
+        log_app.print("\tSystem Memory ID " IDFMT
+                      " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
+                      m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
+        break;
+      case Memory::REGDMA_MEM:
+        log_app.print("\tPinned Memory ID " IDFMT
+                      " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
+                      m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
+        break;
+      case Memory::SOCKET_MEM:
+        log_app.print("\tSocket Memory ID " IDFMT
+                      " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
+                      m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
+        break;
+      case Memory::Z_COPY_MEM:
+        log_app.print("\tZero-Copy Memory ID " IDFMT
+                      " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
+                      m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
+        break;
+      case Memory::GPU_FB_MEM:
+        log_app.print("\tGPU Frame Buffer Memory ID " IDFMT
+                      " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
+                      m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
+        break;
+      case Memory::GPU_MANAGED_MEM:
+        log_app.print("\tGPU Managed Memory ID " IDFMT
+                      " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
+                      m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
+        break;
+      case Memory::GPU_DYNAMIC_MEM:
+        log_app.print("\tGPU Dynamic-allocated Frame Buffer Memory ID " IDFMT
+                      " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
+                      m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
+        break;
+      case Memory::DISK_MEM:
+        log_app.print("\tDisk Memory ID " IDFMT
+                      " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
+                      m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
+        break;
+      case Memory::HDF_MEM:
+        log_app.print("\tHDF Memory ID " IDFMT
+                      " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
+                      m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
+        break;
+      case Memory::FILE_MEM:
+        log_app.print("\tFile Memory ID " IDFMT
+                      " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
+                      m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
+        break;
+      case Memory::LEVEL3_CACHE:
+        log_app.print("\tLevel 3 Cache ID " IDFMT
+                      " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
+                      m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
+        break;
+      case Memory::LEVEL2_CACHE:
+        log_app.print("\tLevel 2 Cache ID " IDFMT
+                      " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
+                      m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
+        break;
+      case Memory::LEVEL1_CACHE:
+        log_app.print("\tLevel 1 Cache ID " IDFMT
+                      " has %zd KB, bandwidth %u, latency %u, is IB_Mem %d",
+                      m.id, memory_size_in_kb, bandwidth, latency, mem_id.is_ib_memory());
+        break;
+      default:
+        log_app.print("\tMemory " IDFMT " is unknown (kind=%d).", it->id, it->kind());
+        break;
+      }
+    }
+  }
+}
 ```
 
-A `Memory` can also be queried by its `kind` and the runtime supports the following options:
+## Main function
 
-- `GLOBAL_MEM` represents CPU memory guaranteed to be visible to all processors on all nodes.
-  e.g. GASNet global memory. `GLOBAL_MEM` is usually slow.
-  `GLOBAL_MEM` is only used by MPI and GASNet1 modules, and it can be specified by `-ll:gsize`.
-- `SYSTEM_MEM` represents CPU memory visible to all processors on a node.
-  It can be specified by `-ll:csize`.
-- `REGDMA_MEM` represents registered memory visible to all processors on a node, and can be a target of RDMA.
-  It can be specified by `-ll:rsize`.
-- `SOCKET_MEM` represents CPU memory visible to all processors within a node.
-  It is NUMA-aware, so it provides better performance for processors on the same socket.
-- `Z_COPY_MEM` represents Zero-Copy memory visible to all CPUs within a node and one or more GPUs.
-  It can be specified by `-ll:zsize`.
-- `GPU_FB_MEM` represents framebuffer memory for a particular GPU.
-  It can be specified by `-ll:fsize`.
-- `GPU_MANAGED_MEM` represents managed memory that can be cached by either host or GPU.
-  It can be specified by `-ll:msize`.
-- `GPU_DYNAMIC_MEM` represents dynamically-allocated framebuffer memory for a particular GPU.
-  Its size is not fixed, but its maximum size can be specified by `-cuda:dynfb_max`.
-- `DISK_MEM` represents disk memory visible to all processors on a node.
-  It can be specified by `-ll:dsize`.
-- `HDF_MEM` and `FILE_MEM` represent HDF and file memory visible to all processors on a node, respectively.
-  They do not have memory space, so their sizes are always 0.
-  These I/O related memories allow users to create instances for I/O operations.
-
-For a list of all the memories kind supported by Realm, please refer to [Full Memory Kind](#full-mem-kind).
-
-## Affinity
-
-Realm provides `ProcessorMemoryAffinity` and `MemoryMemoryAffinity` to query the affinity information
-between processors and memories. In this example, we use `ProcessorMemoryAffinity` to retrieve the information,
-including latency and bandwidth between a pair of memory and processor.
+Putting everything together, we define a `main` function to launch our main task:
 
 ```c++
-std::vector<Machine::ProcessorMemoryAffinity> pm_affinity;
-machine.get_proc_mem_affinity(pm_affinity, p, m, true/*local_only*/);
-unsigned bandwidth = pm_affinity[0].bandwidth;
-unsigned latency = pm_affinity[0].latency;
+int main(int argc, char **argv)
+{
+  Runtime rt;
+  rt.init(&argc, (char ***)&argv);
+
+  Processor p = Machine::ProcessorQuery(Machine::get_machine())
+                    .only_kind(Processor::LOC_PROC)
+                    .first();
+  assert(p.exists());
+
+  Processor::register_task_by_kind(Processor::LOC_PROC, false /*!global*/, MAIN_TASK,
+                                   CodeDescriptor(main_task), ProfilingRequestSet())
+      .external_wait();
+
+  Event e = rt.collective_spawn(p, MAIN_TASK, 0, 0);
+  rt.shutdown(e);
+
+  return rt.wait_for_shutdown();
+}
 ```
-
-## ID
-
-Realm ID is a 64-bit value that uniquely encodes both the type of the referred-to Realm object and its identity.
-Once we convert an ID into a hexadecimal number, it can be decoded. The following is an example of a processor ID
-and a memory ID:
-
-```
-Processor ID 1d00010000000001 is CPU.
-System Memory ID 1e00010000000000 has 0 KB, bandwidth 100, latency 5.
-```
-The highest two digits (8 bits) are used to tell the type of an ID, e.g., `1d` represents Processor and `1e` represents Memory.
-The next four digits (16 bits) are used to tell the owner node of an ID, e.g., `0001` means the processor/memory is on
-node 1. The last two/three digits (8/12 bits) are used tell the local index of a Memory/Processor ID, e.g., `01` means
-the cpu index is 1 while `00` means the memory index is 0.
-Besides processor and memory, the ID of other Realm objects (e.g., Event and etc.) can also be decoded.
-For a complete introduction to Realm ID, please refer to the [ID header file](#id-header-file).
-
-Realm provides `is_TYPE` functions to test the type of an ID, e.g. in this example, `is_processor` is used to check if an ID
-is a processor.
-
-## References
-
-<div id="full-proc-kind"></div>
-\[1]: [Full Processor Kind](https://github.com/StanfordLegion/realm/blob/main/realm/realm_c.h#L45)
-
-<div id="full-mem-kind"></div>
-\[2]: [Full Memory Kind](https://github.com/StanfordLegion/realm/blob/main/realm/realm_c.h#L63)
-
-<div id="id-header-file"></div>
-\[3]: [ID header file](https://github.com/StanfordLegion/realm/blob/main/realm/id.h)


### PR DESCRIPTION
This PR updates the `hello_world`, `basic_events`, and `machine_model` tutorials (based on the new annotated source files provided by @apryakhin) 

* The main tutorials page has the tutorials in alphabetical order. This is probably not desirable / intended. 
* There is still "blog" cruft (share links, comments, etc,) being included from whatever Jekyll layout the tutorial pages are using
* Having the tutorials on `main` is fairly annoying when you want to see how things actually look when rendered locally. Not sure what a better workflow would be though...

Lastly, the column layout seems a bit narrow for the code blocks:

<img width="985" alt="Screenshot 2025-07-03 at 13 44 25" src="https://github.com/user-attachments/assets/96703c9e-c531-4acb-80ad-8d9549135a7b" />
