### PR TITLE
Turn on the cmake setting to generate a compile_commands.json file du…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,8 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 #region External built-ins
 include(GenerateExportHeader)
 include(GNUInstallDirs)


### PR DESCRIPTION
…ring the build. This is required for clangd, et al, to function.