### PR TITLE
Refactor realm_event_wait to take a timer parameter

### DIFF
--- a/src/realm/realm_c.cc
+++ b/src/realm/realm_c.cc
@@ -824,23 +824,40 @@ realm_status_t realm_memory_query_iter(realm_memory_query_t query,
 /* Event API */
 
 realm_status_t realm_event_wait(realm_runtime_t runtime, realm_event_t event,
-                                int *poisoned)
+                                int64_t max_ns, int *poisoned)
 {
   Realm::RuntimeImpl *runtime_impl = nullptr;
   realm_status_t status = check_runtime_validity_and_assign(runtime, runtime_impl);
   if(status != REALM_SUCCESS) {
     return status;
   }
+
   status = check_event_validity(event);
   if(status != REALM_SUCCESS) {
     return status;
   }
+
+  // special case: NO_EVENT is always triggered
+  if(event == REALM_NO_EVENT) {
+    if(poisoned != nullptr) {
+      *poisoned = 0;
+    }
+    return REALM_SUCCESS;
+  }
+
   Realm::Event cxx_event = Realm::Event(event);
   bool poisoned_cxx = false;
-  cxx_event.wait_faultaware(poisoned_cxx);
+
+  if(max_ns == REALM_WAIT_INFINITE) {
+    cxx_event.wait_faultaware(poisoned_cxx);
+  } else {
+    cxx_event.external_timedwait_faultaware(poisoned_cxx, max_ns);
+  }
+
   if(poisoned != nullptr) {
     *poisoned = poisoned_cxx ? 1 : 0;
   }
+
   return REALM_SUCCESS;
 }
 

