### PR TITLE
Kokkos support for multiple instances of each processor type

### DIFF
--- a/src/realm/openmp/openmp_internal.h
+++ b/src/realm/openmp/openmp_internal.h
@@ -42,6 +42,8 @@ namespace Realm {
 
     virtual void shutdown(void);
 
+    int get_num_threads(void) const noexcept;
+
   protected:
     class OpenMPContextManager : public TaskContextManager {
     public:

--- a/src/realm/openmp/openmp_module.cc
+++ b/src/realm/openmp/openmp_module.cc
@@ -106,6 +106,12 @@ namespace Realm {
 #endif
   }
 
+  int LocalOpenMPProcessor::get_num_threads(void) const noexcept
+  {
+    return num_threads;
+  }
+
+
   LocalOpenMPProcessor::~LocalOpenMPProcessor(void) { delete core_rsrv; }
 
   void LocalOpenMPProcessor::shutdown(void)


### PR DESCRIPTION
This branch adds support for executing Kokkos tasks on machines with multiple instances of each processor type. In other words, with this branch, Kokkos tasks can run on machines configured with more than one GPU and/or OpenMP processor. This branch supports older Kokkos versions, but the added capability depends on a minimum Kokkos version of 4.3.0 (for an implementation on all processor types).

The support for multiple OpenMP processors is less developed than the multiple GPU support, and requires further review.

An associated PR on Legion has some tests, but there is no Realm-only test code in this PR.

For OpenMP:

- requires Kokkos v4.0.0, and falls back to previous implementation (including restrictions) otherwise
- implementation should work with either the Realm OpenMP implementation or system OpenMPs
- tested with kokkos_saxpy (in Legion)
- one caveat when using Realm OpenMP: I had some difficulty preventing application code from linking and using the system OpenMP despite my intentions, which I fixed by changing the kokkoscore target properties in the CMakeLists.txt file for the application, but this modification is not part of this PR

For CUDA:

- requires Kokkos v4.3.0, and falls back to previous implementation (including restrictions) otherwise
- tested with kokkos_saxpy (in Legion)