### PR TITLE
GASNetEX Object Buffer Hang Detection

### DIFF
--- a/src/realm/gasnetex/gasnetex_internal.cc
+++ b/src/realm/gasnetex/gasnetex_internal.cc
@@ -440,10 +440,11 @@ namespace Realm {
     {
       AutoLock<> al(mutex);
       md = first_available;
-      if(md)
+      if(md) {
         first_available = md->nextbuf;
-      else if(!overflow_ok)
+      } else if(!overflow_ok) {
         return nullptr;
+      }
       if(new_endpoint && (num_buffers == num_endpoints++)) {
         log_gex_obmgr.fatal()
             << "Detected inevitable hang because there are "

--- a/src/realm/gasnetex/gasnetex_internal.h
+++ b/src/realm/gasnetex/gasnetex_internal.h
@@ -160,6 +160,7 @@ namespace Realm {
     // TODO: Remove this once we insert a slow insertion pathway
     // from dynamically allocated output buffers that are not
     // registered with GASNet
+    // https://github.com/StanfordLegion/realm/issues/239
     size_t num_buffers, num_endpoints;
     OutbufMetadata *overflow_head;
     OutbufMetadata **overflow_tail;


### PR DESCRIPTION
This branch adds a lightweight online analysis for detecting when the number of dynamic endpoints exceeds the number of available object buffers which is guaranteed today to result in a hang. 