### PR TITLE
fixup a missing header

### DIFF
--- a/src/realm/sparsity.inl
+++ b/src/realm/sparsity.inl
@@ -20,6 +20,7 @@
 // nop, but helps IDEs
 #include "realm/sparsity.h"
 
+#include "realm/logging.h"
 #include "realm/serialize.h"
 
 TEMPLATE_TYPE_IS_SERIALIZABLE2(int N, typename T, Realm::SparsityMap<N, T>);


### PR DESCRIPTION
This is a fixup for the PR https://github.com/StanfordLegion/realm/pull/327. We forgot to include the `logging.h`.

Here is the error message:
```
[  5%] Building CXX object CMakeFiles/realm_obj.dir/src/realm/faults.cc.o
/usr/bin/c++ -DNDEBUG -DREALM_STATIC_DEFINE=1 -D_FORTIFY_SOURCE=2 -I/home/weiwu/realm/src/realm/.. -I/home/weiwu/realm/build/include -isystem /usr/local/cuda/targets/x86_64-linux/include -isystem /home/weiwu/anaconda3/envs/legate-ompi5/include -O3  -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -Wall -Wextra -Wno-unused-parameter -MD -MT CMakeFiles/realm_obj.dir/src/realm/faults.cc.o -MF CMakeFiles/realm_obj.dir/src/realm/faults.cc.o.d -o CMakeFiles/realm_obj.dir/src/realm/faults.cc.o -c /home/weiwu/realm/src/realm/faults.cc
In file included from /home/weiwu/realm/src/realm/../realm/realm_config.h:28,
                 from /home/weiwu/realm/src/realm/../realm/realm_c.h:24,
                 from /home/weiwu/realm/src/realm/../realm/event.h:23,
                 from /home/weiwu/realm/src/realm/../realm/faults.h:24,
                 from /home/weiwu/realm/src/realm/faults.cc:20:
/home/weiwu/realm/src/realm/../realm/compiler_support.h: In member function ‘const std::vector<Realm::SparsityMapEntry<N, T> >& Realm::SparsityMapPublicImpl<N, T>::get_entries()’:
/home/weiwu/realm/src/realm/../realm/compiler_support.h:100:17: error: ‘Realm::log_runtime’ has incomplete type
  100 |   extern Logger log_runtime;
      |                 ^~~~~~~~~~~
/home/weiwu/realm/src/realm/../realm/compiler_support.h:99:9: note: forward declaration of ‘class Realm::Logger’
   99 |   class Logger;
      |         ^~~~~~
/home/weiwu/realm/src/realm/../realm/compiler_support.h: In member function ‘const std::vector<Realm::Rect<N, T> >& Realm::SparsityMapPublicImpl<N, T>::get_approx_rects()’:
/home/weiwu/realm/src/realm/../realm/compiler_support.h:100:17: error: ‘Realm::log_runtime’ has incomplete type
  100 |   extern Logger log_runtime;
      |                 ^~~~~~~~~~~
/home/weiwu/realm/src/realm/../realm/compiler_support.h:99:9: note: forward declaration of ‘class Realm::Logger’
   99 |   class Logger;
      |         ^~~~~~
make[3]: *** [CMakeFiles/realm_obj.dir/build.make:247: CMakeFiles/realm_obj.dir/src/realm/faults.cc.o] Error 1
```