### PR TITLE
relax the requirement of lock for checking if redop is supported on remote channels

### DIFF
--- a/src/realm/cuda/cuda_internal.cc
+++ b/src/realm/cuda/cuda_internal.cc
@@ -2223,14 +2223,17 @@ namespace Realm {
       GPU *gpu = checked_cast<GPUreduceChannel *>(channel)->gpu;
       stream = gpu->get_next_d2d_stream();
 
-      std::unordered_map<ReductionOpID, GPU::GPUReductionOpEntry>::const_iterator
-          gpu_red_it = gpu->gpu_reduction_table.find(redop_info.id);
-      if(gpu_red_it != gpu->gpu_reduction_table.end()) {
-        kernel = (redop_info.is_fold
-                      ? (redop_info.is_exclusive ? gpu_red_it->second.fold_excl
-                                                 : gpu_red_it->second.fold_nonexcl)
-                      : (redop_info.is_exclusive ? gpu_red_it->second.apply_excl
-                                                 : gpu_red_it->second.apply_nonexcl));
+      {
+        AutoLock<Mutex> al(gpu->alloc_mutex);
+        std::unordered_map<ReductionOpID, GPU::GPUReductionOpEntry>::const_iterator
+            gpu_red_it = gpu->gpu_reduction_table.find(redop_info.id);
+        if(gpu_red_it != gpu->gpu_reduction_table.end()) {
+          kernel = (redop_info.is_fold
+                        ? (redop_info.is_exclusive ? gpu_red_it->second.fold_excl
+                                                  : gpu_red_it->second.fold_nonexcl)
+                        : (redop_info.is_exclusive ? gpu_red_it->second.apply_excl
+                                                  : gpu_red_it->second.apply_nonexcl));
+        }
       }
 
       if(kernel == nullptr) {
@@ -2621,8 +2624,12 @@ namespace Realm {
       }
 
       // Is this redop in our gpu's reduction table? (i.e. registered with a CUfunc)
-      if(gpu->gpu_reduction_table.find(redop_id) != gpu->gpu_reduction_table.end()) {
-        return true;
+      {
+        // TODO: if we see a performance issue, this is the place where we could investigate
+        AutoLock<Mutex> al(gpu->alloc_mutex);
+        if(gpu->gpu_reduction_table.find(redop_id) != gpu->gpu_reduction_table.end()) {
+          return true;
+        }
       }
 
       // Now check if it was registered along with the host pointer with a valid cuda

--- a/src/realm/runtime_impl.cc
+++ b/src/realm/runtime_impl.cc
@@ -1126,6 +1126,7 @@ namespace Realm {
 
   void RuntimeImpl::add_dma_channel(Channel *c)
   {
+    c->update_channel_state();
     nodes[c->node].dma_channels.push_back(c);
   }
 
@@ -1375,7 +1376,8 @@ namespace Realm {
     RemoteChannelInfo *rci = ch->construct_remote_info();
     bool ok = ((serializer << NODE_ANNOUNCE_DMA_CHANNEL) && (serializer << *rci));
     // TODO: iterate the redop table, check for support and add it here.
-    if(ch->supports_redop(0)) {
+    // ch->has_non_redop_path is used for channels without any paths such as address split channel
+    if(ch->supports_redop(0) && ch->has_non_redop_path) {
       ok = ((serializer << size_t(1)) && (serializer << ReductionOpID(0)));
     } else {
       ok = (serializer << size_t(0));

--- a/src/realm/transfer/channel.cc
+++ b/src/realm/transfer/channel.cc
@@ -3157,11 +3157,12 @@ namespace Realm {
       const std::vector<size_t> *src_frags, const std::vector<size_t> *dst_frags,
       XferDesKind *kind_ret /*= 0*/, unsigned *bw_ret /*= 0*/, unsigned *lat_ret /*= 0*/)
   {
-    Memory src_mem = channel_copy_info.src_mem;
-    Memory dst_mem = channel_copy_info.dst_mem;
     if(!supports_redop(redop_id)) {
       return 0;
     }
+
+    Memory src_mem = channel_copy_info.src_mem;
+    Memory dst_mem = channel_copy_info.dst_mem;
     // If we don't support the indirection memory, then no need to check the paths.
     if((channel_copy_info.ind_mem != Memory::NO_MEMORY) &&
        !supports_indirection_memory(channel_copy_info.ind_mem)) {
@@ -3661,19 +3662,33 @@ namespace Realm {
     return p;
   }
 
+  void Channel::update_channel_state(void)
+  {
+    assert(has_redop_path == false);
+    assert(has_non_redop_path == false);
+
+    for(const SupportedPath &path : paths) {
+      if(path.redops_allowed) {
+        has_redop_path = true;
+      } else {
+        has_non_redop_path = true;
+      }
+
+      // the channel has both redop and non-redop path
+      // early return
+      if (has_redop_path && has_non_redop_path) {
+        return;
+      }
+    }
+  }
+
   bool Channel::supports_redop(ReductionOpID redop_id) const
   {
     if(redop_id == 0) {
       return true;
     }
 
-    for(const SupportedPath &path : paths) {
-      if(path.redops_allowed) {
-        return true;
-      }
-    }
-
-    return false;
+    return has_redop_path;
   }
 
   long Channel::progress_xd(XferDes *xd, long max_nr)
@@ -3900,6 +3915,14 @@ namespace Realm {
 
   bool RemoteChannel::supports_redop(ReductionOpID redop_id) const
   {
+    if (redop_id == 0) {
+      return has_non_redop_path;
+    }
+
+    if (!has_redop_path) {
+      return false;
+    }
+    
     RWLock::AutoReaderLock al(mutex);
     return supported_redops.count(redop_id) != 0;
   }
@@ -3927,10 +3950,6 @@ namespace Realm {
     // simultaneous serialization/deserialization not
     //  allowed anywhere right now
     if((src_serdez_id != 0) && (dst_serdez_id != 0)) {
-      return 0;
-    }
-
-    if(!supports_redop(redop_id)) {
       return 0;
     }
 

--- a/src/realm/transfer/channel.h
+++ b/src/realm/transfer/channel.h
@@ -32,6 +32,7 @@
 #include <vector>
 #include <deque>
 #include <queue>
+#include <unordered_set>
 #include <assert.h>
 #include <string.h>
 
@@ -730,6 +731,12 @@ namespace Realm {
     // the kind of XferDes this channel can accept
     XferDesKind kind;
 
+    // whether the channel has a redop path
+    bool has_redop_path{false};
+
+    // whether the channel has a non-redop path
+    bool has_non_redop_path{false};
+
     virtual bool supports_redop(ReductionOpID redop_id) const;
 
     // attempt to make progress on the specified xferdes
@@ -809,6 +816,8 @@ namespace Realm {
     };
 
     const std::vector<SupportedPath> &get_paths(void) const;
+
+    void update_channel_state(void);
 
     // returns 0 if the path is not supported, or a strictly-positive
     //  estimate of the time required (in nanoseconds) to transfer data
@@ -978,7 +987,7 @@ namespace Realm {
   protected:
     mutable RWLock mutex;
     uintptr_t remote_ptr;
-    std::set<ReductionOpID> supported_redops;
+    std::unordered_set<ReductionOpID> supported_redops;
     SimpleXferDesFactory factory_singleton;
     const std::set<Memory> indirect_memories;
   };

--- a/tests/unit_tests/memcpy_channel_test.cc
+++ b/tests/unit_tests/memcpy_channel_test.cc
@@ -82,6 +82,8 @@ TEST_P(SupportsPathTest, CheckSupportsPath)
   std::unique_ptr<Channel> channel(
       new MemcpyChannel(bgwork, &node, remote_shared_memory_mappings));
 
+  channel->update_channel_state();
+
   uint64_t cost = channel->supports_path(
       ChannelCopyInfo(src_mem->me, dst_mem->me), test_case.src_serdez_id,
       test_case.dst_serdez_id, test_case.redop_id, bytes,


### PR DESCRIPTION
This PR should fix the performance issue of https://github.com/nv-legate/nv-realm/issues/135