--- a/src/realm/realm_c.h
+++ b/src/realm/realm_c.h
@@ -173,6 +173,8 @@ typedef struct realm_region_instance_copy_params_t {
 #define REALM_TASK_ID_PROCESSOR_SHUTDOWN ((realm_task_func_id_t)2U)
 #define REALM_TASK_ID_FIRST_AVAILABLE ((realm_task_func_id_t)4U)
 
+#define REALM_WAIT_INFINITE ((int64_t)INT64_MIN)
+
 typedef enum realm_register_task_flags
 {
   REALM_REGISTER_TASK_DEFAULT = 0x0ULL,
@@ -758,14 +760,16 @@ realm_status_t REALM_EXPORT realm_memory_query_iter(realm_memory_query_t query,
  * @brief Waits for a specific event to complete.
  *
  * @param runtime The runtime instance to use.
- * @param[out] event The event to wait for.
+ * @param event The event to wait for.
+ * @param max_ns The maximum number of nanoseconds to wait.
+ *               REALM_WAIT_INFINITE is a special value that means wait forever.
  * @param[out] poisoned Whether the event is poisoned.
  * @return Realm status indicating success or failure.
  *
  * @ingroup Event
  */
 realm_status_t REALM_EXPORT realm_event_wait(realm_runtime_t runtime, realm_event_t event,
-                                             int *poisoned);
+                                             int64_t max_ns, int *poisoned);
 
 /**
  * @brief Merges multiple events into a single event.

--- a/tests/c/test_c_external_inst.cc
+++ b/tests/c/test_c_external_inst.cc
@@ -103,7 +103,7 @@ bool create_instance_and_copy_and_verify(
   realm_event_t event = REALM_NO_EVENT;
   CHECK_REALM(realm_region_instance_create(runtime, &src_instance_params, nullptr,
                                            REALM_NO_EVENT, &src_inst, &event));
-  CHECK_REALM(realm_event_wait(runtime, event, nullptr));
+  CHECK_REALM(realm_event_wait(runtime, event, REALM_WAIT_INFINITE, nullptr));
 
   Realm::RegionInstance src_inst_cxx = Realm::RegionInstance(src_inst);
   const Realm::InstanceLayoutGeneric *src_layout = src_inst_cxx.get_layout();
@@ -131,7 +131,7 @@ bool create_instance_and_copy_and_verify(
 
   CHECK_REALM(realm_region_instance_copy(runtime, &copy_params, nullptr, REALM_NO_EVENT,
                                          0, &event));
-  CHECK_REALM(realm_event_wait(runtime, event, nullptr));
+  CHECK_REALM(realm_event_wait(runtime, event, REALM_WAIT_INFINITE, nullptr));
 
   Realm::RegionInstance dst_inst_cxx = Realm::RegionInstance(dst_inst);
   dst_inst_cxx.fetch_metadata(Realm::Processor(proc)).wait();
@@ -194,7 +194,7 @@ static void test_copy(realm_runtime_t runtime, realm_memory_t dst_mem,
   realm_region_instance_t dst_inst;
   CHECK_REALM(realm_region_instance_create(runtime, &dst_instance_params, nullptr,
                                            REALM_NO_EVENT, &dst_inst, &event));
-  CHECK_REALM(realm_event_wait(runtime, event, nullptr));
+  CHECK_REALM(realm_event_wait(runtime, event, REALM_WAIT_INFINITE, nullptr));
 
   Realm::RegionInstance dst_inst_cxx = Realm::RegionInstance(dst_inst);
   const Realm::InstanceLayoutGeneric *dst_layout = dst_inst_cxx.get_layout();
@@ -351,7 +351,8 @@ int main(int argc, char **argv)
   CHECK_REALM(realm_processor_register_task_by_kind(
       runtime, target_proc_kind, REALM_REGISTER_TASK_DEFAULT, MAIN_TASK, main_task, 0, 0,
       &register_task_event));
-  CHECK_REALM(realm_event_wait(runtime, register_task_event, nullptr));
+  CHECK_REALM(
+      realm_event_wait(runtime, register_task_event, REALM_WAIT_INFINITE, nullptr));
 
   realm_processor_query_t proc_query;
   CHECK_REALM(realm_processor_query_create(runtime, &proc_query));

--- a/tests/c/test_c_inst.cc
+++ b/tests/c/test_c_inst.cc
@@ -91,7 +91,7 @@ static void test_copy(realm_runtime_t runtime, realm_memory_t src_mem,
   };
   CHECK_REALM(realm_region_instance_create(runtime, &src_instance_params, nullptr,
                                            REALM_NO_EVENT, &src_inst, &event));
-  CHECK_REALM(realm_event_wait(runtime, event, nullptr));
+  CHECK_REALM(realm_event_wait(runtime, event, REALM_WAIT_INFINITE, nullptr));
   realm_region_instance_create_params_t dst_instance_params = {
       .memory = dst_mem,
       .lower_bound = lower_bound,
@@ -107,7 +107,7 @@ static void test_copy(realm_runtime_t runtime, realm_memory_t src_mem,
   };
   CHECK_REALM(realm_region_instance_create(runtime, &dst_instance_params, nullptr,
                                            REALM_NO_EVENT, &dst_inst, &event));
-  CHECK_REALM(realm_event_wait(runtime, event, nullptr));
+  CHECK_REALM(realm_event_wait(runtime, event, REALM_WAIT_INFINITE, nullptr));
   Realm::RegionInstance src_inst_cxx = Realm::RegionInstance(src_inst);
   Realm::RegionInstance dst_inst_cxx = Realm::RegionInstance(dst_inst);
   src_inst_cxx.fetch_metadata(Realm::Processor(proc)).wait();
@@ -140,7 +140,7 @@ static void test_copy(realm_runtime_t runtime, realm_memory_t src_mem,
 
   CHECK_REALM(realm_region_instance_copy(runtime, &copy_params, nullptr, REALM_NO_EVENT,
                                          0, &event));
-  CHECK_REALM(realm_event_wait(runtime, event, nullptr));
+  CHECK_REALM(realm_event_wait(runtime, event, REALM_WAIT_INFINITE, nullptr));
 
   bool success = true;
   Realm::GenericAccessor<int, N, T> acc(Realm::RegionInstance(dst_inst), FID_BASE);
@@ -254,7 +254,8 @@ int main(int argc, char **argv)
   CHECK_REALM(realm_processor_register_task_by_kind(
       runtime, LOC_PROC, REALM_REGISTER_TASK_DEFAULT, MAIN_TASK, main_task, 0, 0,
       &register_task_event));
-  CHECK_REALM(realm_event_wait(runtime, register_task_event, nullptr));
+  CHECK_REALM(
+      realm_event_wait(runtime, register_task_event, REALM_WAIT_INFINITE, nullptr));
 
   realm_processor_query_t proc_query;
   CHECK_REALM(realm_processor_query_create(runtime, &proc_query));

--- a/tests/c/test_event_poisoned.cc
+++ b/tests/c/test_event_poisoned.cc
@@ -46,7 +46,7 @@ void test_merge(realm_runtime_t runtime, int ignore_faults, int *poisoned)
   realm_event_t merged_event;
   CHECK_REALM(
       realm_event_merge(runtime, event_poisoned, 10, &merged_event, ignore_faults));
-  CHECK_REALM(realm_event_wait(runtime, merged_event, poisoned));
+  CHECK_REALM(realm_event_wait(runtime, merged_event, REALM_WAIT_INFINITE, poisoned));
 }
 
 void test_trigger(realm_runtime_t runtime, int ignore_faults, bool use_wait,
@@ -60,7 +60,7 @@ void test_trigger(realm_runtime_t runtime, int ignore_faults, bool use_wait,
   CHECK_REALM(
       realm_user_event_trigger(runtime, user_event, wait_on_event, ignore_faults));
   if(use_wait) {
-    CHECK_REALM(realm_event_wait(runtime, user_event, poisoned));
+    CHECK_REALM(realm_event_wait(runtime, user_event, REALM_WAIT_INFINITE, poisoned));
   } else {
     int has_triggered = 0;
     CHECK_REALM(realm_event_has_triggered(runtime, user_event, &has_triggered, poisoned));
@@ -108,7 +108,8 @@ int main(int argc, char **argv)
   CHECK_REALM(realm_processor_register_task_by_kind(
       runtime, LOC_PROC, REALM_REGISTER_TASK_DEFAULT, MAIN_TASK, main_task, 0, 0,
       &register_task_event));
-  CHECK_REALM(realm_event_wait(runtime, register_task_event, nullptr));
+  CHECK_REALM(
+      realm_event_wait(runtime, register_task_event, REALM_WAIT_INFINITE, nullptr));
 
   realm_processor_query_t proc_query;
   CHECK_REALM(realm_processor_query_create(runtime, &proc_query));

--- a/tests/c/test_memory_query.cc
+++ b/tests/c/test_memory_query.cc
@@ -99,7 +99,8 @@ int main(int argc, char **argv)
   CHECK_REALM(realm_processor_register_task_by_kind(
       runtime, LOC_PROC, REALM_REGISTER_TASK_DEFAULT, TOP_LEVEL_TASK, top_level_task, 0,
       0, &register_task_event));
-  CHECK_REALM(realm_event_wait(runtime, register_task_event, nullptr));
+  CHECK_REALM(
+      realm_event_wait(runtime, register_task_event, REALM_WAIT_INFINITE, nullptr));
 
   realm_processor_query_t proc_query;
   CHECK_REALM(realm_processor_query_create(runtime, &proc_query));

--- a/tests/c/test_processor_query.cc
+++ b/tests/c/test_processor_query.cc
@@ -99,7 +99,8 @@ int main(int argc, char **argv)
   CHECK_REALM(realm_processor_register_task_by_kind(
       runtime, LOC_PROC, REALM_REGISTER_TASK_DEFAULT, TOP_LEVEL_TASK, top_level_task, 0,
       0, &register_task_event));
-  CHECK_REALM(realm_event_wait(runtime, register_task_event, nullptr));
+  CHECK_REALM(
+      realm_event_wait(runtime, register_task_event, REALM_WAIT_INFINITE, nullptr));
 
   realm_processor_query_t proc_query;
   CHECK_REALM(realm_processor_query_create(runtime, &proc_query));

--- a/tests/c/test_runtime.cc
+++ b/tests/c/test_runtime.cc
@@ -72,7 +72,7 @@ void REALM_FNPTR top_level_task(const void *args, size_t arglen, const void *use
                                       0, 0, NULL, 0, 0, &events[i]));
   }
   CHECK_REALM(realm_event_merge(runtime, events.data(), events.size(), &event, 0));
-  CHECK_REALM(realm_event_wait(runtime, event, nullptr));
+  CHECK_REALM(realm_event_wait(runtime, event, REALM_WAIT_INFINITE, nullptr));
 
 #ifdef REALM_USE_CUDA
   CHECK_REALM(realm_processor_query_create(runtime, &proc_query));
@@ -85,7 +85,7 @@ void REALM_FNPTR top_level_task(const void *args, size_t arglen, const void *use
 
   CHECK_REALM(
       realm_processor_spawn(runtime, gpu_proc, HELLO_TASK, 0, 0, NULL, 0, 0, &event));
-  CHECK_REALM(realm_event_wait(runtime, event, nullptr));
+  CHECK_REALM(realm_event_wait(runtime, event, REALM_WAIT_INFINITE, nullptr));
 #endif
 }
 
@@ -105,17 +105,20 @@ int main(int argc, char **argv)
   CHECK_REALM(realm_processor_register_task_by_kind(
       runtime, LOC_PROC, REALM_REGISTER_TASK_DEFAULT, TOP_LEVEL_TASK, top_level_task, 0,
       0, &register_task_event));
-  CHECK_REALM(realm_event_wait(runtime, register_task_event, nullptr));
+  CHECK_REALM(
+      realm_event_wait(runtime, register_task_event, REALM_WAIT_INFINITE, nullptr));
 
   CHECK_REALM(realm_processor_register_task_by_kind(
       runtime, LOC_PROC, REALM_REGISTER_TASK_DEFAULT, HELLO_TASK, hello_task, 0, 0,
       &register_task_event));
-  CHECK_REALM(realm_event_wait(runtime, register_task_event, nullptr));
+  CHECK_REALM(
+      realm_event_wait(runtime, register_task_event, REALM_WAIT_INFINITE, nullptr));
 
   CHECK_REALM(realm_processor_register_task_by_kind(
       runtime, TOC_PROC, REALM_REGISTER_TASK_DEFAULT, HELLO_TASK, hello_task, 0, 0,
       &register_task_event));
-  CHECK_REALM(realm_event_wait(runtime, register_task_event, nullptr));
+  CHECK_REALM(
+      realm_event_wait(runtime, register_task_event, REALM_WAIT_INFINITE, nullptr));
 
   realm_processor_query_t proc_query;
   CHECK_REALM(realm_processor_query_create(runtime, &proc_query));


### PR DESCRIPTION
This eliminates the need for timed_wait as a separate function. Then update the tests to the new API definition