### PR TITLE
cuda: Fixes for 13.0

### DIFF
--- a/src/realm/cuda/cuda_internal.h
+++ b/src/realm/cuda/cuda_internal.h
@@ -1278,6 +1278,20 @@ namespace Realm {
     CUresult cuCtxRecordEvent(CUcontext hctx, CUevent event);
 #endif
 
+#if CUDA_VERSION >= 13000
+// Unfortunately, 13.0 violates it's own source compatibility rules versus
+// cuGetProcAddress, so fix that ourselves here.
+#if !defined(cuCtxGetDevice)
+#define cuCtxGetDevice cuCtxGetDevice_v2
+#endif
+#if !defined(cuCtxSynchronize)
+#define cuCtxSynchronize cuCtxSynchronize_v2
+#endif
+#if !defined(cuStreamGetCtx)
+#define cuStreamGetCtx cuStreamGetCtx_v2
+#endif
+#endif
+
     // cuda driver and/or runtime entry points
 #define CUDA_DRIVER_HAS_FNPTR(name) ((name##_fnptr) != nullptr)
 #define CUDA_DRIVER_FNPTR(name) (assert(name##_fnptr != nullptr), name##_fnptr)


### PR DESCRIPTION
* cuGetProcAddress broke it's own rules for a couple of apis and kept back old versions of apis, but left cuGetProcAddress to return the newer ones, breaking source compatibility guarentees for 13.0
* For those apis that were held back, an explicit context or location was added, so modify the calls to pass in the required arguments, being compatible with older toolkits as well.