### PR TITLE
Support transfers for layouts with multiple id-indexed fields (PR 5/6)

### DIFF
--- a/src/realm/cuda/cuda_internal.cc
+++ b/src/realm/cuda/cuda_internal.cc
@@ -1672,7 +1672,7 @@ namespace Realm {
         // self-path
         unsigned bw = src_gpu->info->logical_peer_bandwidth[_src_gpu->info->index];
         unsigned latency = src_gpu->info->logical_peer_latency[_src_gpu->info->index];
-        unsigned frag_overhead = 2000; // HACK - estimate at 2 us
+        unsigned frag_overhead = 1000; // HACK - estimate at 2 us
 
         add_path(local_gpu_mems, local_gpu_mems, bw, latency, frag_overhead,
                  XFER_GPU_IN_FB)

--- a/src/realm/cuda/cuda_internal.cc
+++ b/src/realm/cuda/cuda_internal.cc
@@ -1672,7 +1672,7 @@ namespace Realm {
         // self-path
         unsigned bw = src_gpu->info->logical_peer_bandwidth[_src_gpu->info->index];
         unsigned latency = src_gpu->info->logical_peer_latency[_src_gpu->info->index];
-        unsigned frag_overhead = 1000; // HACK - estimate at 2 us
+        unsigned frag_overhead = 200; // HACK - estimate at 2 us
 
         add_path(local_gpu_mems, local_gpu_mems, bw, latency, frag_overhead,
                  XFER_GPU_IN_FB)
@@ -1697,7 +1697,7 @@ namespace Realm {
                 src_gpu->info->logical_peer_bandwidth[peer_gpu->info->index]);
             unsigned latency = static_cast<unsigned>(
                 src_gpu->info->logical_peer_latency[peer_gpu->info->index]);
-            unsigned frag_overhead = 2000; // HACK - estimate at 2 us
+            unsigned frag_overhead = 200; // HACK - estimate at 2 us
             if(peer_gpu->fbmem != nullptr) {
               add_path(local_gpu_mems, peer_gpu->fbmem->me, bw, latency, frag_overhead,
                        XFER_GPU_PEER_FB)
@@ -1729,7 +1729,7 @@ namespace Realm {
           size_t bw =
               std::max(src_gpu->info->pci_bandwidth, src_gpu->info->nvswitch_bandwidth);
           size_t latency = 1000;         // HACK - estimate at 1 us
-          unsigned frag_overhead = 2000; // HACK - estimate at 2 us
+          unsigned frag_overhead = 200; // HACK - estimate at 2 us
           if(mapping.src_gpu != nullptr) {
             bw = src_gpu->info->logical_peer_bandwidth[mapping.src_gpu->info->index];
             latency = src_gpu->info->logical_peer_latency[mapping.src_gpu->info->index];

--- a/src/realm/inst_layout.inl
+++ b/src/realm/inst_layout.inl
@@ -243,6 +243,7 @@ namespace Realm {
         pl_sizes[pl_key] = layout->bytes_used - pl_start;
       }
 
+
       // now that the we know which piece list we are using, we can set the
       //  actual field offsets
       for(std::map<FieldID, size_t>::const_iterator it2 = field_offsets.begin();
@@ -544,6 +545,7 @@ namespace Realm {
     copy->bytes_used = bytes_used;
     copy->alignment_reqd = alignment_reqd;
     copy->fields = fields;
+    copy->idindexed_fields = idindexed_fields;
     copy->space = space;
     copy->piece_lists.resize(piece_lists.size());
     for(size_t i = 0; i < piece_lists.size(); i++) {

--- a/src/realm/inst_layout.inl
+++ b/src/realm/inst_layout.inl
@@ -525,6 +525,7 @@ namespace Realm {
     if((s >> il->bytes_used) &&
        (s >> il->alignment_reqd) &&
        (s >> il->fields) &&
+       (s >> il->idindexed_fields) &&
        (s >> il->space) &&
        (s >> il->piece_lists)) {
       return il;
@@ -616,6 +617,7 @@ namespace Realm {
     return ((s << bytes_used) &&
 	    (s << alignment_reqd) &&
 	    (s << fields) &&
+	    (s << idindexed_fields) &&
 	    (s << space) &&
 	    (s << piece_lists));
   }

--- a/src/realm/runtime_impl.cc
+++ b/src/realm/runtime_impl.cc
@@ -784,6 +784,7 @@ namespace Realm {
     config_map.insert({"pin_util_procs", &pin_util_procs});
     config_map.insert({"use_ext_sysmem", &use_ext_sysmem});
     config_map.insert({"regmem", &reg_mem_size});
+    config_map.insert({"ib_regmem", &reg_ib_mem_size});
     config_map.insert({"report_sparsity_leaks", &report_sparsity_leaks});
     config_map.insert({"barrier_broadcast_radix", &barrier_broadcast_radix});
     config_map.insert({"diskmem", &disk_mem_size});

--- a/src/realm/transfer/address_list.cc
+++ b/src/realm/transfer/address_list.cc
@@ -131,8 +131,8 @@ namespace Realm {
   {
     const size_t *entry = read_entry();
     // decode header
-    const size_t contig = entry[AddressList::SLOT_HEADER] >> AddressList::CONTIG_SHIFT;
-    const int dims = int(entry[AddressList::SLOT_HEADER] & AddressList::DIM_MASK);
+    const size_t contig = detail::contig_bytes(entry);
+    const int dims = detail::actdim(entry);
     size_t bytes = contig;
     for(int d = 1; d < dims; d++) {
       bytes *= entry[detail::count_index(d)];

--- a/src/realm/transfer/address_list.h
+++ b/src/realm/transfer/address_list.h
@@ -28,7 +28,7 @@
 
 namespace Realm {
 
-  template <typename FieldID = int>
+  template <typename FieldID>
   struct FieldBlockBase {
     std::size_t count;
     FieldID fields[1];

--- a/src/realm/transfer/channel.cc
+++ b/src/realm/transfer/channel.cc
@@ -4176,7 +4176,7 @@ namespace Realm {
   {
     unsigned bw = 5000;            // HACK - estimate at 5 GB/s
     unsigned latency = 2000;       // HACK - estimate at 2 us
-    unsigned frag_overhead = 1500; // HACK - estimate at 1 us
+    unsigned frag_overhead = 2000; // HACK - estimate at 1 us
     // any combination of SYSTEM/REGDMA/Z_COPY/SOCKET_MEM
     // for(size_t i = 0; i < num_cpu_mem_kinds; i++)
     //   add_path(cpu_mem_kinds[i], false,

--- a/src/realm/transfer/channel.cc
+++ b/src/realm/transfer/channel.cc
@@ -4176,7 +4176,7 @@ namespace Realm {
   {
     unsigned bw = 5000;            // HACK - estimate at 5 GB/s
     unsigned latency = 2000;       // HACK - estimate at 2 us
-    unsigned frag_overhead = 1000; // HACK - estimate at 1 us
+    unsigned frag_overhead = 1500; // HACK - estimate at 1 us
     // any combination of SYSTEM/REGDMA/Z_COPY/SOCKET_MEM
     // for(size_t i = 0; i < num_cpu_mem_kinds; i++)
     //   add_path(cpu_mem_kinds[i], false,

--- a/src/realm/transfer/transfer.cc
+++ b/src/realm/transfer/transfer.cc
@@ -3919,8 +3919,13 @@ namespace Realm {
       min_granularity = combined_field_size;
     }
 
+    size_t max_ib_size = 0;
+    bool success =
+        get_runtime()->get_module_config("core")->get_property("ib_regmem", max_ib_size);
+    assert(success);
+
     size_t ib_size = domain_size * element_size + serdez_pad;
-    const size_t IB_MAX_SIZE = 16 << 20; // 16MB
+    const size_t IB_MAX_SIZE = max_ib_size; // 16 << 20; // 16MB
     if(ib_size > IB_MAX_SIZE) {
       // take up to IB_MAX_SIZE, respecting the min granularity
       if(min_granularity > 1) {

--- a/src/realm/transfer/transfer_utils.h
+++ b/src/realm/transfer/transfer_utils.h
@@ -20,6 +20,7 @@
 
 #include "realm/point.h"
 #include "realm/inst_layout.h"
+#include <unordered_map>
 
 namespace Realm {
   // finds the largest subrectangle of 'domain' that starts with 'start',

--- a/tests/multifield_transfer.cc
+++ b/tests/multifield_transfer.cc
@@ -25,7 +25,7 @@
 
 using namespace Realm;
 
-const size_t MAX_DIM = 1;
+const size_t MAX_DIM = 2;
 // typedef size_t ElementType;
 typedef unsigned short ElementType;
 
@@ -356,11 +356,11 @@ public:
 
     constexpr ElementType value = 9;
 
-    // Realm::Point<MAX_DIM> start_pnt(0, 0);
-    // Realm::Point<MAX_DIM> end_pnt(1, TestConfig::size);
+    Realm::Point<MAX_DIM> start_pnt(0, 0);
+    Realm::Point<MAX_DIM> end_pnt(1, TestConfig::size);
 
-    Realm::Point<MAX_DIM> start_pnt(0);
-    Realm::Point<MAX_DIM> end_pnt(TestConfig::size);
+    //Realm::Point<MAX_DIM> start_pnt(0);
+    //Realm::Point<MAX_DIM> end_pnt(TestConfig::size);
     CopyIndexSpace is(Rect<MAX_DIM>{start_pnt, end_pnt});
 
     std::map<FieldID, size_t> src_fields;

--- a/tests/multifield_transfer.cc
+++ b/tests/multifield_transfer.cc
@@ -52,7 +52,7 @@ namespace TestConfig {
   size_t max_ops = 4;
   size_t max_copy_fields = 32000;
   size_t num_fields = 1;
-  size_t field_size = sizeof(long long);
+  size_t field_size = sizeof(ElementType);
   size_t size = 4ULL * 256ULL; // 1024ULL * 4ULL;//1024ULL;
 };                             // namespace TestConfig
 


### PR DESCRIPTION
This is the 5th PR out of 6.

This patch adds a fast‐path for multi‐field copies when source and destination instances store fields consecutively in memory with strictly increasing IDs. Instead of the generic per‐field iterator, Realm switches to an IDIndexedIterator and issues the entire copy as a single batched DMA operation.
**Fast‐Path Mechanics**


- Layout Detection: During instance construction, Realm identifies when field IDs form a consecutive sequence and marks the instances for the optimized path.
- IDIndexedIterator: Attaches a single FieldBlock (allocated from the replicated heap) to the address list, skipping per‐field offset lookups.
- Affine Collapse: Treats the multi‐field operation as one affine rectangle with N attached fields, collapsing what would be N separate copies into a single batched command.
- Flow‐Control Splitting: The DMA engine automatically splits the batch according to internal flow‐control limits and IB fragment sizes (for cross‐node transfers).

**Testing**

- Integration Test: Verifies end-to-end multi-field copy behavior on real instances.
- Unit Tests: Covers iterator construction, address-list setup, FieldBlock allocation, and DMA splitting logic.

```
src_inst{ 0: [..field_size..], 1: [..field_size..], 2: [..field_size..], N-1: [..field_size..] }
dst_inst{ 0: [..field_size..], 1: [..field_size..], 2: [..field_size..], N-1: [..field_size..] }
index_space.copy(src_fids[32, 16, 612, 0..], dst_fids[17, 3, 999, 2..])
```