### PR TITLE
Support transfers for layouts with multiple id-indexed fields (PR 2/6)

### DIFF
--- a/src/realm/cuda/cuda_internal.cc
+++ b/src/realm/cuda/cuda_internal.cc
@@ -325,7 +325,7 @@ namespace Realm {
                                      AddressListCursor &in_alc, uintptr_t in_base,
                                      GPU *in_gpu, AddressListCursor &out_alc,
                                      uintptr_t out_base, GPU *out_gpu, size_t bytes_left,
-                                     size_t max_xfer_fields, size_t& fields_total)
+                                     size_t max_xfer_fields, size_t &fields_total)
     {
       AffineCopyPair<3> &copy_info = copy_infos.subrects[copy_infos.num_rects++];
 
@@ -364,6 +364,9 @@ namespace Realm {
         copy_info.dst.fields = out_alc.fields_data(); // dst_field_block->fields;
         fields_total = std::max(fields_total, copy_info.dst.num_fields);
       }
+
+      // std::cout << "src_fields:" << copy_info.src.num_fields << std::endl;
+      // std::cout << "dst_fields:" << copy_info.dst.num_fields << std::endl;
 
       min_align = std::min({min_align, calculate_type_alignment(copy_info.src.addr),
                             calculate_type_alignment(copy_info.dst.addr),
@@ -812,7 +815,7 @@ namespace Realm {
           memset(&transpose_copy, 0, sizeof(transpose_copy));
         }
 
-        //bool needs_fast_multifield = false;
+        // bool needs_fast_multifield = false;
         size_t fields_total = 1;
 
         // 2) Batch loop - Collect all the rectangles for this inport/outport pair by
@@ -972,9 +975,9 @@ namespace Realm {
                             << " bytes=" << copy_info_total
                             << " out_is_ipc=" << out_is_ipc;
           fields_total = std::max<size_t>(1, fields_total);
-          stream->get_gpu()->launch_batch_affine_kernel(
-              &copy_infos, 3, min_align, (copy_info_total / min_align),
-              fields_total, stream);
+          stream->get_gpu()->launch_batch_affine_kernel(&copy_infos, 3, min_align,
+                                                        (copy_info_total / min_align),
+                                                        fields_total, stream);
           bytes_to_fence += copy_info_total;
         } else if(copy_infos.num_rects == 1) {
           // Then the affine copies to/from the device

--- a/src/realm/cuda/cuda_internal.cc
+++ b/src/realm/cuda/cuda_internal.cc
@@ -359,13 +359,13 @@ namespace Realm {
       size_t fields_total = 1;
 
       if(src_field_block) {
-        copy_info.src.num_fields = std::min(MAX_FIELDS, in_alc.fields());
+        copy_info.src.num_fields = std::min(MAX_FIELDS, in_alc.remaining_fields());
         copy_info.src.fields = in_alc.fields_data(); // src_field_block->fields;
         fields_total = std::max(fields_total, copy_info.src.num_fields);
       }
 
       if(dst_field_block) {
-        copy_info.dst.num_fields = std::min(MAX_FIELDS, out_alc.fields());
+        copy_info.dst.num_fields = std::min(MAX_FIELDS, out_alc.remaining_fields());
         copy_info.dst.fields = out_alc.fields_data(); // dst_field_block->fields;
         fields_total = std::max(fields_total, copy_info.dst.num_fields);
       }

--- a/src/realm/cuda/cuda_internal.h
+++ b/src/realm/cuda/cuda_internal.h
@@ -921,7 +921,8 @@ namespace Realm {
       GPU *get_gpu() const { return src_gpu; }
 
       virtual bool supports_fat_transfers(Memory src_mem, Memory dst_mem) const { 
-          return src_mem.kind() == Memory::GPU_FB_MEM && dst_mem.kind() == Memory::GPU_FB_MEM; }
+          return true;}
+          //return src_mem.kind() == Memory::GPU_FB_MEM && dst_mem.kind() == Memory::GPU_FB_MEM; }
 
     private:
       GPU *src_gpu;

--- a/src/realm/cuda/cuda_internal.h
+++ b/src/realm/cuda/cuda_internal.h
@@ -413,8 +413,9 @@ namespace Realm {
 
       void launch_batch_affine_fill_kernel(void *fill_info, size_t dim, size_t elemSize,
                                            size_t volume, GPUStream *stream);
-      void launch_batch_affine_kernel(void *copy_info, size_t dim, size_t elemSize,
-                                      size_t volume, GPUStream *stream);
+      void launch_batch_affine_kernel(void *copy_info, size_t dim,
+                                      size_t elemSize, size_t volume, size_t fields,
+                                      GPUStream *stream);
       void launch_transpose_kernel(MemcpyTransposeInfo<size_t> &copy_info,
                                    size_t elemSize, GPUStream *stream);
 
@@ -464,6 +465,7 @@ namespace Realm {
       GPUFuncInfo indirect_copy_kernels[REALM_MAX_DIM][CUDA_MEMCPY_KERNEL_MAX2_LOG2_BYTES]
                                        [CUDA_MEMCPY_KERNEL_MAX2_LOG2_BYTES];
       GPUFuncInfo batch_affine_kernels[REALM_MAX_DIM][CUDA_MEMCPY_KERNEL_MAX2_LOG2_BYTES];
+      GPUFuncInfo multi_batch_affine_kernels[REALM_MAX_DIM][CUDA_MEMCPY_KERNEL_MAX2_LOG2_BYTES];
       GPUFuncInfo batch_fill_affine_kernels[REALM_MAX_DIM]
                                            [CUDA_MEMCPY_KERNEL_MAX2_LOG2_BYTES];
       GPUFuncInfo fill_affine_large_kernels[REALM_MAX_DIM]

--- a/src/realm/cuda/cuda_internal.h
+++ b/src/realm/cuda/cuda_internal.h
@@ -906,7 +906,7 @@ namespace Realm {
       long submit(Request **requests, long nr);
       GPU *get_gpu() const { return src_gpu; }
 
-      virtual bool supports_fast_fields() const { return true; }
+      virtual bool supports_fat_transfers() const { return true; }
 
     private:
       GPU *src_gpu;

--- a/src/realm/cuda/cuda_memcpy.h
+++ b/src/realm/cuda/cuda_memcpy.h
@@ -31,12 +31,13 @@ namespace Realm {
 
     template <size_t N, typename Offset_t = size_t>
     struct alignas(8) AffineSubRect {
+      using FieldID = int;
       // Extent of the ND array
       Offset_t strides[N - 1];
       // Address of the ND array
       uintptr_t addr;
 
-      size_t *fields;
+      const FieldID *fields;
       size_t num_fields;
     };
 

--- a/src/realm/cuda/cuda_module.cc
+++ b/src/realm/cuda/cuda_module.cc
@@ -1071,6 +1071,7 @@ namespace Realm {
           static_cast<unsigned int>(
               func_info.occ_num_blocks)); // Cap the grid based on the given volume
 
+      //std::cout << "num_blocks:" << num_blocks << " num_threads:" << num_threads << std::endl;
       CHECK_CU(CUDA_DRIVER_FNPTR(cuLaunchKernel)(func_info.func, num_blocks, 1, 1,
                                                  num_threads, 1, 1, 0,
                                                  stream->get_stream(), args, nullptr));

--- a/src/realm/cuda/cuda_module.cc
+++ b/src/realm/cuda/cuda_module.cc
@@ -1071,8 +1071,6 @@ namespace Realm {
           static_cast<unsigned int>(
               func_info.occ_num_blocks)); // Cap the grid based on the given volume
 
-      // TODO: block per field
-      // num_blocks = 2000;
       CHECK_CU(CUDA_DRIVER_FNPTR(cuLaunchKernel)(func_info.func, num_blocks, 1, 1,
                                                  num_threads, 1, 1, 0,
                                                  stream->get_stream(), args, nullptr));

--- a/src/realm/cuda/cuda_module.cc
+++ b/src/realm/cuda/cuda_module.cc
@@ -1071,7 +1071,8 @@ namespace Realm {
           static_cast<unsigned int>(
               func_info.occ_num_blocks)); // Cap the grid based on the given volume
 
-      //num_blocks = 2000;
+      // TODO: block per field
+      // num_blocks = 2000;
       CHECK_CU(CUDA_DRIVER_FNPTR(cuLaunchKernel)(func_info.func, num_blocks, 1, 1,
                                                  num_threads, 1, 1, 0,
                                                  stream->get_stream(), args, nullptr));

--- a/src/realm/inst_layout.h
+++ b/src/realm/inst_layout.h
@@ -226,7 +226,7 @@ namespace Realm {
 
     using FieldMap = std::map<FieldID, FieldLayout>;
     FieldMap fields;
-    bool uniform_mutlifield_layout{false};
+    bool idindexed_fields{false};
   };
 
   REALM_PUBLIC_API

--- a/src/realm/inst_layout.inl
+++ b/src/realm/inst_layout.inl
@@ -139,7 +139,7 @@ namespace Realm {
     std::map<std::pair<size_t, size_t>, size_t> pl_indexes, pl_starts, pl_sizes;
 
     size_t field_stride = 0;
-    layout->uniform_mutlifield_layout = true;
+    layout->idindexed_fields = true;
 
     // reserve space so that we don't have to copy piece lists as we grow
     layout->piece_lists.reserve(ilc.field_groups.size());
@@ -250,7 +250,7 @@ namespace Realm {
         // should not have seen this field before
         assert(layout->fields.count(it2->first) == 0);
 
-        layout->uniform_mutlifield_layout &=
+        layout->idindexed_fields &=
             (static_cast<size_t>(it2->first * field_stride) == reuse_offset);
 
         InstanceLayoutGeneric::FieldLayout &fl = layout->fields[it2->first];

--- a/src/realm/transfer/address_list.cc
+++ b/src/realm/transfer/address_list.cc
@@ -54,6 +54,29 @@ namespace Realm {
     data.reserve(max_entries);
   }
 
+  bool AddressList::append_entry(
+      int dims, size_t contig_bytes, size_t total_bytes, size_t base_offset,
+      const std::unordered_map<int, std::pair<size_t, size_t>> &count_strides,
+      bool wrap_around)
+  {
+    size_t *entry = begin_entry(dims, wrap_around);
+
+    if(entry == nullptr) {
+      return false;
+    }
+
+    entry[AddressList::SLOT_BASE] = base_offset;
+
+    for(auto &[dim, count_stride] : count_strides) {
+      entry[detail::count_index(dim)] = count_stride.first;
+      entry[detail::stride_index(dim)] = count_stride.second;
+    }
+
+    entry[AddressList::SLOT_HEADER] = pack_entry_header(contig_bytes, dims);
+    commit_entry(dims, total_bytes);
+    return true;
+  }
+
   size_t *AddressList::begin_entry(int max_dim, bool wrap_mode)
   {
     size_t entries_needed = detail::count_index(max_dim);

--- a/src/realm/transfer/address_list.cc
+++ b/src/realm/transfer/address_list.cc
@@ -33,6 +33,7 @@ namespace Realm {
     {
       return ((e[AddressList::SLOT_HEADER] >> AddressList::CONTIG_SHIFT));
     }
+
     inline int actdim(const size_t *e)
     {
       return int(e[AddressList::SLOT_HEADER] & AddressList::DIM_MASK);

--- a/src/realm/transfer/address_list.cc
+++ b/src/realm/transfer/address_list.cc
@@ -119,6 +119,11 @@ namespace Realm {
     total_bytes += bytes * (field_block ? field_block->count : 1);
   }
 
+  void AddressList::attach_field_block(const FieldBlock *_field_block)
+  {
+    field_block = _field_block;
+  }
+
   size_t AddressList::bytes_pending() const { return total_bytes; }
 
   size_t AddressList::pack_entry_header(size_t contig_bytes, int dims)
@@ -330,6 +335,24 @@ namespace Realm {
         }
       }
     }
+  }
+
+  const FieldBlock *AddressListCursor::field_block() const
+  {
+    return addrlist->field_block;
+  }
+
+  const FieldID *AddressListCursor::fields_data() const
+  {
+    return addrlist->field_block->fields + partial_fields;
+  }
+
+  size_t AddressListCursor::remaining_fields() const
+  {
+    if(addrlist->field_block) {
+      return addrlist->field_block->count - partial_fields;
+    }
+    return 1;
   }
 
   std::ostream &operator<<(std::ostream &os, const AddressListCursor &alc)

--- a/src/realm/transfer/address_list.cc
+++ b/src/realm/transfer/address_list.cc
@@ -37,10 +37,9 @@ namespace Realm {
     data.reserve(max_entries);
   }
 
-  size_t *AddressList::being_entry(int max_dim, size_t payload_size, bool wrap_mode)
+  size_t *AddressList::begin_entry(int max_dim, bool wrap_mode)
   {
-    size_t entries_needed =
-        DIM_SLOTS * max_dim + (payload_size > 0 ? payload_size + 1 : 0);
+    size_t entries_needed = DIM_SLOTS * max_dim;
 
     if(wrap_mode) {
       size_t new_wp = write_pointer + entries_needed;
@@ -73,27 +72,14 @@ namespace Realm {
     }
   }
 
-  void AddressList::commit_entry(int act_dim, size_t bytes, size_t payload_size)
+  void AddressList::commit_entry(int act_dim, size_t bytes)
   {
     size_t entries_used = act_dim * DIM_SLOTS;
-
-    if(payload_size > 0) {
-      data[write_pointer + entries_used] = payload_size;
-      entries_used += 1;
-    }
-
-    entries_used += payload_size;
-    data[write_pointer] |= (payload_size > 0 ? HAS_EXTRA : 0);
-
     write_pointer += entries_used;
-
     total_bytes += bytes * (field_block ? field_block->count : 1);
   }
 
-  size_t AddressList::bytes_pending() const
-  {
-    return total_bytes;
-  }
+  size_t AddressList::bytes_pending() const { return total_bytes; }
 
   size_t AddressList::pack_entry_header(size_t contig_bytes, int dims)
   {
@@ -142,17 +128,15 @@ namespace Realm {
     if(partial) {
       return (partial_dim + 1);
     } else {
-      const size_t *entry = addrlist->read_entry();
-      int act_dim = (entry[0] & AddressList::DIM_MASK);
-      return act_dim;
+      return detail::actdim(addrlist->read_entry());
     }
   }
 
   uintptr_t AddressListCursor::get_offset() const
   {
     const size_t *entry = addrlist->read_entry();
-    int act_dim = (entry[0] & AddressList::DIM_MASK);
-    uintptr_t ofs = entry[1];
+    int act_dim = detail::actdim(entry);
+    uintptr_t ofs = entry[AddressList::SLOT_BASE];
     if(partial) {
       for(int i = partial_dim; i < act_dim; i++)
         if(i == 0) {
@@ -169,20 +153,9 @@ namespace Realm {
   uintptr_t AddressListCursor::get_stride(int dim) const
   {
     const size_t *entry = addrlist->read_entry();
-    int act_dim = (entry[0] & AddressList::DIM_MASK);
+    int act_dim = detail::actdim(entry);
     assert((dim > 0) && (dim < act_dim));
     return entry[AddressList::DIM_SLOTS * dim + 1];
-  }
-
-  const size_t *AddressListCursor::get_payload(size_t &count)
-  {
-    const size_t *entry = addrlist->read_entry();
-    int act_dim = (entry[0] & AddressList::DIM_MASK);
-    if(entry[0] & AddressList::HAS_EXTRA) {
-      count = entry[act_dim * AddressList::DIM_SLOTS];
-      return entry + act_dim * AddressList::DIM_SLOTS + 1;
-    }
-    return nullptr;
   }
 
   size_t AddressListCursor::remaining(int dim) const
@@ -193,7 +166,6 @@ namespace Realm {
     size_t r = entry[AddressList::DIM_SLOTS * dim];
 
     if(dim == 0) {
-      r &= ~AddressList::HAS_EXTRA;
       r >>= AddressList::CONTIG_SHIFT;
     }
 
@@ -208,94 +180,15 @@ namespace Realm {
     return r;
   }
 
-  /*void AddressListCursor::advance(int dim, size_t amount, int f)
-  {
-    const size_t *entry = addrlist->read_entry();
-    int act_dim = (entry[0] & AddressList::DIM_MASK);
-    assert(dim < act_dim);
-    size_t r = entry[AddressList::DIM_SLOTS * dim];
-
-    if(dim == 0) {
-      r &= ~AddressList::HAS_EXTRA;
-      r >>= AddressList::CONTIG_SHIFT;
-    }
-
-    size_t bytes = amount;
-    if(dim > 0) {
-#ifdef DEBUG_REALM
-      for(int i = 0; i < dim; i++)
-        assert(pos[i] == 0);
-#endif
-      bytes *= (entry[0] >> AddressList::CONTIG_SHIFT);
-      for(int i = 1; i < dim; i++)
-        bytes *= entry[AddressList::DIM_SLOTS * i];
-    }
-
-#ifdef DEBUG_REALM
-    assert(addrlist->total_bytes >= bytes * f);
-#endif
-    addrlist->total_bytes -= bytes * f;
-
-    const FieldBlock *fields = field_block();
-    if(fields && partial_dim == 0 && f > 0) {
-      partial_fields += f;
-    }
-
-    bool fields_complete = (!fields || (partial_fields == fields->count));
-
-    if(!partial) {
-      if((dim == (act_dim - 1)) && (amount == r) && fields_complete) {
-        partial_fields = 0;
-        // simple case - we consumed the whole thing
-        addrlist->read_pointer += AddressList::DIM_SLOTS * act_dim;
-        return;
-      } else {
-        // record partial consumption
-        partial = true;
-        partial_dim = dim;
-        pos[partial_dim] = amount;
-      }
-    } else {
-      // update a partial consumption in progress
-      assert(dim <= partial_dim);
-      partial_dim = dim;
-      pos[partial_dim] += amount;
-    }
-
-    while(pos[partial_dim] == r) {
-      pos[partial_dim++] = 0;
-
-      if(partial_dim == act_dim) {
-        partial = false;
-
-        if(fields_complete) {
-          partial_fields = 0;
-          // all done
-          addrlist->read_pointer += AddressList::DIM_SLOTS * act_dim;
-        } else {
-          partial_dim = 0;
-          pos.fill(0);
-        }
-
-        break;
-      } else {
-        pos[partial_dim]++; // carry into next dimension
-        r = entry[AddressList::DIM_SLOTS *
-                  partial_dim]; // no shift because partial_dim > 0
-      }
-    }
-  }*/
-
   void AddressListCursor::advance(int dim, size_t amount, int f)
   {
     const size_t *entry = addrlist->read_entry();
-    int act_dim = (entry[0] & AddressList::DIM_MASK);
+    int act_dim = detail::actdim(entry); // entry[0] & AddressList::DIM_MASK);
     assert(dim < act_dim);
 
     // size of this “slice” in dim
     size_t r = entry[AddressList::DIM_SLOTS * dim];
     if(dim == 0) {
-      r &= ~AddressList::HAS_EXTRA;
       r >>= AddressList::CONTIG_SHIFT;
     }
 
@@ -306,7 +199,7 @@ namespace Realm {
       for(int i = 0; i < dim; i++)
         assert(pos[i] == 0);
 #endif
-      bytes *= (entry[0] >> AddressList::CONTIG_SHIFT);
+      bytes *= detail::contig_bytes(entry);
       for(int i = 1; i < dim; i++)
         bytes *= entry[AddressList::DIM_SLOTS * i];
     }

--- a/src/realm/transfer/address_list.cc
+++ b/src/realm/transfer/address_list.cc
@@ -98,7 +98,7 @@ namespace Realm {
 
   const size_t *AddressList::read_entry()
   {
-    assert(total_bytes > 0);
+    // assert(total_bytes > 0);
     if(read_pointer >= max_entries) {
       assert(read_pointer == max_entries);
       read_pointer = 0;
@@ -174,8 +174,12 @@ namespace Realm {
     int act_dim = (entry[0] & AddressList::ADDRLIST_DIM_MASK);
     assert(dim < act_dim);
     size_t r = entry[AddressList::ADDRLIST_DIM_SLOTS * dim];
-    if(dim == 0)
+
+    if(dim == 0) {
+      r &= ~AddressList::ADDRLIST_HAS_EXTRA;
       r >>= AddressList::ADDRLIST_CONTIG_SHIFT;
+    }
+
     if(partial) {
       if(dim > partial_dim)
         r = 1;
@@ -193,8 +197,11 @@ namespace Realm {
     int act_dim = (entry[0] & AddressList::ADDRLIST_DIM_MASK);
     assert(dim < act_dim);
     size_t r = entry[AddressList::ADDRLIST_DIM_SLOTS * dim];
-    if(dim == 0)
+
+    if(dim == 0) {
+      r &= ~AddressList::ADDRLIST_HAS_EXTRA;
       r >>= AddressList::ADDRLIST_CONTIG_SHIFT;
+    }
 
     size_t bytes = amount;
     if(dim > 0) {

--- a/src/realm/transfer/address_list.h
+++ b/src/realm/transfer/address_list.h
@@ -36,10 +36,10 @@ namespace Realm {
     {
       const std::size_t bytes = sizeof(FieldBlock) + (n - 1) * sizeof(FieldID);
       void *mem = heap.alloc_obj(bytes, align);
-      auto *fb = new(mem) FieldBlock;
-      fb->count = n;
-      std::copy_n(src, n, fb->fields);
-      return fb;
+      FieldBlock *field_block = new(mem) FieldBlock;
+      field_block->count = n;
+      std::copy_n(src, n, field_block->fields);
+      return field_block;
     }
   };
 
@@ -56,7 +56,7 @@ namespace Realm {
                  const std::unordered_map<int, std::pair<size_t, size_t>> &count_strides,
                  bool wrap_around = false);
 
-    [[nodiscard]] size_t *begin_entry(int max_dim, bool wrap_mode = true);
+    [[nodiscard]] size_t *begin_entry(int max_dim, bool wrap_around = true);
     void commit_entry(int act_dim, size_t bytes);
     void attach_field_block(const FieldBlock *_field_block);
 

--- a/src/realm/transfer/address_list.h
+++ b/src/realm/transfer/address_list.h
@@ -105,7 +105,7 @@ namespace Realm {
       return addrlist->field_block->fields + partial_fields;
     }
 
-    size_t fields() const
+    size_t remaining_fields() const
     {
       if(addrlist->field_block) {
         return addrlist->field_block->count - partial_fields;

--- a/src/realm/transfer/address_list.h
+++ b/src/realm/transfer/address_list.h
@@ -22,6 +22,9 @@
 #include "realm/indexspace.h"
 #include "realm/id.h"
 
+#include <array>
+#include <unordered_map>
+
 namespace Realm {
 
   struct FieldBlock {

--- a/src/realm/transfer/address_list.h
+++ b/src/realm/transfer/address_list.h
@@ -51,6 +51,11 @@ namespace Realm {
     AddressList(size_t _max_entries = 1000);
 
     // ─── entry construction ──────────────────────────────────────────────────────
+    bool
+    append_entry(int dims, size_t contig_bytes, size_t total_bytes, size_t base_offset,
+                 const std::unordered_map<int, std::pair<size_t, size_t>> &count_strides,
+                 bool wrap_around = false);
+
     size_t *begin_entry(int max_dim, bool wrap_mode = true);
     void commit_entry(int act_dim, size_t bytes);
 

--- a/src/realm/transfer/address_list.h
+++ b/src/realm/transfer/address_list.h
@@ -51,21 +51,21 @@ namespace Realm {
     AddressList(size_t _max_entries = 1000);
 
     // ─── entry construction ──────────────────────────────────────────────────────
-    bool
+    [[nodiscard]] bool
     append_entry(int dims, size_t contig_bytes, size_t total_bytes, size_t base_offset,
                  const std::unordered_map<int, std::pair<size_t, size_t>> &count_strides,
                  bool wrap_around = false);
 
-    size_t *begin_entry(int max_dim, bool wrap_mode = true);
+    [[nodiscard]] size_t *begin_entry(int max_dim, bool wrap_mode = true);
     void commit_entry(int act_dim, size_t bytes);
+    void attach_field_block(const FieldBlock *_field_block);
 
-    size_t bytes_pending() const;
-    void set_field_block(const FieldBlock *_field_block) { field_block = _field_block; }
+    [[nodiscard]] size_t bytes_pending() const;
 
     // entry packs:
     // the contiguous byte count (contig_bytes) in the upper bitsthe
     // the actual dimension count (act_dim) in the lower 4 bits
-    static size_t pack_entry_header(size_t contig_bytes, int dims);
+    [[nodiscard]] static size_t pack_entry_header(size_t contig_bytes, int dims);
 
     // ─── layout constants ───────────────────────────────────────────────────────
     static constexpr size_t SLOT_HEADER = 0;
@@ -76,7 +76,7 @@ namespace Realm {
 
   protected:
     friend class AddressListCursor;
-    const size_t *read_entry();
+    [[nodiscard]] const size_t *read_entry();
 
     const FieldBlock *field_block{nullptr};
 
@@ -96,27 +96,20 @@ namespace Realm {
 
     void set_addrlist(AddressList *_addrlist);
 
-    int get_dim() const;
-    uintptr_t get_offset() const;
-    uintptr_t get_stride(int dim) const;
-    size_t remaining(int dim) const;
-    void advance(int dim, size_t amount, int f = 1);
+    // ─── layout accessors ──────────────────────────────────────────────────────
+    [[nodiscard]] int get_dim() const;
+    [[nodiscard]] uintptr_t get_offset() const;
+    [[nodiscard]] uintptr_t get_stride(int dim) const;
+    [[nodiscard]] size_t remaining(int dim) const;
 
+    // ─── progress───────────────────────────────────────────────────────────────
+    void advance(int dim, size_t amount, int f = 1);
     void skip_bytes(size_t bytes);
 
-    const FieldBlock *field_block() const { return addrlist->field_block; }
-    const FieldID *fields_data() const
-    {
-      return addrlist->field_block->fields + partial_fields;
-    }
-
-    size_t remaining_fields() const
-    {
-      if(addrlist->field_block) {
-        return addrlist->field_block->count - partial_fields;
-      }
-      return 1;
-    }
+    // ─── field accessors ──────────────────────────────────────────────────────
+    [[nodiscard]] const FieldBlock *field_block() const;
+    [[nodiscard]] const FieldID *fields_data() const;
+    [[nodiscard]] size_t remaining_fields() const;
 
   protected:
     AddressList *addrlist{nullptr};

--- a/src/realm/transfer/address_list.h
+++ b/src/realm/transfer/address_list.h
@@ -24,6 +24,25 @@
 
 namespace Realm {
 
+  struct FieldBlock {
+    using FieldID = int;
+    std::size_t count;
+    FieldID fields[1];
+
+    // allocate a FieldBlock via heap.alloc_obj and store n field IDs
+    template <typename Heap>
+    static FieldBlock *create(Heap &heap, const FieldID *src, std::size_t n,
+                              std::size_t align = 16)
+    {
+      const std::size_t bytes = sizeof(FieldBlock) + (n - 1) * sizeof(FieldID);
+      void *mem = heap.alloc_obj(bytes, align);
+      auto *fb = new(mem) FieldBlock;
+      fb->count = n;
+      std::copy_n(src, n, fb->fields);
+      return fb;
+    }
+  };
+
   class AddressList {
   public:
     AddressList(size_t _max_entries = 1000);
@@ -32,21 +51,24 @@ namespace Realm {
     void commit_entry(int act_dim, size_t bytes, size_t payload_size = 0);
 
     size_t bytes_pending() const;
+    void set_field_block(const FieldBlock *_field_block) { field_block = _field_block; }
 
     // entry packs:
     // the contiguous byte count (contig_bytes) in the upper bitsthe
     // the actual dimension count (act_dim) in the lower 4 bits
     static size_t pack_entry_header(size_t contig_bytes, int dims);
 
-    constexpr static size_t ADDRLIST_DIM_SLOTS = 2;
+    constexpr static size_t SLOT_HEADER = 0;
+    constexpr static size_t DIM_SLOTS = 2;
+    constexpr static size_t HAS_EXTRA = (1UL << (sizeof(size_t) * 8 - 1));
+    constexpr static size_t DIM_MASK = 0xF;
+    constexpr static size_t CONTIG_SHIFT = 4;
 
   protected:
-    constexpr static size_t ADDRLIST_HAS_EXTRA = (1UL << (sizeof(size_t) * 8 - 1));
-    constexpr static size_t ADDRLIST_DIM_MASK = 0xF;
-    constexpr static size_t ADDRLIST_CONTIG_SHIFT = 4;
-
     friend class AddressListCursor;
     const size_t *read_entry();
+
+    const FieldBlock *field_block{nullptr};
 
     size_t total_bytes{0};
     size_t write_pointer{0};
@@ -65,10 +87,24 @@ namespace Realm {
     uintptr_t get_offset() const;
     uintptr_t get_stride(int dim) const;
     size_t remaining(int dim) const;
-    void advance(int dim, size_t amount);
+    void advance(int dim, size_t amount, int f = 1);
 
     void skip_bytes(size_t bytes);
     const size_t *get_payload(size_t &count);
+
+    const FieldBlock *field_block() const { return addrlist->field_block; }
+    const FieldID *fields_data() const
+    {
+      return addrlist->field_block->fields + partial_fields;
+    }
+
+    size_t fields() const
+    {
+      if(addrlist->field_block) {
+        return addrlist->field_block->count - partial_fields;
+      }
+      return 1;
+    }
 
   protected:
     AddressList *addrlist{nullptr};
@@ -77,6 +113,7 @@ namespace Realm {
     //  we use the contiguous bytes within a field as a "dimension" in some
     //  cases
     int partial_dim{0};
+    int partial_fields{0};
     std::array<size_t, REALM_MAX_DIM + 1> pos{};
   };
 

--- a/src/realm/transfer/channel.h
+++ b/src/realm/transfer/channel.h
@@ -731,7 +731,7 @@ namespace Realm {
     XferDesKind kind;
 
       virtual bool supports_redop(ReductionOpID redop_id) const;
-      virtual bool supports_fast_fields() const { return false; };
+      virtual bool supports_fat_transfers() const { return false; };
 
     // attempt to make progress on the specified xferdes
     virtual long progress_xd(XferDes *xd, long max_nr);

--- a/src/realm/transfer/channel.h
+++ b/src/realm/transfer/channel.h
@@ -731,7 +731,7 @@ namespace Realm {
     XferDesKind kind;
 
       virtual bool supports_redop(ReductionOpID redop_id) const;
-      virtual bool supports_fat_transfers() const { return false; };
+      virtual bool supports_fat_transfers(Memory src_mem, Memory dst_mem) const { return false; };
 
     // attempt to make progress on the specified xferdes
     virtual long progress_xd(XferDes *xd, long max_nr);

--- a/src/realm/transfer/lowlevel_dma.cc
+++ b/src/realm/transfer/lowlevel_dma.cc
@@ -857,7 +857,7 @@ namespace Realm {
     //  the same location twice)
     size_t lines = std::max<size_t>((1 << 30) / size, 1);
     int dim = (lines > 1) ? 2 : 1;
-    size_t *data = addrlist.being_entry(dim);
+    size_t *data = addrlist.begin_entry(dim);
     if(!data)
       return true; // can't add more until some is consumed
 

--- a/src/realm/transfer/transfer.cc
+++ b/src/realm/transfer/transfer.cc
@@ -957,7 +957,7 @@ namespace Realm {
     nonaffine = 0;
 
     if(rect_idx == 0) {
-      addrlist.set_field_block(field_block);
+      addrlist.attach_field_block(field_block);
     }
 
     while(!this->done()) {

--- a/src/realm/transfer/transfer.cc
+++ b/src/realm/transfer/transfer.cc
@@ -2246,12 +2246,12 @@ namespace Realm {
       const std::vector<size_t> &fld_sizes, Channel *channel) const
   {
     assert(dim_order.size() == N);
+    constexpr int MIN_UNIFORM_FIELDS = 2;
     RegionInstanceImpl *impl = get_runtime()->get_instance_impl(inst);
     const InstanceLayout<N, T> *inst_layout =
         checked_cast<const InstanceLayout<N, T> *>(impl->metadata.layout);
     if(inst_layout->uniform_mutlifield_layout && channel &&
-       channel->supports_fat_transfers()) {
-      // if(channel && channel->supports_fat_transfers()) {
+       channel->supports_fat_transfers() && fields.size() >= MIN_UNIFORM_FIELDS) {
       return new TransferIteratorUniformFields<N, T>(dim_order.data(), fields,
                                                      fld_sizes.front(), impl, is);
     } else {

--- a/src/realm/transfer/transfer.cc
+++ b/src/realm/transfer/transfer.cc
@@ -993,9 +993,12 @@ namespace Realm {
       assert(total_bytes > 0);
       assert(contig_bytes > 0);
 
-      size_t *entry = addrlist.begin_entry(N, /*wrap_mode=*/false);
+      bool commited = addrlist.append_entry(ndims, contig_bytes, total_bytes, base_offset,
+                                            count_strides);
+      assert(commited);
 
-      assert(entry);
+      // size_t *entry = addrlist.begin_entry(N, /*wrap_mode=*/false);
+      /*assert(entry);
       entry[AddressList::SLOT_BASE] = base_offset;
       for(auto &[dim, count_stride] : count_strides) {
         entry[dim * AddressList::DIM_SLOTS] = count_stride.first;
@@ -1004,7 +1007,7 @@ namespace Realm {
 
       entry[AddressList::SLOT_HEADER] =
           AddressList::pack_entry_header(contig_bytes, ndims);
-      addrlist.commit_entry(ndims, total_bytes);
+      addrlist.commit_entry(ndims, total_bytes);*/
     }
 
     return true;

--- a/src/realm/transfer/transfer.cc
+++ b/src/realm/transfer/transfer.cc
@@ -975,9 +975,6 @@ namespace Realm {
       const AffineLayoutPiece<N, T> *affine =
           static_cast<const AffineLayoutPiece<N, T> *>(layout_piece);
 
-      std::cout << "INST_OFFSET:" << this->inst_impl->metadata.inst_offset
-                << " affine:" << affine->offset << std::endl;
-
       assert(this->inst_impl->metadata.is_valid());
       size_t base_offset = this->inst_impl->metadata.inst_offset + affine->offset +
                            affine->strides.dot(target_subrect.lo); //+ field_rel_offset;
@@ -2266,7 +2263,7 @@ namespace Realm {
     const InstanceLayout<N, T> *inst_layout =
         checked_cast<const InstanceLayout<N, T> *>(impl->metadata.layout);
     if(uniform_fields && inst_layout->uniform_mutlifield_layout &&
-       fields.size() >= MIN_UNIFORM_FIELDS || 1 == 1) {
+       fields.size() >= MIN_UNIFORM_FIELDS) {
       return new TransferIteratorUniformFields<N, T>(
           dim_order.data(), fields, fld_sizes.front(), impl, is,
           FieldBlock::create(get_runtime()->repl_heap, fields.data(), fields.size()));

--- a/src/realm/transfer/transfer.cc
+++ b/src/realm/transfer/transfer.cc
@@ -819,11 +819,11 @@ namespace Realm {
 
   ////////////////////////////////////////////////////////////////////////
   //
-  // class UniformFieldsTransferIterator<N,T>
+  // class TransferIteratorUniformFields<N,T>
   //
 
   template <int N, typename T>
-  UniformFieldsTransferIterator<N, T>::UniformFieldsTransferIterator(
+  TransferIteratorUniformFields<N, T>::TransferIteratorUniformFields(
       const int _dim_order[N], const std::vector<FieldID> &_fields, size_t _field_size,
       RegionInstanceImpl *_inst_impl, const IndexSpace<N, T> &_is)
     : TransferIteratorBase<N, T>(_inst_impl, _dim_order)
@@ -843,7 +843,7 @@ namespace Realm {
   }
 
   template <int N, typename T>
-  void UniformFieldsTransferIterator<N, T>::prefill(void)
+  void TransferIteratorUniformFields<N, T>::prefill(void)
   {
     assert(!fields.empty());
     const InstanceLayout<N, T> *inst_layout =
@@ -854,7 +854,7 @@ namespace Realm {
   }
 
   /*template <int N, typename T>
-  UniformFieldsTransferIterator<N, T>::UniformFieldsTransferIterator(
+  TransferIteratorUniformFields<N, T>::TransferIteratorUniformFields(
       const int _dim_order[N], const std::vector<FieldID> &_fields,
       const std::vector<size_t> &_fld_offsets, const std::vector<size_t> &_fld_sizes,
       RegionInstanceImpl *_inst_impl, const Rect<N, T> &_bounds,
@@ -873,13 +873,13 @@ namespace Realm {
   }*/
 
   template <int N, typename T>
-  UniformFieldsTransferIterator<N, T>::UniformFieldsTransferIterator(void)
+  TransferIteratorUniformFields<N, T>::TransferIteratorUniformFields(void)
   {}
 
   template <int N, typename T>
   template <typename S>
   /*static*/ TransferIterator *
-  UniformFieldsTransferIterator<N, T>::deserialize_new(S &deserializer)
+  TransferIteratorUniformFields<N, T>::deserialize_new(S &deserializer)
   {
     IndexSpace<N, T> is;
     RegionInstance inst;
@@ -898,17 +898,17 @@ namespace Realm {
       }
     }
 
-    UniformFieldsTransferIterator<N, T> *tiis = new UniformFieldsTransferIterator<N, T>(
+    TransferIteratorUniformFields<N, T> *tiis = new TransferIteratorUniformFields<N, T>(
         dim_order, fields, field_size, get_runtime()->get_instance_impl(inst), is);
     return tiis;
   }
 
   template <int N, typename T>
-  UniformFieldsTransferIterator<N, T>::~UniformFieldsTransferIterator(void)
+  TransferIteratorUniformFields<N, T>::~TransferIteratorUniformFields(void)
   {}
 
   template <int N, typename T>
-  Event UniformFieldsTransferIterator<N, T>::request_metadata(void)
+  Event TransferIteratorUniformFields<N, T>::request_metadata(void)
   {
     Event e = TransferIteratorBase<N, T>::request_metadata();
 
@@ -920,7 +920,7 @@ namespace Realm {
   }
 
   template <int N, typename T>
-  void UniformFieldsTransferIterator<N, T>::reset(void)
+  void TransferIteratorUniformFields<N, T>::reset(void)
   {
     TransferIteratorBase<N, T>::reset();
     field_idx = 0;
@@ -928,7 +928,7 @@ namespace Realm {
   }
 
   template <int N, typename T>
-  void UniformFieldsTransferIterator<N, T>::reset_internal(void)
+  void TransferIteratorUniformFields<N, T>::reset_internal(void)
   {
     // assert(!iter_init_deferred);
     if(!sparsity_impl) {
@@ -943,7 +943,7 @@ namespace Realm {
   }
 
   template <int N, typename T>
-  bool UniformFieldsTransferIterator<N, T>::get_addresses(
+  bool TransferIteratorUniformFields<N, T>::get_addresses(
       AddressList &addrlist, const InstanceLayoutPieceBase *&nonaffine)
   {
     nonaffine = 0;
@@ -999,7 +999,7 @@ namespace Realm {
   }
 
   template <int N, typename T>
-  bool UniformFieldsTransferIterator<N, T>::get_next_rect(Rect<N, T> &r, FieldID &fid,
+  bool TransferIteratorUniformFields<N, T>::get_next_rect(Rect<N, T> &r, FieldID &fid,
                                                           size_t &offset, size_t &fsize)
   {
     if(iter_init_deferred) {
@@ -1026,12 +1026,12 @@ namespace Realm {
 
   template <int N, typename T>
   /*static*/ Serialization::PolymorphicSerdezSubclass<TransferIterator,
-                                                      UniformFieldsTransferIterator<N, T>>
-      UniformFieldsTransferIterator<N, T>::serdez_subclass;
+                                                      TransferIteratorUniformFields<N, T>>
+      TransferIteratorUniformFields<N, T>::serdez_subclass;
 
   template <int N, typename T>
   template <typename S>
-  bool UniformFieldsTransferIterator<N, T>::serialize(S &serializer) const
+  bool TransferIteratorUniformFields<N, T>::serialize(S &serializer) const
   {
     if(!((serializer << iter.space) && (serializer << this->inst_impl->me) &&
          (serializer << fields) && (serializer << field_size))) {
@@ -2250,9 +2250,9 @@ namespace Realm {
     const InstanceLayout<N, T> *inst_layout =
         checked_cast<const InstanceLayout<N, T> *>(impl->metadata.layout);
     if(inst_layout->uniform_mutlifield_layout && channel &&
-       channel->supports_fast_fields()) {
-      // if(channel && channel->supports_fast_fields()) {
-      return new UniformFieldsTransferIterator<N, T>(dim_order.data(), fields,
+       channel->supports_fat_transfers()) {
+      // if(channel && channel->supports_fat_transfers()) {
+      return new TransferIteratorUniformFields<N, T>(dim_order.data(), fields,
                                                      fld_sizes.front(), impl, is);
     } else {
       return new TransferIteratorIndexSpace<N, T>(dim_order.data(), fields, fld_offsets,
@@ -5297,7 +5297,7 @@ namespace Realm {
       const ProfilingRequestSet &, Event, int) const;                                    \
   template class TransferIteratorIndexSpace<N, T>;                                       \
   template class TransferIteratorIndirect<N, T>;                                         \
-  template class UniformFieldsTransferIterator<N, T>;                                    \
+  template class TransferIteratorUniformFields<N, T>;                                    \
   template class WrappingTransferIteratorIndirect<N, T>;                                 \
   template class TransferIteratorIndirectRange<N, T>;                                    \
   template class AddressSplitXferDesFactory<N, T>;                                       \

--- a/src/realm/transfer/transfer.cc
+++ b/src/realm/transfer/transfer.cc
@@ -988,13 +988,14 @@ namespace Realm {
       size_t *entry = addrlist.begin_entry(N, /*wrap_mode=*/false);
 
       assert(entry);
-      entry[1] = base_offset;
+      entry[AddressList::SLOT_BASE] = base_offset;
       for(auto &[dim, count_stride] : count_strides) {
         entry[dim * AddressList::DIM_SLOTS] = count_stride.first;
         entry[dim * AddressList::DIM_SLOTS + 1] = count_stride.second;
       }
 
-      entry[0] = AddressList::pack_entry_header(contig_bytes, ndims);
+      entry[AddressList::SLOT_HEADER] =
+          AddressList::pack_entry_header(contig_bytes, ndims);
       addrlist.commit_entry(ndims, total_bytes);
     }
 

--- a/src/realm/transfer/transfer.cc
+++ b/src/realm/transfer/transfer.cc
@@ -523,7 +523,7 @@ namespace Realm {
 
       // we may be able to compact dimensions, but ask for space to write a
       //  an address record of the maximum possible dimension (i.e. N)
-      size_t *addr_data = addrlist.being_entry(N);
+      size_t *addr_data = addrlist.begin_entry(N);
       if(!addr_data) {
         return true; // out of space for now
       }
@@ -985,9 +985,7 @@ namespace Realm {
       assert(total_bytes != 0);
       assert(contig_bytes != 0);
 
-      //size_t *entry = addrlist.being_entry(N, fields.size(), /*wrap_mode=*/false);
-
-      size_t *entry = addrlist.being_entry(N, 0, /*wrap_mode=*/false);
+      size_t *entry = addrlist.begin_entry(N, /*wrap_mode=*/false);
 
       assert(entry);
       entry[1] = base_offset;
@@ -995,12 +993,9 @@ namespace Realm {
         entry[dim * AddressList::DIM_SLOTS] = count_stride.first;
         entry[dim * AddressList::DIM_SLOTS + 1] = count_stride.second;
       }
-      //entry[ndims * AddressList::DIM_SLOTS] = fields.size();
-      //std::copy(fields.begin(), fields.end(),
-                //entry + AddressList::DIM_SLOTS * ndims + 1);
 
       entry[0] = AddressList::pack_entry_header(contig_bytes, ndims);
-      addrlist.commit_entry(ndims, total_bytes);///, fields.size());
+      addrlist.commit_entry(ndims, total_bytes);
     }
 
     return true;
@@ -1261,7 +1256,7 @@ namespace Realm {
         return false;
       }
 
-      size_t *addr_data = addrlist.being_entry(1);
+      size_t *addr_data = addrlist.begin_entry(1);
       if(!addr_data) {
         return true;
       }

--- a/src/realm/transfer/transfer.cc
+++ b/src/realm/transfer/transfer.cc
@@ -975,7 +975,7 @@ namespace Realm {
       const AffineLayoutPiece<N, T> *affine =
           static_cast<const AffineLayoutPiece<N, T> *>(layout_piece);
 
-      assert(this->inst_impl->metadata.is_valid());
+      //assert(this->inst_impl->metadata.is_valid());
       size_t base_offset = this->inst_impl->metadata.inst_offset + affine->offset +
                            affine->strides.dot(target_subrect.lo); //+ field_rel_offset;
 

--- a/src/realm/transfer/transfer.cc
+++ b/src/realm/transfer/transfer.cc
@@ -819,11 +819,11 @@ namespace Realm {
 
   ////////////////////////////////////////////////////////////////////////
   //
-  // class TransferIteratorUniformFields<N,T>
+  // class IDIndexedFieldsIterator<N,T>
   //
 
   template <int N, typename T>
-  TransferIteratorUniformFields<N, T>::TransferIteratorUniformFields(
+  IDIndexedFieldsIterator<N, T>::IDIndexedFieldsIterator(
       const int _dim_order[N], const std::vector<FieldID> &_fields, size_t _field_size,
       RegionInstanceImpl *_inst_impl, const IndexSpace<N, T> &_is,
       const FieldBlock *_field_block)
@@ -848,7 +848,7 @@ namespace Realm {
   }
 
   template <int N, typename T>
-  void TransferIteratorUniformFields<N, T>::prefill(void)
+  void IDIndexedFieldsIterator<N, T>::prefill(void)
   {
     assert(!fields.empty());
     const InstanceLayout<N, T> *inst_layout =
@@ -859,7 +859,7 @@ namespace Realm {
   }
 
   /*template <int N, typename T>
-  TransferIteratorUniformFields<N, T>::TransferIteratorUniformFields(
+  IDIndexedFieldsIterator<N, T>::IDIndexedFieldsIterator(
       const int _dim_order[N], const std::vector<FieldID> &_fields,
       const std::vector<size_t> &_fld_offsets, const std::vector<size_t> &_fld_sizes,
       RegionInstanceImpl *_inst_impl, const Rect<N, T> &_bounds,
@@ -878,13 +878,13 @@ namespace Realm {
   }*/
 
   template <int N, typename T>
-  TransferIteratorUniformFields<N, T>::TransferIteratorUniformFields(void)
+  IDIndexedFieldsIterator<N, T>::IDIndexedFieldsIterator(void)
   {}
 
   template <int N, typename T>
   template <typename S>
   /*static*/ TransferIterator *
-  TransferIteratorUniformFields<N, T>::deserialize_new(S &deserializer)
+  IDIndexedFieldsIterator<N, T>::deserialize_new(S &deserializer)
   {
     IndexSpace<N, T> is;
     RegionInstance inst;
@@ -903,7 +903,7 @@ namespace Realm {
       }
     }
 
-    TransferIteratorUniformFields<N, T> *tiis = new TransferIteratorUniformFields<N, T>(
+    IDIndexedFieldsIterator<N, T> *tiis = new IDIndexedFieldsIterator<N, T>(
         dim_order, fields, field_size, get_runtime()->get_instance_impl(inst), is,
         FieldBlock::create(get_runtime()->repl_heap, fields.data(), fields.size()));
 
@@ -911,11 +911,11 @@ namespace Realm {
   }
 
   template <int N, typename T>
-  TransferIteratorUniformFields<N, T>::~TransferIteratorUniformFields(void)
+  IDIndexedFieldsIterator<N, T>::~IDIndexedFieldsIterator(void)
   {}
 
   template <int N, typename T>
-  Event TransferIteratorUniformFields<N, T>::request_metadata(void)
+  Event IDIndexedFieldsIterator<N, T>::request_metadata(void)
   {
     Event e = TransferIteratorBase<N, T>::request_metadata();
 
@@ -927,7 +927,7 @@ namespace Realm {
   }
 
   template <int N, typename T>
-  void TransferIteratorUniformFields<N, T>::reset(void)
+  void IDIndexedFieldsIterator<N, T>::reset(void)
   {
     TransferIteratorBase<N, T>::reset();
     rect_idx = 0;
@@ -935,7 +935,7 @@ namespace Realm {
   }
 
   template <int N, typename T>
-  void TransferIteratorUniformFields<N, T>::reset_internal(void)
+  void IDIndexedFieldsIterator<N, T>::reset_internal(void)
   {
     // assert(!iter_init_deferred);
     if(!sparsity_impl) {
@@ -950,8 +950,9 @@ namespace Realm {
   }
 
   template <int N, typename T>
-  bool TransferIteratorUniformFields<N, T>::get_addresses(
-      AddressList &addrlist, const InstanceLayoutPieceBase *&nonaffine)
+  bool
+  IDIndexedFieldsIterator<N, T>::get_addresses(AddressList &addrlist,
+                                               const InstanceLayoutPieceBase *&nonaffine)
   {
     nonaffine = 0;
 
@@ -975,7 +976,7 @@ namespace Realm {
       const AffineLayoutPiece<N, T> *affine =
           static_cast<const AffineLayoutPiece<N, T> *>(layout_piece);
 
-      //assert(this->inst_impl->metadata.is_valid());
+      // assert(this->inst_impl->metadata.is_valid());
       size_t base_offset = this->inst_impl->metadata.inst_offset + affine->offset +
                            affine->strides.dot(target_subrect.lo); //+ field_rel_offset;
 
@@ -1010,8 +1011,8 @@ namespace Realm {
   }
 
   template <int N, typename T>
-  bool TransferIteratorUniformFields<N, T>::get_next_rect(Rect<N, T> &r, FieldID &fid,
-                                                          size_t &offset, size_t &fsize)
+  bool IDIndexedFieldsIterator<N, T>::get_next_rect(Rect<N, T> &r, FieldID &fid,
+                                                    size_t &offset, size_t &fsize)
   {
     if(iter_init_deferred) {
       reset_internal();
@@ -1038,12 +1039,12 @@ namespace Realm {
 
   template <int N, typename T>
   /*static*/ Serialization::PolymorphicSerdezSubclass<TransferIterator,
-                                                      TransferIteratorUniformFields<N, T>>
-      TransferIteratorUniformFields<N, T>::serdez_subclass;
+                                                      IDIndexedFieldsIterator<N, T>>
+      IDIndexedFieldsIterator<N, T>::serdez_subclass;
 
   template <int N, typename T>
   template <typename S>
-  bool TransferIteratorUniformFields<N, T>::serialize(S &serializer) const
+  bool IDIndexedFieldsIterator<N, T>::serialize(S &serializer) const
   {
     if(!((serializer << iter.space) && (serializer << this->inst_impl->me) &&
          (serializer << fields) && (serializer << field_size))) {
@@ -2262,9 +2263,9 @@ namespace Realm {
     RegionInstanceImpl *impl = get_runtime()->get_instance_impl(inst);
     const InstanceLayout<N, T> *inst_layout =
         checked_cast<const InstanceLayout<N, T> *>(impl->metadata.layout);
-    if(uniform_fields && inst_layout->uniform_mutlifield_layout &&
+    if(uniform_fields && inst_layout->idindexed_fields &&
        fields.size() >= MIN_UNIFORM_FIELDS) {
-      return new TransferIteratorUniformFields<N, T>(
+      return new IDIndexedFieldsIterator<N, T>(
           dim_order.data(), fields, fld_sizes.front(), impl, is,
           FieldBlock::create(get_runtime()->repl_heap, fields.data(), fields.size()));
     } else {
@@ -5312,7 +5313,7 @@ namespace Realm {
       const ProfilingRequestSet &, Event, int) const;                                    \
   template class TransferIteratorIndexSpace<N, T>;                                       \
   template class TransferIteratorIndirect<N, T>;                                         \
-  template class TransferIteratorUniformFields<N, T>;                                    \
+  template class IDIndexedFieldsIterator<N, T>;                                          \
   template class WrappingTransferIteratorIndirect<N, T>;                                 \
   template class TransferIteratorIndirectRange<N, T>;                                    \
   template class AddressSplitXferDesFactory<N, T>;                                       \

--- a/src/realm/transfer/transfer.h
+++ b/src/realm/transfer/transfer.h
@@ -219,22 +219,20 @@ namespace Realm {
 
   ////////////////////////////////////////////////////////////////////////
   //
-  // class TransferIteratorUniformFields<N,T>
+  // class IDIndexedFieldsIterator<N,T>
   //
 
   template <int N, typename T>
-  class TransferIteratorUniformFields : public TransferIteratorBase<N, T> {
+  class IDIndexedFieldsIterator : public TransferIteratorBase<N, T> {
   protected:
-    TransferIteratorUniformFields(void);
+    IDIndexedFieldsIterator(void);
 
   public:
-    TransferIteratorUniformFields(const int _dim_order[N],
-                                  const std::vector<FieldID> &_fields, size_t _field_size,
-                                  RegionInstanceImpl *_inst_impl,
-                                  const IndexSpace<N, T> &_is,
-                                  const FieldBlock *_field_block);
+    IDIndexedFieldsIterator(const int _dim_order[N], const std::vector<FieldID> &_fields,
+                            size_t _field_size, RegionInstanceImpl *_inst_impl,
+                            const IndexSpace<N, T> &_is, const FieldBlock *_field_block);
 
-    /*TransferIteratorUniformFields(const int _dim_order[N],
+    /*IDIndexedFieldsIterator(const int _dim_order[N],
                                const std::vector<FieldID> &_fields,
                                const std::vector<size_t> &_fld_offsets,
                                const std::vector<size_t> &_fld_sizes,
@@ -244,14 +242,14 @@ namespace Realm {
     template <typename S>
     static TransferIterator *deserialize_new(S &deserializer);
 
-    virtual ~TransferIteratorUniformFields(void);
+    virtual ~IDIndexedFieldsIterator(void);
 
     virtual Event request_metadata(void);
 
     virtual void reset(void);
 
     static Serialization::PolymorphicSerdezSubclass<TransferIterator,
-                                                    TransferIteratorUniformFields<N, T>>
+                                                    IDIndexedFieldsIterator<N, T>>
         serdez_subclass;
 
     template <typename S>

--- a/src/realm/transfer/transfer.h
+++ b/src/realm/transfer/transfer.h
@@ -275,7 +275,9 @@ namespace Realm {
     const InstanceLayoutPiece<N, T> *layout_piece{nullptr};
 
     size_t field_size{0};
-    size_t field_idx{0};
+    size_t rect_idx{0};
+
+    const FieldBlock* field_block{nullptr};
   };
 
   template <int N, typename T>

--- a/src/realm/transfer/transfer.h
+++ b/src/realm/transfer/transfer.h
@@ -231,7 +231,8 @@ namespace Realm {
     TransferIteratorUniformFields(const int _dim_order[N],
                                   const std::vector<FieldID> &_fields, size_t _field_size,
                                   RegionInstanceImpl *_inst_impl,
-                                  const IndexSpace<N, T> &_is);
+                                  const IndexSpace<N, T> &_is,
+                                  const FieldBlock *_field_block);
 
     /*TransferIteratorUniformFields(const int _dim_order[N],
                                const std::vector<FieldID> &_fields,
@@ -277,7 +278,7 @@ namespace Realm {
     size_t field_size{0};
     size_t rect_idx{0};
 
-    const FieldBlock* field_block{nullptr};
+    const FieldBlock *field_block{nullptr};
   };
 
   template <int N, typename T>

--- a/src/realm/transfer/transfer.h
+++ b/src/realm/transfer/transfer.h
@@ -363,7 +363,7 @@ namespace Realm {
                                               const std::vector<FieldID> &fields,
                                               const std::vector<size_t> &fld_offsets,
                                               const std::vector<size_t> &fld_sizes,
-                                              Channel *channel = nullptr) const = 0;
+                                              bool uniform_fields = false) const = 0;
 
     virtual TransferIterator *
     create_iterator(RegionInstance inst, RegionInstance peer,
@@ -389,6 +389,7 @@ namespace Realm {
       int scatter_control_input;
       XferDesRedopInfo redop;
       Channel *channel = nullptr;
+      bool uniform_fields = false;
 
       enum IOType
       {

--- a/src/realm/transfer/transfer.h
+++ b/src/realm/transfer/transfer.h
@@ -219,21 +219,21 @@ namespace Realm {
 
   ////////////////////////////////////////////////////////////////////////
   //
-  // class UniformFieldsTransferIterator<N,T>
+  // class TransferIteratorUniformFields<N,T>
   //
 
   template <int N, typename T>
-  class UniformFieldsTransferIterator : public TransferIteratorBase<N, T> {
+  class TransferIteratorUniformFields : public TransferIteratorBase<N, T> {
   protected:
-    UniformFieldsTransferIterator(void);
+    TransferIteratorUniformFields(void);
 
   public:
-    UniformFieldsTransferIterator(const int _dim_order[N],
+    TransferIteratorUniformFields(const int _dim_order[N],
                                   const std::vector<FieldID> &_fields, size_t _field_size,
                                   RegionInstanceImpl *_inst_impl,
                                   const IndexSpace<N, T> &_is);
 
-    /*UniformFieldsTransferIterator(const int _dim_order[N],
+    /*TransferIteratorUniformFields(const int _dim_order[N],
                                const std::vector<FieldID> &_fields,
                                const std::vector<size_t> &_fld_offsets,
                                const std::vector<size_t> &_fld_sizes,
@@ -243,14 +243,14 @@ namespace Realm {
     template <typename S>
     static TransferIterator *deserialize_new(S &deserializer);
 
-    virtual ~UniformFieldsTransferIterator(void);
+    virtual ~TransferIteratorUniformFields(void);
 
     virtual Event request_metadata(void);
 
     virtual void reset(void);
 
     static Serialization::PolymorphicSerdezSubclass<TransferIterator,
-                                                    UniformFieldsTransferIterator<N, T>>
+                                                    TransferIteratorUniformFields<N, T>>
         serdez_subclass;
 
     template <typename S>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -111,7 +111,7 @@ list(
   repl_heap_test.cc
   nodeset_test.cc
   transfer_iterator_test.cc
-  transfer_iterator_unifields_test.cc
+  idindexed_fields_iterator_test.cc
   lowlevel_dma_test.cc
   circ_queue_test.cc
   gather_scatter_test.cc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -111,6 +111,7 @@ list(
   repl_heap_test.cc
   nodeset_test.cc
   transfer_iterator_test.cc
+  transfer_iterator_unifields_test.cc
   lowlevel_dma_test.cc
   circ_queue_test.cc
   gather_scatter_test.cc

--- a/tests/kvcache.cc
+++ b/tests/kvcache.cc
@@ -24,7 +24,7 @@
 
 using namespace Realm;
 
-const size_t MAX_DIM = 2;
+const size_t MAX_DIM = 1;
 typedef size_t ElementType;
 
 typedef Realm::IndexSpace<MAX_DIM, int> CopyIndexSpace;
@@ -324,9 +324,12 @@ public:
   void create(std::vector<CopyOperation> &graph) override
   {
     graph.clear();
-    Realm::Point<MAX_DIM> start_pnt(0, 0);
 
-    Realm::Point<MAX_DIM> end_pnt(1, TestConfig::size);
+    //Realm::Point<MAX_DIM> start_pnt(0, 0);
+    //Realm::Point<MAX_DIM> end_pnt(1, TestConfig::size);
+
+    Realm::Point<MAX_DIM> start_pnt(0);
+    Realm::Point<MAX_DIM> end_pnt(TestConfig::size);
     CopyIndexSpace is(Rect<MAX_DIM>{start_pnt, end_pnt});
 
     std::map<FieldID, size_t> src_fields;

--- a/tests/kvcache.cc
+++ b/tests/kvcache.cc
@@ -41,7 +41,7 @@ enum
 };
 
 namespace TestConfig {
-  bool verify = true;
+  bool verify = false;
   bool enable_profiling = true;
   bool enable_remote_copy = false;
   bool graphviz = false;

--- a/tests/kvcache.cc
+++ b/tests/kvcache.cc
@@ -83,7 +83,7 @@ static void dump_and_verify(RegionInstance inst, RegionInstance proxy_inst,
       for(PointInRectIterator<N, T> it2(it.rect); it2.valid; it2.step()) {
         DT v = acc[it2.p];
         if(value != DT(-1) && v != value) {
-          // std::cout << "v:" << int(v) << " p:" << it2.p << " fid:" << fid << std::endl;
+          std::cout << "v:" << int(v) << " p:" << it2.p << " fid:" << fid << std::endl;
           fail_count++;
         }
         if(verbose) {

--- a/tests/unit_tests/address_list_test.cc
+++ b/tests/unit_tests/address_list_test.cc
@@ -37,10 +37,10 @@ namespace {
 
   static void make_1d_entry(AddressList &alist, size_t bytes, int payload = 0)
   {
-    size_t *e = alist.being_entry(1, payload);
+    size_t *e = alist.begin_entry(1);
     ASSERT_NE(e, nullptr);
     e[0] = AddressList::pack_entry_header(bytes, 1);
-    alist.commit_entry(1, bytes, payload);
+    alist.commit_entry(1, bytes);
   }
 
   TEST(AddressListTests, AdvanceWithFieldsBasic)
@@ -52,7 +52,7 @@ namespace {
     auto *fb = FieldBlock::create(heap, fields.data(), fields.size());
     addrlist.set_field_block(fb);
 
-    size_t *entry = addrlist.being_entry(1);
+    size_t *entry = addrlist.begin_entry(1);
     ASSERT_NE(entry, nullptr);
     entry[0] = AddressList::pack_entry_header(kBytes, 1);
     addrlist.commit_entry(1, kBytes);
@@ -201,7 +201,7 @@ namespace {
     auto *fb = FieldBlock::create(heap, ids.data(), ids.size());
     al.set_field_block(fb);
 
-    size_t *entry = al.being_entry(3);
+    size_t *entry = al.begin_entry(3);
     entry[0] = AddressList::pack_entry_header(kBytes, 3);
     entry[1] = 0;    // base offset
     entry[2] = 8;    // dim1 count
@@ -235,7 +235,7 @@ namespace {
     auto *fb = FieldBlock::create(heap, ids.data(), ids.size());
     al.set_field_block(fb);
 
-    size_t *entry = al.being_entry(3);
+    size_t *entry = al.begin_entry(3);
     entry[0] = AddressList::pack_entry_header(kBytes, 3);
     entry[1] = 0;    // base offset
     entry[2] = 8;    // dim1 count
@@ -260,7 +260,7 @@ namespace {
     AddressList addrlist;
     const int dim = 1;
 
-    size_t *entry = addrlist.being_entry(dim);
+    size_t *entry = addrlist.begin_entry(dim);
     ASSERT_NE(entry, nullptr);
     entry[0] = AddressList::pack_entry_header(kBytes, dim);
     addrlist.commit_entry(dim, kBytes);
@@ -282,38 +282,13 @@ namespace {
     EXPECT_EQ(addrlist.bytes_pending(), 0);
   }
 
-  TEST(AddressListTests, Basic1DEntryWithPayload)
-  {
-    AddressList addrlist;
-    const int dim = 1;
-    std::vector<size_t> payload = {10, 20, 30};
-
-    size_t *entry = addrlist.being_entry(dim, payload.size());
-    ASSERT_NE(entry, nullptr);
-
-    entry[dim * AddressList::DIM_SLOTS] = payload.size();
-    std::copy(payload.begin(), payload.end(), entry + dim * AddressList::DIM_SLOTS + 1);
-    entry[0] = AddressList::pack_entry_header(kBytes, dim);
-    addrlist.commit_entry(dim, kBytes, payload.size());
-
-    AddressListCursor cursor;
-    cursor.set_addrlist(&addrlist);
-
-    size_t payload_count = 0;
-    const size_t *loaded_payload = cursor.get_payload(payload_count);
-    ASSERT_NE(loaded_payload, nullptr);
-    ASSERT_EQ(payload_count, payload.size());
-    for(size_t i = 0; i < payload.size(); ++i)
-      EXPECT_EQ(payload[i], loaded_payload[i]);
-  }
-
   TEST(AddressListTests, Multiple1DEntries)
   {
     AddressList addrlist;
     const size_t entries = 10;
 
     for(size_t i = 0; i < entries; ++i) {
-      size_t *entry = addrlist.being_entry(1);
+      size_t *entry = addrlist.begin_entry(1);
       ASSERT_NE(entry, nullptr);
       entry[0] = AddressList::pack_entry_header(kBytes, 1);
       addrlist.commit_entry(1, kBytes);
@@ -334,7 +309,7 @@ namespace {
   {
     AddressList addrlist;
 
-    size_t *entry = addrlist.being_entry(3);
+    size_t *entry = addrlist.begin_entry(3);
     entry[0] = AddressList::pack_entry_header(kBytes, 3);
     entry[1] = 0;    // base offset
     entry[2] = 8;    // dim1 count
@@ -363,7 +338,7 @@ namespace {
 
     size_t successful = 0;
     while(true) {
-      size_t *entry = addrlist.being_entry(1);
+      size_t *entry = addrlist.begin_entry(1);
       if(!entry)
         break;
       entry[0] = AddressList::pack_entry_header(kBytes, 1);

--- a/tests/unit_tests/address_list_test.cc
+++ b/tests/unit_tests/address_list_test.cc
@@ -305,6 +305,29 @@ namespace {
     EXPECT_EQ(addrlist.bytes_pending(), 0);
   }
 
+  TEST(AddressListTests, AppendComplex3DEntry)
+  {
+    AddressList addrlist;
+
+    std::unordered_map<int, std::pair<size_t, size_t>> count_strides;
+    count_strides[1] = {8, 1024};
+    count_strides[2] = {2, 8192};
+    bool commited = addrlist.append_entry(3, kBytes, kBytes * 8 * 2, /*base_offset=*/0,
+                                          count_strides);
+    ASSERT_TRUE(commited);
+
+    AddressListCursor cursor;
+    cursor.set_addrlist(&addrlist);
+
+    EXPECT_EQ(cursor.remaining(0), kBytes);
+    EXPECT_EQ(cursor.remaining(1), 8);
+    EXPECT_EQ(cursor.remaining(2), 2);
+    EXPECT_EQ(cursor.get_offset(), 0);
+
+    cursor.advance(2, 2);
+    EXPECT_EQ(addrlist.bytes_pending(), 0);
+  }
+
   TEST(AddressListTests, Complex3DEntry)
   {
     AddressList addrlist;

--- a/tests/unit_tests/address_list_test.cc
+++ b/tests/unit_tests/address_list_test.cc
@@ -39,7 +39,7 @@ namespace {
   {
     size_t *e = alist.begin_entry(1);
     ASSERT_NE(e, nullptr);
-    e[0] = AddressList::pack_entry_header(bytes, 1);
+    e[AddressList::SLOT_HEADER] = AddressList::pack_entry_header(bytes, 1);
     alist.commit_entry(1, bytes);
   }
 
@@ -54,7 +54,7 @@ namespace {
 
     size_t *entry = addrlist.begin_entry(1);
     ASSERT_NE(entry, nullptr);
-    entry[0] = AddressList::pack_entry_header(kBytes, 1);
+    entry[AddressList::SLOT_HEADER] = AddressList::pack_entry_header(kBytes, 1);
     addrlist.commit_entry(1, kBytes);
 
     ASSERT_NE(fb, nullptr);
@@ -202,12 +202,12 @@ namespace {
     al.set_field_block(fb);
 
     size_t *entry = al.begin_entry(3);
-    entry[0] = AddressList::pack_entry_header(kBytes, 3);
-    entry[1] = 0;    // base offset
-    entry[2] = 8;    // dim1 count
-    entry[3] = 1024; // dim1 stride
-    entry[4] = 2;    // dim2 count
-    entry[5] = 8192; // dim2 stride
+    entry[AddressList::SLOT_HEADER] = AddressList::pack_entry_header(kBytes, 3);
+    entry[AddressList::SLOT_BASE] = 0;            // base offset
+    entry[AddressList::DIM_SLOTS * 1] = 8;        // dim1 count
+    entry[AddressList::DIM_SLOTS * 1 + 1] = 1024; // dim1 stride
+    entry[AddressList::DIM_SLOTS * 2] = 2;        // dim2 count
+    entry[AddressList::DIM_SLOTS * 2 + 1] = 8192; // dim2 stride
     const size_t volume = kBytes * 8 * 2;
     al.commit_entry(3, volume);
 
@@ -236,12 +236,12 @@ namespace {
     al.set_field_block(fb);
 
     size_t *entry = al.begin_entry(3);
-    entry[0] = AddressList::pack_entry_header(kBytes, 3);
-    entry[1] = 0;    // base offset
-    entry[2] = 8;    // dim1 count
-    entry[3] = 1024; // dim1 stride
-    entry[4] = 2;    // dim2 count
-    entry[5] = 8192; // dim2 stride
+    entry[AddressList::SLOT_HEADER] = AddressList::pack_entry_header(kBytes, 3);
+    entry[AddressList::SLOT_BASE] = 0;            // base offset
+    entry[AddressList::DIM_SLOTS * 1] = 8;        // dim1 count
+    entry[AddressList::DIM_SLOTS * 1 + 1] = 1024; // dim1 stride
+    entry[AddressList::DIM_SLOTS * 2] = 2;        // dim2 count
+    entry[AddressList::DIM_SLOTS * 2 + 1] = 8192; // dim2 stride
     const size_t volume = kBytes * 8 * 2;
     al.commit_entry(3, volume);
 
@@ -310,12 +310,12 @@ namespace {
     AddressList addrlist;
 
     size_t *entry = addrlist.begin_entry(3);
-    entry[0] = AddressList::pack_entry_header(kBytes, 3);
-    entry[1] = 0;    // base offset
-    entry[2] = 8;    // dim1 count
-    entry[3] = 1024; // dim1 stride
-    entry[4] = 2;    // dim2 count
-    entry[5] = 8192; // dim2 stride
+    entry[AddressList::SLOT_HEADER] = AddressList::pack_entry_header(kBytes, 3);
+    entry[AddressList::SLOT_BASE] = 0;            // base offset
+    entry[AddressList::DIM_SLOTS * 1] = 8;        // dim1 count
+    entry[AddressList::DIM_SLOTS * 1 + 1] = 1024; // dim1 stride
+    entry[AddressList::DIM_SLOTS * 2] = 2;        // dim2 count
+    entry[AddressList::DIM_SLOTS * 2 + 1] = 8192; // dim2 stride
     const size_t volume = kBytes * 8 * 2;
     addrlist.commit_entry(3, volume);
 

--- a/tests/unit_tests/address_list_test.cc
+++ b/tests/unit_tests/address_list_test.cc
@@ -16,103 +16,141 @@
  */
 
 #include "realm/transfer/address_list.h"
-
-#include <tuple>
 #include <gtest/gtest.h>
 
 using namespace Realm;
 
-TEST(AddressListTestsWithParams, Create1DEntry)
-{
-  const size_t dim = 1;
-  const size_t stride = 8;
-  const size_t bytes = 1024;
-  assert(stride <= bytes);
+namespace {
 
-  AddressList addrlist;
-  size_t *addr_data = addrlist.being_entry(dim);
-  // addr_data[0] = (bytes << 4) + dim;
-  addr_data[0] = AddressList::pack_entry_header(bytes, dim);
-  addrlist.commit_entry(dim, bytes);
+  constexpr size_t kStride = 8;
+  constexpr size_t kBytes = 1024;
 
-  AddressListCursor addrcursor;
-  addrcursor.set_addrlist(&addrlist);
+  TEST(AddressListTests, Basic1DEntryNoPayload)
+  {
+    AddressList addrlist;
+    const int dim = 1;
 
-  EXPECT_EQ(addrcursor.remaining(dim - 1), bytes);
-  EXPECT_EQ(addrcursor.get_dim(), dim);
-  EXPECT_EQ(addrcursor.get_offset(), 0);
+    size_t *entry = addrlist.being_entry(dim);
+    ASSERT_NE(entry, nullptr);
+    entry[0] = AddressList::pack_entry_header(kBytes, dim);
+    addrlist.commit_entry(dim, kBytes);
 
-  addrcursor.advance(dim - 1, stride);
-  EXPECT_EQ(addrcursor.remaining(dim - 1), bytes - stride);
+    AddressListCursor cursor;
+    cursor.set_addrlist(&addrlist);
 
-  addrcursor.skip_bytes(stride);
-  EXPECT_EQ(addrcursor.remaining(dim - 1), bytes - 2 * stride);
+    EXPECT_EQ(cursor.get_dim(), 1);
+    EXPECT_EQ(cursor.remaining(0), kBytes);
+    EXPECT_EQ(cursor.get_offset(), 0);
 
-  addrcursor.advance(dim - 1, bytes - 2 * stride);
-  EXPECT_EQ(addrlist.bytes_pending(), 0);
-}
+    cursor.advance(0, kStride);
+    EXPECT_EQ(cursor.remaining(0), kBytes - kStride);
 
-TEST(AddressListTestsWithParams, Create3DEntry)
-{
-  AddressList addrlist;
-  // TODO(apryakhin): parameterize dimensions
-  const size_t dim = 3;
-  const size_t stride = 8;
-  const size_t bytes = 1024;
-  const std::vector<size_t> strides{stride, stride * stride, stride * stride * stride};
-  size_t *addr_data = addrlist.being_entry(dim);
+    cursor.skip_bytes(kStride);
+    EXPECT_EQ(cursor.remaining(0), kBytes - 2 * kStride);
 
-  size_t cur_dim = 1;
-  for(size_t i = 0; i < strides.size() - 1; i++) {
-    addr_data[cur_dim * AddressList::ADDRLIST_DIM_SLOTS] = bytes / strides[i];
-    addr_data[cur_dim * AddressList::ADDRLIST_DIM_SLOTS + 1] = strides[i];
-    cur_dim++;
+    cursor.advance(0, kBytes - 2 * kStride);
+    EXPECT_EQ(addrlist.bytes_pending(), 0);
   }
 
-  // addr_data[0] = (strides[0] << 4) + cur_dim;
+  TEST(AddressListTests, Basic1DEntryWithPayload)
+  {
+    AddressList addrlist;
+    const int dim = 1;
+    std::vector<size_t> payload = {10, 20, 30};
 
-  addr_data[0] = AddressList::pack_entry_header(strides[0], cur_dim);
-  addrlist.commit_entry(cur_dim, bytes);
+    size_t *entry = addrlist.being_entry(dim, payload.size());
+    ASSERT_NE(entry, nullptr);
 
-  AddressListCursor addrcursor;
-  addrcursor.set_addrlist(&addrlist);
-  EXPECT_EQ(addrcursor.remaining(dim - 1), bytes / strides[1]);
-  EXPECT_EQ(addrcursor.remaining(dim - 2), bytes / strides[0]);
-  EXPECT_EQ(addrcursor.remaining(dim - 3), strides[0]);
+    entry[dim * AddressList::ADDRLIST_DIM_SLOTS] = payload.size();
+    std::copy(payload.begin(), payload.end(),
+              entry + dim * AddressList::ADDRLIST_DIM_SLOTS + 1);
+    entry[0] = AddressList::pack_entry_header(kBytes, dim);
+    addrlist.commit_entry(dim, kBytes, payload.size());
 
-  addrcursor.advance(dim - 1, 1);
-  EXPECT_EQ(addrlist.bytes_pending(), 0);
-}
+    AddressListCursor cursor;
+    cursor.set_addrlist(&addrlist);
 
-TEST(AddressListTestsWithParams, CommitMax1DEntries)
-{
-  const size_t dim = 1;
-  const size_t stride = 8;
-  const size_t bytes = 1024;
-  const size_t max_entries = 499;
-  assert(stride <= bytes);
-
-  AddressList addrlist;
-  for(size_t i = 0; i < max_entries; i++) {
-    size_t *addr_data = addrlist.being_entry(dim);
-    EXPECT_NE(addr_data, nullptr);
-    // addr_data[0] = (bytes << 4) + dim;
-    addr_data[0] = AddressList::pack_entry_header(bytes, dim);
-    addrlist.commit_entry(dim, bytes);
+    size_t payload_count = 0;
+    const size_t *loaded_payload = cursor.get_payload(payload_count);
+    ASSERT_NE(loaded_payload, nullptr);
+    ASSERT_EQ(payload_count, payload.size());
+    for(size_t i = 0; i < payload.size(); ++i)
+      EXPECT_EQ(payload[i], loaded_payload[i]);
   }
 
-  AddressListCursor addrcursor;
-  addrcursor.set_addrlist(&addrlist);
+  TEST(AddressListTests, Multiple1DEntries)
+  {
+    AddressList addrlist;
+    const size_t entries = 10;
 
-  EXPECT_EQ(addrcursor.remaining(dim - 1), bytes);
-  EXPECT_EQ(addrcursor.get_dim(), dim);
+    for(size_t i = 0; i < entries; ++i) {
+      size_t *entry = addrlist.being_entry(1);
+      ASSERT_NE(entry, nullptr);
+      entry[0] = AddressList::pack_entry_header(kBytes, 1);
+      addrlist.commit_entry(1, kBytes);
+    }
 
-  EXPECT_EQ(addrcursor.get_offset(), 0);
+    EXPECT_EQ(addrlist.bytes_pending(), entries * kBytes);
 
-  addrcursor.advance(dim - 1, stride);
-  EXPECT_EQ(addrcursor.remaining(dim - 1), bytes - stride);
+    AddressListCursor cursor;
+    cursor.set_addrlist(&addrlist);
+    for(size_t i = 0; i < entries; ++i) {
+      EXPECT_EQ(cursor.remaining(0), kBytes);
+      cursor.advance(0, kBytes);
+    }
+    EXPECT_EQ(addrlist.bytes_pending(), 0);
+  }
 
-  // advance rest of first entry
-  addrcursor.advance(dim - 1, bytes - stride);
-  EXPECT_EQ(addrlist.bytes_pending(), bytes * (max_entries - 1));
-}
+  TEST(AddressListTests, Complex3DEntry)
+  {
+    AddressList addrlist;
+
+    size_t *entry = addrlist.being_entry(3);
+    entry[0] = AddressList::pack_entry_header(kBytes, 3);
+    entry[1] = 0;    // base offset
+    entry[2] = 8;    // dim1 count
+    entry[3] = 1024; // dim1 stride
+    entry[4] = 2;    // dim2 count
+    entry[5] = 8192; // dim2 stride
+    const size_t volume = kBytes * 8 * 2;
+    addrlist.commit_entry(3, volume);
+
+    AddressListCursor cursor;
+    cursor.set_addrlist(&addrlist);
+
+    EXPECT_EQ(cursor.remaining(0), kBytes);
+    EXPECT_EQ(cursor.remaining(1), 8);
+    EXPECT_EQ(cursor.remaining(2), 2);
+    EXPECT_EQ(cursor.get_offset(), 0);
+
+    cursor.advance(2, 2);
+    EXPECT_EQ(addrlist.bytes_pending(), 0);
+  }
+
+  TEST(AddressListTests, WraparoundBufferSafety)
+  {
+    const size_t max_entries = 16;
+    AddressList addrlist(max_entries);
+
+    size_t successful = 0;
+    while(true) {
+      size_t *entry = addrlist.being_entry(1);
+      if(!entry)
+        break;
+      entry[0] = AddressList::pack_entry_header(kBytes, 1);
+      addrlist.commit_entry(1, kBytes);
+      successful++;
+    }
+
+    EXPECT_GT(successful, 0);
+    EXPECT_LE(successful, max_entries);
+
+    AddressListCursor cursor;
+    cursor.set_addrlist(&addrlist);
+    for(size_t i = 0; i < successful; ++i) {
+      cursor.advance(0, kBytes);
+    }
+    EXPECT_EQ(addrlist.bytes_pending(), 0);
+  }
+
+} // namespace

--- a/tests/unit_tests/address_list_test.cc
+++ b/tests/unit_tests/address_list_test.cc
@@ -24,7 +24,6 @@ namespace {
 
   constexpr size_t kStride = 8;
   constexpr size_t kBytes = 1024;
-  constexpr int kFieldsPerEntry = 4;
 
   struct MockHeap {
     void *alloc_obj(std::size_t bytes, std::size_t align = 16)

--- a/tests/unit_tests/address_list_test.cc
+++ b/tests/unit_tests/address_list_test.cc
@@ -66,22 +66,22 @@ namespace {
 
     EXPECT_EQ(addrlist.bytes_pending(), kBytes * fields.size());
 
-    ASSERT_EQ(cursor.fields(), fields.size());
+    ASSERT_EQ(cursor.remaining_fields(), fields.size());
     cursor.advance(0, 128, 1);
     EXPECT_EQ(addrlist.bytes_pending(), kBytes * fields.size() - 128);
-    ASSERT_EQ(cursor.fields(), fields.size());
+    ASSERT_EQ(cursor.remaining_fields(), fields.size());
 
     cursor.advance(0, 128, 1);
     EXPECT_EQ(addrlist.bytes_pending(), kBytes * fields.size() - 256);
-    ASSERT_EQ(cursor.fields(), fields.size());
+    ASSERT_EQ(cursor.remaining_fields(), fields.size());
 
     cursor.advance(0, kBytes - 256, 1);
     EXPECT_EQ(addrlist.bytes_pending(), kBytes * (fields.size() - 1));
-    ASSERT_EQ(cursor.fields(), fields.size() - 1);
+    ASSERT_EQ(cursor.remaining_fields(), fields.size() - 1);
 
     cursor.advance(0, kBytes, fields.size() - 1);
     EXPECT_EQ(addrlist.bytes_pending(), 0);
-    ASSERT_EQ(cursor.fields(), 0);
+    ASSERT_EQ(cursor.remaining_fields(), 0);
 
     delete fb;
   }
@@ -102,7 +102,7 @@ namespace {
     cur.advance(0, 128, 1);
     EXPECT_EQ(cur.fields_data(), fb->fields + 0);
     EXPECT_EQ(al.bytes_pending(), kBytes * ids.size() - 128);
-    ASSERT_EQ(cur.fields(), ids.size());
+    ASSERT_EQ(cur.remaining_fields(), ids.size());
 
     delete fb;
   }
@@ -124,7 +124,7 @@ namespace {
     EXPECT_EQ(cur.fields_data(), fb->fields + 1);
     // entry still pending until all 4 fields done
     EXPECT_EQ(al.bytes_pending(), kBytes * ids.size() - kBytes);
-    ASSERT_EQ(cur.fields(), ids.size() - 1);
+    ASSERT_EQ(cur.remaining_fields(), ids.size() - 1);
 
     delete fb;
   }
@@ -145,7 +145,7 @@ namespace {
     cur.advance(0, kBytes, 2);
     EXPECT_EQ(cur.fields_data(), fb->fields + 2);
     EXPECT_EQ(al.bytes_pending(), kBytes * ids.size() - 2 * kBytes);
-    ASSERT_EQ(cur.fields(), ids.size() - 2);
+    ASSERT_EQ(cur.remaining_fields(), ids.size() - 2);
 
     delete fb;
   }
@@ -166,7 +166,7 @@ namespace {
     cur.advance(0, kBytes, ids.size());
     EXPECT_EQ(al.bytes_pending(), 0);
     EXPECT_EQ(cur.fields_data(), fb->fields + ids.size());
-    ASSERT_EQ(cur.fields(), 0);
+    ASSERT_EQ(cur.remaining_fields(), 0);
 
     delete fb;
   }

--- a/tests/unit_tests/address_list_test.cc
+++ b/tests/unit_tests/address_list_test.cc
@@ -50,7 +50,7 @@ namespace {
     std::vector<int> fields = {100, 101, 102, 103};
     MockHeap heap;
     auto *fb = FieldBlock::create(heap, fields.data(), fields.size());
-    addrlist.set_field_block(fb);
+    addrlist.attach_field_block(fb);
 
     size_t *entry = addrlist.begin_entry(1);
     ASSERT_NE(entry, nullptr);
@@ -92,7 +92,7 @@ namespace {
     std::vector<int> ids = {1, 2, 3, 4};
     MockHeap heap;
     auto *fb = FieldBlock::create(heap, ids.data(), ids.size());
-    al.set_field_block(fb);
+    al.attach_field_block(fb);
     make_1d_entry(al, kBytes, ids.size());
 
     AddressListCursor cur;
@@ -113,7 +113,7 @@ namespace {
     std::vector<int> ids = {1, 2, 3, 4};
     MockHeap heap;
     auto *fb = FieldBlock::create(heap, ids.data(), ids.size());
-    al.set_field_block(fb);
+    al.attach_field_block(fb);
     make_1d_entry(al, kBytes, ids.size());
 
     AddressListCursor cur;
@@ -135,7 +135,7 @@ namespace {
     std::vector<int> ids = {1, 2, 3, 4};
     MockHeap heap;
     auto *fb = FieldBlock::create(heap, ids.data(), ids.size());
-    al.set_field_block(fb);
+    al.attach_field_block(fb);
     make_1d_entry(al, kBytes, ids.size());
 
     AddressListCursor cur;
@@ -156,7 +156,7 @@ namespace {
     std::vector<int> ids = {1, 2, 3, 4};
     MockHeap heap;
     auto *fb = FieldBlock::create(heap, ids.data(), ids.size());
-    al.set_field_block(fb);
+    al.attach_field_block(fb);
     make_1d_entry(al, kBytes, ids.size());
 
     AddressListCursor cur;
@@ -177,7 +177,7 @@ namespace {
     std::vector<int> ids = {1, 2, 3, 4};
     MockHeap heap;
     auto *fb = FieldBlock::create(heap, ids.data(), ids.size());
-    al.set_field_block(fb);
+    al.attach_field_block(fb);
     make_1d_entry(al, kBytes, ids.size());
 
     AddressListCursor cur;
@@ -199,7 +199,7 @@ namespace {
     std::vector<int> ids = {7, 8, 9};
     MockHeap heap;
     auto *fb = FieldBlock::create(heap, ids.data(), ids.size());
-    al.set_field_block(fb);
+    al.attach_field_block(fb);
 
     size_t *entry = al.begin_entry(3);
     entry[AddressList::SLOT_HEADER] = AddressList::pack_entry_header(kBytes, 3);
@@ -233,7 +233,7 @@ namespace {
     std::vector<int> ids = {7, 8, 9};
     MockHeap heap;
     auto *fb = FieldBlock::create(heap, ids.data(), ids.size());
-    al.set_field_block(fb);
+    al.attach_field_block(fb);
 
     size_t *entry = al.begin_entry(3);
     entry[AddressList::SLOT_HEADER] = AddressList::pack_entry_header(kBytes, 3);

--- a/tests/unit_tests/transfer_iterator_unifields_test.cc
+++ b/tests/unit_tests/transfer_iterator_unifields_test.cc
@@ -1,0 +1,167 @@
+// TransferIteratorUniformFieldsTest.cpp
+
+#include "realm/transfer/transfer.h"
+#include "realm/inst_layout.h"
+#include "test_common.h"
+#include <gtest/gtest.h>
+
+using namespace Realm;
+
+// Base class for parameterized test cases
+struct BaseUniformTransferItTestCaseData {
+  virtual ~BaseUniformTransferItTestCaseData() = default;
+  virtual int get_dim() const = 0;
+};
+
+template <int N>
+struct UniformTransferItTestCaseData {
+  // The iteration space
+  Rect<N, int> domain;
+  // The expected subrects from get_addresses (for uniform fields it's just the full
+  // domain)
+  std::vector<Rect<N, int>> expected;
+  // Dimension traversal order
+  std::vector<int> dim_order;
+  // The list of field IDs (all fields have the same uniform size)
+  std::vector<FieldID> fields;
+  // Uniform field size in bytes
+  size_t field_size;
+};
+
+template <int N>
+struct WrappedUniformTransferItTestCaseData : public BaseUniformTransferItTestCaseData {
+  UniformTransferItTestCaseData<N> data;
+  explicit WrappedUniformTransferItTestCaseData(UniformTransferItTestCaseData<N> d)
+    : data(std::move(d))
+  {}
+  int get_dim() const override { return N; }
+};
+
+class TransferIteratorUniformFieldsGetAddressesTest
+  : public ::testing::TestWithParam<BaseUniformTransferItTestCaseData *> {
+protected:
+  void TearDown() override { delete GetParam(); }
+};
+
+struct MockHeap {
+  void *alloc_obj(std::size_t bytes, std::size_t align = 16)
+  {
+    void *ptr = nullptr;
+    posix_memalign(&ptr, align, bytes);
+    return ptr;
+  }
+};
+
+template <int N>
+void run_uniform_test_case(const UniformTransferItTestCaseData<N> &tc)
+{
+  using T = int;
+
+  // Create an instance with one entry per field, all uniformly sized
+  std::vector<size_t> field_sizes(tc.fields.size(), tc.field_size);
+  RegionInstanceImpl *inst_impl = create_inst<N, T>(tc.domain, tc.fields, field_sizes);
+
+  MockHeap mock_heap;
+  auto *field_block = FieldBlock::create(mock_heap, tc.fields.data(), tc.fields.size());
+
+  // Build the TransferIteratorUniformFields
+  auto it = std::make_unique<TransferIteratorUniformFields<N, T>>(
+      tc.dim_order.data(), tc.fields, tc.field_size, inst_impl, tc.domain, field_block);
+
+  const InstanceLayoutPieceBase *nonaffine = nullptr;
+  AddressList addrlist;
+  AddressListCursor cursor;
+
+  // Invoke get_addresses
+  bool ok = it->get_addresses(addrlist, nonaffine);
+  ASSERT_TRUE(ok) << "get_addresses() failed";
+  ASSERT_TRUE(it->done()) << "Iterator should be done after get_addresses";
+
+  // Check total bytes pending
+  size_t total_volume = 0;
+  for(auto &r : tc.expected)
+    total_volume += r.volume();
+  size_t expected_bytes = total_volume * tc.field_size * tc.fields.size();
+  ASSERT_EQ(addrlist.bytes_pending(), expected_bytes) << "bytes_pending mismatch";
+
+  // If 1D, walk through with the cursor and drain the bytes
+  cursor.set_addrlist(&addrlist);
+  if(expected_bytes > 0 && cursor.get_dim() == 1) {
+    int dim = cursor.get_dim() - 1;
+    for(size_t f = 0; f < tc.fields.size(); f++) {
+      for(auto &r : tc.expected) {
+        size_t rem = cursor.remaining(dim);
+        ASSERT_EQ(rem, r.volume() * tc.field_size)
+            << "Unexpected remaining bytes for field " << f;
+        cursor.advance(dim, rem);
+      }
+    }
+    ASSERT_EQ(addrlist.bytes_pending(), 0u) << "All bytes should have been consumed";
+  }
+}
+
+TEST_P(TransferIteratorUniformFieldsGetAddressesTest, Base)
+{
+  BaseUniformTransferItTestCaseData const *base = GetParam();
+  dispatch_for_dimension(
+      base->get_dim(),
+      [&](auto Dim) {
+        constexpr int N = Dim;
+        auto const &tc =
+            static_cast<WrappedUniformTransferItTestCaseData<N> const *>(base)->data;
+        run_uniform_test_case(tc);
+      },
+      std::make_index_sequence<REALM_MAX_DIM>{});
+}
+
+INSTANTIATE_TEST_SUITE_P(UniformFieldsCases,
+                         TransferIteratorUniformFieldsGetAddressesTest,
+                         ::testing::Values(
+                             // 1D: empty domain
+                             new WrappedUniformTransferItTestCaseData<1>({
+                                 /* domain */ Rect<1, int>::make_empty(),
+                                 /* expected */ {},
+                                 /* dim_order */ {0},
+                                 /* fields */ {0},
+                                 /* field_size */ sizeof(int),
+                             }),
+                             // 1D: single field, full domain
+                             new WrappedUniformTransferItTestCaseData<1>({
+                                 /* domain */ Rect<1, int>(0, 14),
+                                 /* expected */ {Rect<1, int>(0, 14)},
+                                 /* dim_order */ {0},
+                                 /* fields */ {0},
+                                 /* field_size */ sizeof(int),
+                             }),
+                             // 1D: two uniform fields, full domain
+                             new WrappedUniformTransferItTestCaseData<1>({
+                                 /* domain */ Rect<1, int>(0, 14),
+                                 /* expected */ {Rect<1, int>(0, 14)},
+                                 /* dim_order */ {0},
+                                 /* fields */ {0, 1},
+                                 /* field_size */ sizeof(int),
+                             }),
+                             // 2D: single field, full rectangular domain
+                             new WrappedUniformTransferItTestCaseData<2>({
+                                 /* domain */ Rect<2, int>({0, 0}, {10, 10}),
+                                 /* expected */ {Rect<2, int>({0, 0}, {10, 10})},
+                                 /* dim_order */ {0, 1},
+                                 /* fields */ {0},
+                                 /* field_size */ sizeof(int),
+                             }),
+                             // 2D: single field, reverse dims
+                             new WrappedUniformTransferItTestCaseData<2>({
+                                 /* domain */ Rect<2, int>({0, 0}, {10, 10}),
+                                 /* expected */ {Rect<2, int>({0, 0}, {10, 10})},
+                                 /* dim_order */ {1, 0},
+                                 /* fields */ {0},
+                                 /* field_size */ sizeof(int),
+                             }),
+                             // 3D: single field, small cube
+                             new WrappedUniformTransferItTestCaseData<3>({
+                                 /* domain */ Rect<3, int>({0, 0, 0}, {1, 1, 1}),
+                                 /* expected */ {Rect<3, int>({0, 0, 0}, {1, 1, 1})},
+                                 /* dim_order */ {0, 1, 2},
+                                 /* fields */ {0},
+                                 /* field_size */ sizeof(int),
+                             })));


### PR DESCRIPTION
This is the 2nd PR out of 6 and  address list refactoring and shared field block changes.

This patch adds a fast‐path for multi‐field copies when source and destination instances store fields consecutively in memory with strictly increasing IDs. Instead of the generic per‐field iterator, Realm switches to an IDIndexedIterator and issues the entire copy as a single batched DMA operation.
Fast‐Path Mechanics

Layout Detection: During instance construction, Realm identifies when field IDs form a consecutive sequence and marks the instances for the optimized path.

IDIndexedIterator: Attaches a single FieldBlock (allocated from the replicated heap) to the address list, skipping per‐field offset lookups.

Affine Collapse: Treats the multi‐field operation as one affine rectangle with N attached fields, collapsing what would be N separate copies into a single batched command.

Flow‐Control Splitting: The DMA engine automatically splits the batch according to internal flow‐control limits and IB fragment sizes (for cross‐node transfers).

Testing

Integration Test: Verifies end-to-end multi-field copy behavior on real instances.

Unit Tests: Covers iterator construction, address-list setup, FieldBlock allocation, and DMA splitting logic.

```
src_inst{ 0: [..field_size..], 1: [..field_size..], 2: [..field_size..], N-1: [..field_size..] }
dst_inst{ 0: [..field_size..], 1: [..field_size..], 2: [..field_size..], N-1: [..field_size..] }
index_space.copy(src_fids[32, 16, 612, 0..], dst_fids[17, 3, 999, 2..])
```