### PR TITLE
fixup the assert from activemsg to dynamic_template

### DIFF
--- a/src/realm/activemsg.cc
+++ b/src/realm/activemsg.cc
@@ -56,7 +56,7 @@ namespace Realm {
       start = static_cast<char *>(start) + step;
       ofs += step;
     }
-    assert(ofs == bytes);
+    REALM_ASSERT(ofs == bytes);
   }
 
   /*static*/ void CompletionCallbackBase::clone_all(void *dst, const void *src,
@@ -71,7 +71,7 @@ namespace Realm {
       dst = static_cast<char *>(dst) + step;
       ofs += step;
     }
-    assert(ofs == bytes);
+    REALM_ASSERT(ofs == bytes);
   }
 
   /*static*/ void CompletionCallbackBase::destroy_all(void *start, size_t bytes)
@@ -84,7 +84,7 @@ namespace Realm {
       start = static_cast<char *>(start) + step;
       ofs += step;
     }
-    assert(ofs == bytes);
+    REALM_ASSERT(ofs == bytes);
   }
 
   ////////////////////////////////////////////////////////////////////////
@@ -123,14 +123,14 @@ namespace Realm {
   ActiveMessageHandlerTable::HandlerEntry *
   ActiveMessageHandlerTable::lookup_message_handler(MessageID id)
   {
-    assert(id < handlers.size());
+    REALM_ASSERT(id < handlers.size());
     return &handlers[id];
   }
 
   const char *
   ActiveMessageHandlerTable::lookup_message_name(ActiveMessageHandlerTable::MessageID id)
   {
-    assert(id < handlers.size());
+    REALM_ASSERT(id < handlers.size());
     return handlers[id].name;
   }
 
@@ -138,7 +138,7 @@ namespace Realm {
                                                               long long t_start,
                                                               long long t_end)
   {
-    assert(id < handlers.size());
+    REALM_ASSERT(id < handlers.size());
     handlers[id].stats.record(t_start, t_end);
   }
 
@@ -188,7 +188,7 @@ namespace Realm {
       e.extract_frag_info = nextreg->extract_frag_info;
       e.handler_notimeout = nextreg->get_handler_notimeout();
       // at least one of the two above must be non-null
-      assert((e.handler != 0) || (e.handler_notimeout != 0));
+      REALM_ASSERT((e.handler != 0) || (e.handler_notimeout != 0));
       e.handler_inline = nextreg->get_handler_inline();
       handlers.push_back(e);
     }
@@ -216,7 +216,7 @@ namespace Realm {
   IncomingMessageManager::MessageBlock::new_block(size_t _total_size)
   {
     void *ptr = malloc(_total_size);
-    assert(ptr != 0);
+    REALM_ASSERT(ptr != 0);
     MessageBlock *block = new(ptr) MessageBlock;
     block->total_size = _total_size;
     block->next_free = 0;
@@ -281,7 +281,7 @@ namespace Realm {
       return msg;
     } else {
       // would it have ever fit?
-      assert((new_used - size_used) <= (total_size - sizeof(MessageBlock)));
+      REALM_ASSERT((new_used - size_used) <= (total_size - sizeof(MessageBlock)));
 
       // return failure - caller will find a new block
       return 0;
@@ -415,7 +415,7 @@ namespace Realm {
         }
 
         bool ok = it->second->add_chunk(frag_info.chunk_id, payload, payload_size);
-        assert(ok);
+        REALM_ASSERT(ok);
 
         if(!it->second->is_complete()) {
           total_messages_handled += 1;
@@ -489,7 +489,7 @@ namespace Realm {
           current_block->reset();
           log_amhandler.debug() << "reusing message block: " << current_block;
         } else {
-          assert(available_blocks != 0);
+          REALM_ASSERT(available_blocks != 0);
           current_block = available_blocks;
           available_blocks = available_blocks->next_free;
           current_block->next_free = 0;
@@ -499,7 +499,7 @@ namespace Realm {
 
         // either way, this must now succeed
         msg = current_block->append_message(hdr_bytes_needed, payload_bytes_needed);
-        assert(msg != 0);
+        REALM_ASSERT(msg != 0);
         break;
       }
 
@@ -543,7 +543,7 @@ namespace Realm {
 
     if(heads[sender]) {
       // tack this on to the existing list
-      assert(tails[sender]);
+      REALM_ASSERT(tails[sender]);
       *(tails[sender]) = msg;
       tails[sender] = &(msg->next_msg);
     } else {
@@ -559,7 +559,7 @@ namespace Realm {
         todo_newest++;
         if(todo_newest > nodes)
           todo_newest = 0;
-        assert(todo_newest != todo_oldest); // should never wrap around
+        REALM_ASSERT(todo_newest != todo_oldest); // should never wrap around
         if(sleeper_count > 0)
           condvar.broadcast(); // wake up any sleepers
 
@@ -699,7 +699,7 @@ namespace Realm {
       todo_newest++;
       if(todo_newest > nodes)
         todo_newest = 0;
-      assert(todo_newest != todo_oldest); // should never wrap around
+      REALM_ASSERT(todo_newest != todo_oldest); // should never wrap around
       if(sleeper_count > 0)
         condvar.broadcast(); // wake up any sleepers
 
@@ -734,7 +734,7 @@ namespace Realm {
     // we're here because there was work to do, so an empty list is bad unless
     //  there are also dedicated threads that might have grabbed it
     if(sender == -1) {
-      assert(dedicated_threads > 0);
+      REALM_ASSERT(dedicated_threads > 0);
       return false;
     }
 

--- a/src/realm/activemsg.inl
+++ b/src/realm/activemsg.inl
@@ -50,7 +50,7 @@ namespace Realm {
   void ActiveMessage<T, INLINE_STORAGE>::init(NodeID _target,
                                               size_t _max_payload_size /*= 0*/)
   {
-    assert(impl == 0);
+    REALM_ASSERT(impl == 0);
     unsigned short msgid = activemsg_handler_table.lookup_message_id<T>();
     impl = Network::create_active_message_impl(_target, msgid, sizeof(T),
                                                _max_payload_size, 0, 0, 0,
@@ -72,7 +72,7 @@ namespace Realm {
   void ActiveMessage<T, INLINE_STORAGE>::init(NodeID _target, size_t _max_payload_size,
                                               const RemoteAddress &_dest_payload_addr)
   {
-    assert(impl == 0);
+    REALM_ASSERT(impl == 0);
     unsigned short msgid = activemsg_handler_table.lookup_message_id<T>();
     impl = Network::create_active_message_impl(_target, msgid, sizeof(T),
                                                _max_payload_size, _dest_payload_addr,
@@ -93,7 +93,7 @@ namespace Realm {
   void ActiveMessage<T, INLINE_STORAGE>::init(const Realm::NodeSet &_targets,
                                               size_t _max_payload_size /*= 0*/)
   {
-    assert(impl == 0);
+    REALM_ASSERT(impl == 0);
     unsigned short msgid = activemsg_handler_table.lookup_message_id<T>();
     impl = Network::create_active_message_impl(_targets, msgid, sizeof(T),
                                                _max_payload_size, 0, 0, 0,
@@ -114,7 +114,7 @@ namespace Realm {
   void ActiveMessage<T, INLINE_STORAGE>::init(NodeID _target, const void *_data,
                                               size_t _datalen)
   {
-    assert(impl == 0);
+    REALM_ASSERT(impl == 0);
     unsigned short msgid = activemsg_handler_table.lookup_message_id<T>();
     impl =
         Network::create_active_message_impl(_target, msgid, sizeof(T), _datalen, _data, 0,
@@ -138,7 +138,7 @@ namespace Realm {
                                               size_t _datalen,
                                               const RemoteAddress &_dest_payload_addr)
   {
-    assert(impl == 0);
+    REALM_ASSERT(impl == 0);
     unsigned short msgid = activemsg_handler_table.lookup_message_id<T>();
     impl = Network::create_active_message_impl(
         _target, msgid, sizeof(T), _datalen, _src_payload_addr, 0, 0, _dest_payload_addr,
@@ -158,7 +158,7 @@ namespace Realm {
   void ActiveMessage<T, INLINE_STORAGE>::init(const Realm::NodeSet &_targets,
                                               const void *_data, size_t _datalen)
   {
-    assert(impl == 0);
+    REALM_ASSERT(impl == 0);
     unsigned short msgid = activemsg_handler_table.lookup_message_id<T>();
     impl = Network::create_active_message_impl(_targets, msgid, sizeof(T), _datalen,
                                                _data, 0, 0, &inline_capacity,
@@ -180,7 +180,7 @@ namespace Realm {
                                               size_t _bytes_per_line, size_t _lines,
                                               size_t _line_stride)
   {
-    assert(impl == 0);
+    REALM_ASSERT(impl == 0);
     unsigned short msgid = activemsg_handler_table.lookup_message_id<T>();
     impl = Network::create_active_message_impl(
         _target, msgid, sizeof(T), _bytes_per_line * _lines, _data, _lines, _line_stride,
@@ -207,7 +207,7 @@ namespace Realm {
                                               size_t _line_stride,
                                               const RemoteAddress &_dest_payload_addr)
   {
-    assert(impl == 0);
+    REALM_ASSERT(impl == 0);
     unsigned short msgid = activemsg_handler_table.lookup_message_id<T>();
     impl = Network::create_active_message_impl(
         _target, msgid, sizeof(T), _bytes_per_line * _lines, _src_payload_addr, _lines,
@@ -230,7 +230,7 @@ namespace Realm {
                                               const void *_data, size_t _bytes_per_line,
                                               size_t _lines, size_t _line_stride)
   {
-    assert(impl == 0);
+    REALM_ASSERT(impl == 0);
     unsigned short msgid = activemsg_handler_table.lookup_message_id<T>();
     impl = Network::create_active_message_impl(
         _targets, msgid, sizeof(T), _bytes_per_line * _lines, _data, _lines, _line_stride,
@@ -241,7 +241,7 @@ namespace Realm {
   template <typename T, size_t INLINE_STORAGE>
   ActiveMessage<T, INLINE_STORAGE>::~ActiveMessage(void)
   {
-    assert(impl == 0);
+    REALM_ASSERT(impl == 0);
   }
 
   template <typename T, size_t INLINE_STORAGE>
@@ -325,7 +325,7 @@ namespace Realm {
                                                      int payload_mode /*= PAYLOAD_COPY*/)
   {
     bool ok = fbs.append_bytes(data, datalen);
-    assert(ok);
+    REALM_ASSERT(ok);
     if(payload_mode == PAYLOAD_FREE)
       free(const_cast<void *>(data));
   }
@@ -339,12 +339,12 @@ namespace Realm {
     // detect case where 2d collapses to 1d
     if(line_stride == bytes_per_line) {
       bool ok = fbs.append_bytes(data, bytes_per_line * lines);
-      assert(ok);
+      REALM_ASSERT(ok);
     } else {
       for(size_t i = 0; i < lines; i++) {
         bool ok = fbs.append_bytes((static_cast<const char *>(data) + (i * line_stride)),
                                    bytes_per_line);
-        assert(ok);
+        REALM_ASSERT(ok);
       }
     }
     if(payload_mode == PAYLOAD_FREE)
@@ -367,7 +367,7 @@ namespace Realm {
   template <typename CALLABLE>
   void ActiveMessage<T, INLINE_STORAGE>::add_local_completion(const CALLABLE &callable)
   {
-    assert(impl != 0);
+    REALM_ASSERT(impl != 0);
 
     size_t bytes = sizeof(CompletionCallback<CALLABLE>);
     // round up
@@ -381,7 +381,7 @@ namespace Realm {
   template <typename CALLABLE>
   void ActiveMessage<T, INLINE_STORAGE>::add_remote_completion(const CALLABLE &callable)
   {
-    assert(impl != 0);
+    REALM_ASSERT(impl != 0);
 
     size_t bytes = sizeof(CompletionCallback<CALLABLE>);
     // round up
@@ -395,7 +395,7 @@ namespace Realm {
   template <typename T, size_t INLINE_STORAGE>
   void ActiveMessage<T, INLINE_STORAGE>::commit(void)
   {
-    assert(impl != 0);
+    REALM_ASSERT(impl != 0);
 
     size_t act_payload_len;
     if(impl->payload_size)
@@ -414,7 +414,7 @@ namespace Realm {
   template <typename T, size_t INLINE_STORAGE>
   void ActiveMessage<T, INLINE_STORAGE>::cancel(void)
   {
-    assert(impl != 0);
+    REALM_ASSERT(impl != 0);
     impl->cancel();
 
     // now tear things down
@@ -444,7 +444,7 @@ namespace Realm {
   {
     // double-check that our alignment is satisfactory
 #ifdef DEBUG_REALM
-    assert(REALM_ALIGNOF(CompletionCallback<CALLABLE>) <= ALIGNMENT);
+    REALM_ASSERT(REALM_ALIGNOF(CompletionCallback<CALLABLE>) <= ALIGNMENT);
 #endif
     size_t bytes = sizeof(CompletionCallback<CALLABLE>);
     // round up to ALIGNMENT boundary
@@ -488,7 +488,7 @@ namespace Realm {
         return mid;
     }
 
-    assert(0);
+    abort();
     return 0;
   }
 

--- a/src/realm/bgwork.cc
+++ b/src/realm/bgwork.cc
@@ -173,7 +173,7 @@ namespace Realm {
 
   BackgroundWorkManager::~BackgroundWorkManager(void)
   {
-    assert(dedicated_workers.empty());
+    REALM_ASSERT(dedicated_workers.empty());
   }
 
   unsigned BackgroundWorkManager::assign_slot(BackgroundWorkItem *item)
@@ -181,10 +181,10 @@ namespace Realm {
     AutoLock<> al(mutex);
     // TODO: reuse slots
     unsigned slot = num_work_items.load();
-    assert(slot < MAX_WORK_ITEMS);
+    REALM_ASSERT(slot < MAX_WORK_ITEMS);
     work_items[slot] = item;
     int prev = work_item_usecounts[slot].fetch_add_acqrel(1);
-    assert(prev == 0);
+    REALM_ASSERT(prev == 0);
     (void)prev;
     num_work_items.store_release(slot + 1);
     return slot;
@@ -196,7 +196,7 @@ namespace Realm {
     unsigned elem = slot / BITMASK_BITS;
     unsigned ofs = slot % BITMASK_BITS;
     BitMask mask = BitMask(1) << ofs;
-    assert((active_work_item_mask[elem].load() & mask) == 0);
+    REALM_ASSERT((active_work_item_mask[elem].load() & mask) == 0);
 
     // use count has to change from 1 (i.e. we are only remaining user)
     //  to 0 _before_ we enter critical section
@@ -265,7 +265,7 @@ namespace Realm {
         .add_option_int("-ll:bgslice", cfg.work_item_timeslice);
 
     bool ok = cp.parse_command_line(cmdline);
-    assert(ok);
+    REALM_ASSERT(ok);
   }
 
   void BackgroundWorkManager::start_dedicated_workers(Realm::CoreReservationSet &crs)
@@ -513,7 +513,7 @@ namespace Realm {
           // slot pointer is valid and can't change until we decrement the
           //  use count again
           BackgroundWorkItem *item = manager->work_items[unknown_slot];
-          assert(item != 0);
+          REALM_ASSERT(item != 0);
 
           bool allowed = true;
 
@@ -573,7 +573,7 @@ namespace Realm {
           //  an invalid slot because we have claimed a work request and
           //  not ack'd it yet
           int prev_usecount = manager->work_item_usecounts[slot].fetch_add_acqrel(1);
-          assert(prev_usecount > 0);
+          REALM_ASSERT(prev_usecount > 0);
           (void)prev_usecount;
 
           BackgroundWorkItem *item = manager->work_items[slot];

--- a/src/realm/bytearray.inl
+++ b/src/realm/bytearray.inl
@@ -20,9 +20,10 @@
 // this is a nop, but it's for the benefit of IDEs trying to parse this file
 #include "realm/bytearray.h"
 
+#include "realm/logging.h"
+
 #include <string.h>
 #include <stdlib.h>
-#include <assert.h>
 
 // for std::swap
 #include <algorithm>

--- a/src/realm/bytearray.inl
+++ b/src/realm/bytearray.inl
@@ -67,7 +67,7 @@ namespace Realm {
   const T &ByteArrayRef::at(size_t offset) const
   {
     // always range check?
-    assert((offset + sizeof(T)) <= array_size);
+    REALM_ASSERT((offset + sizeof(T)) <= array_size);
     return *static_cast<const T *>(static_cast<char *>(array_base) + offset);
   }
 
@@ -147,7 +147,7 @@ namespace Realm {
   T &ByteArray::at(size_t offset)
   {
     // always range check?
-    assert((offset + sizeof(T)) <= array_size);
+    REALM_ASSERT((offset + sizeof(T)) <= array_size);
     return *static_cast<T *>(static_cast<char *>(array_base) + offset);
   }
 
@@ -155,7 +155,7 @@ namespace Realm {
   const T &ByteArray::at(size_t offset) const
   {
     // always range check?
-    assert((offset + sizeof(T)) <= array_size);
+    REALM_ASSERT((offset + sizeof(T)) <= array_size);
     return *static_cast<const T *>(static_cast<char *>(array_base) + offset);
   }
 
@@ -165,7 +165,7 @@ namespace Realm {
     clear(); // throw away any data we had before
     if(new_size) {
       array_base = new_base;
-      assert(array_base != 0);
+      REALM_ASSERT(array_base != 0);
       array_size = new_size;
     } else {
       // if we were given ownership of a 0-length allocation, free it rather than leaking
@@ -180,7 +180,7 @@ namespace Realm {
   {
     if(copy_size) {
       array_base = malloc(copy_size);
-      assert(array_base != 0);
+      REALM_ASSERT(array_base != 0);
       memcpy(array_base, copy_base, copy_size);
       array_size = copy_size;
     } else {
@@ -234,7 +234,7 @@ namespace Realm {
     void *new_base = 0;
     if(new_size) {
       new_base = malloc(new_size);
-      assert(new_base != 0);
+      REALM_ASSERT(new_base != 0);
       if(!serdez.extract_bytes(new_base, new_size)) {
         free(new_base); // no leaks plz
         return false;

--- a/src/realm/caching_allocator.h
+++ b/src/realm/caching_allocator.h
@@ -85,7 +85,7 @@ namespace Realm {
 
       ~Block()
       {
-        assert((num_alloced_chunks.load() == 0) && "Not all chunks have been freed!");
+        REALM_ASSERT((num_alloced_chunks.load() == 0) && "Not all chunks have been freed!");
         // If we're part of the global list, make sure to clean up the rest of the
         // list (only done on process exit)
         if(block_link.next != nullptr) {
@@ -102,12 +102,12 @@ namespace Realm {
           // All full up, the block is now flagged for reclaimation
           return nullptr;
         } else {
-          assert((expected_full_size >= 0) &&
+          REALM_ASSERT((expected_full_size >= 0) &&
                  "Tried to allocate from a block marked for reclaimation!");
         }
 
         old_head = free_chunk_head.load_acquire();
-        assert((old_head != nullptr) && "Non-empty block with no free chunks!");
+        REALM_ASSERT((old_head != nullptr) && "Non-empty block with no free chunks!");
 
         // Only the owning thread can pop off the free list, so no ABA issue here
         // and we know from num_alloced_chunks that there must at least be one
@@ -189,7 +189,7 @@ namespace Realm {
         }
         if(newblk != nullptr) {
           obj = newblk->alloc_obj();
-          assert((obj != nullptr) && "Newly acquired block can't allocate!");
+          REALM_ASSERT((obj != nullptr) && "Newly acquired block can't allocate!");
           current_block.release();
           current_block.reset(newblk);
         }

--- a/src/realm/circ_queue.inl
+++ b/src/realm/circ_queue.inl
@@ -172,7 +172,7 @@ namespace Realm {
   {
     // check for full-ness
     if(current_size == max_size) {
-      assert(growth_factor != 0);
+      REALM_ASSERT(growth_factor != 0);
       if(growth_factor > 0)
         reserve(max_size + growth_factor);
       else if(max_size > 0)
@@ -195,7 +195,7 @@ namespace Realm {
   template <typename T, unsigned INTSIZE>
   inline void CircularQueue<T, INTSIZE>::pop_front(void)
   {
-    assert(current_size > 0);
+    REALM_ASSERT(current_size > 0);
 
     // destruct existing entry
     T *ptr = item_ptr(external_buffer ? external_buffer : internal_buffer, head);
@@ -226,7 +226,7 @@ namespace Realm {
   {
     // check for full-ness
     if(current_size == max_size) {
-      assert(growth_factor != 0);
+      REALM_ASSERT(growth_factor != 0);
       if(growth_factor > 0)
         reserve(max_size + growth_factor);
       else if(max_size > 0)
@@ -249,7 +249,7 @@ namespace Realm {
   template <typename T, unsigned INTSIZE>
   inline void CircularQueue<T, INTSIZE>::pop_back(void)
   {
-    assert(current_size > 0);
+    REALM_ASSERT(current_size > 0);
 
     // destruct existing entry
     T *ptr = item_ptr(external_buffer ? external_buffer : internal_buffer, tail);
@@ -270,7 +270,7 @@ namespace Realm {
     if((current_size > 0) && (external_buffer == 0)) {
       if((swap_with.current_size > 0) && (swap_with.external_buffer == 0)) {
         // both sides have valid data - yuck
-        assert(0);
+        abort();
       } else {
         // copy items from *this to swap_with
         size_t p = head;
@@ -321,7 +321,7 @@ namespace Realm {
   inline void CircularQueue<T, INTSIZE>::swap(CircularQueue<T, INTSIZE2> &swap_with)
   {
     // not yet implemented
-    assert(0);
+    abort();
   }
 
   template <typename T, unsigned INTSIZE>
@@ -422,7 +422,7 @@ namespace Realm {
   template <typename T, unsigned INTSIZE>
   inline T CircularQueueIterator<T, INTSIZE>::operator*(void)
   {
-    assert(cq && !at_end);
+    REALM_ASSERT(cq && !at_end);
     return *(cq->item_ptr(cq->external_buffer ? cq->external_buffer : cq->internal_buffer,
                           pos));
   }
@@ -430,7 +430,7 @@ namespace Realm {
   template <typename T, unsigned INTSIZE>
   inline const T *CircularQueueIterator<T, INTSIZE>::operator->(void)
   {
-    assert(cq && !at_end);
+    REALM_ASSERT(cq && !at_end);
     return (cq->item_ptr(cq->external_buffer ? cq->external_buffer : cq->internal_buffer,
                          pos));
   }
@@ -439,7 +439,7 @@ namespace Realm {
   CircularQueueIterator<T, INTSIZE> &
       CircularQueueIterator<T, INTSIZE>::operator++(/*prefix*/)
   {
-    assert(cq && !at_end);
+    REALM_ASSERT(cq && !at_end);
     if(pos == cq->tail) {
       at_end = true;
     } else {
@@ -456,7 +456,7 @@ namespace Realm {
   CircularQueueIterator<T, INTSIZE>::operator++(int /*postfix*/)
   {
     CircularQueueIterator<T, INTSIZE> orig(*this);
-    assert(cq && !at_end);
+    REALM_ASSERT(cq && !at_end);
     if(pos == cq->tail) {
       at_end = true;
     } else {

--- a/src/realm/codedesc.cc
+++ b/src/realm/codedesc.cc
@@ -351,7 +351,7 @@ namespace Realm {
     if(target_impl_type == typeid(FunctionPointerImplementation)) {
       const DSOReferenceImplementation *dsoref =
           dynamic_cast<const DSOReferenceImplementation *>(source);
-      assert(dsoref != 0);
+      REALM_ASSERT(dsoref != 0);
 
       void *handle = 0;
       // check to see if we've already loaded the module?
@@ -385,7 +385,7 @@ namespace Realm {
     if(target_impl_type == typeid(DSOReferenceImplementation)) {
       const FunctionPointerImplementation *fpi =
           dynamic_cast<const FunctionPointerImplementation *>(source);
-      assert(fpi != 0);
+      REALM_ASSERT(fpi != 0);
 
       return dladdr_helper((void *)(fpi->fnptr), false /*!quiet*/);
     }

--- a/src/realm/codedesc.inl
+++ b/src/realm/codedesc.inl
@@ -608,7 +608,7 @@ namespace Realm {
   inline CodeDescriptor::CodeDescriptor(T fnptr)
     : m_type(TypeConv::from_cpp_type<T>())
   {
-    assert(m_type.is<FunctionPointerType>());
+    REALM_ASSERT(m_type.is<FunctionPointerType>());
     FunctionPointerImplementation *fpi =
         new FunctionPointerImplementation(reinterpret_cast<void (*)()>(fnptr));
     m_impls.push_back(fpi);

--- a/src/realm/custom_serdez.h
+++ b/src/realm/custom_serdez.h
@@ -115,7 +115,7 @@ namespace Realm {
     {
       Serialization::ByteCountSerializer bcs;
       bool ok = (bcs << (*val));
-      assert(ok);
+      REALM_ASSERT(ok);
       return bcs.bytes_used();
     }
 
@@ -125,7 +125,7 @@ namespace Realm {
       size_t max_size = size_t(-1) - reinterpret_cast<size_t>(buffer);
       Serialization::FixedBufferSerializer fbs(buffer, max_size);
       bool ok = (fbs << *val);
-      assert(ok);
+      REALM_ASSERT(ok);
       return max_size -
              fbs.bytes_left(); // because we didn't really tell it how many bytes we had
     }
@@ -137,7 +137,7 @@ namespace Realm {
       size_t max_size = size_t(-1) - reinterpret_cast<size_t>(buffer);
       Serialization::FixedBufferDeserializer fbd(buffer, max_size);
       bool ok = (fbd >> (*val));
-      assert(ok);
+      REALM_ASSERT(ok);
       return max_size - fbd.bytes_left();
     }
 

--- a/src/realm/dynamic_table.inl
+++ b/src/realm/dynamic_table.inl
@@ -179,7 +179,7 @@ namespace Realm {
                                                                      int level)
   {
 #ifdef DEBUG_REALM
-    assert(((reinterpret_cast<intptr_t>(root) & 7) == 0) && (level >= 0) && (level <= 7));
+    REALM_ASSERT(((reinterpret_cast<intptr_t>(root) & 7) == 0) && (level >= 0) && (level <= 7));
 #endif
     return (reinterpret_cast<intptr_t>(root) | level);
   }
@@ -255,7 +255,7 @@ namespace Realm {
     if(rlval == 0)
       return false; // empty tree
 #ifdef DEBUG_REALM
-    assert(extract_root(rlval)->level == extract_level(rlval));
+    REALM_ASSERT(extract_root(rlval)->level == extract_level(rlval));
 #endif
     int n_level = extract_level(rlval);
     if(n_level < level_needed)
@@ -264,14 +264,14 @@ namespace Realm {
 
 #ifdef DEBUG_REALM
     // when we get here, root is high enough
-    assert((level_needed <= n->level) && (index >= n->first_index) &&
+    REALM_ASSERT((level_needed <= n->level) && (index >= n->first_index) &&
            (index <= n->last_index));
 #endif
 
     // now walk tree, populating the path we need
     while(n_level > 0) {
 #ifdef DEBUG_REALM
-      assert(n_level == n->level);
+      REALM_ASSERT(n_level == n->level);
 #endif
       // intermediate nodes
       typename ALLOCATOR::INNER_TYPE *inner =
@@ -280,7 +280,7 @@ namespace Realm {
       IT i = ((index >> (ALLOCATOR::LEAF_BITS + (n->level - 1) * ALLOCATOR::INNER_BITS)) &
               ((((IT)1) << ALLOCATOR::INNER_BITS) - 1));
 #ifdef DEBUG_REALM
-      assert(((size_t)i) < ALLOCATOR::INNER_TYPE::SIZE);
+      REALM_ASSERT(((size_t)i) < ALLOCATOR::INNER_TYPE::SIZE);
 #endif
 
       NodeBase *child = inner->elems[i].load_acquire();
@@ -288,7 +288,7 @@ namespace Realm {
         return false;
       }
 #ifdef DEBUG_REALM
-      assert((child != 0) && (child->level == (n_level - 1)) &&
+      REALM_ASSERT((child != 0) && (child->level == (n_level - 1)) &&
              (index >= child->first_index) && (index <= child->last_index));
 #endif
       n = child;
@@ -320,7 +320,7 @@ namespace Realm {
     NodeBase *n = extract_root(rlval);
     int n_level = extract_level(rlval);
 #ifdef DEBUG_REALM
-    assert(!n || (n_level == n->level));
+    REALM_ASSERT(!n || (n_level == n->level));
 #endif
     if(!n || (n_level < level_needed)) {
       // root doesn't appear to be high enough - take lock and fix it if it's really
@@ -362,14 +362,14 @@ namespace Realm {
     }
 #ifdef DEBUG_REALM
     // when we get here, root is high enough
-    assert((level_needed <= n->level) && (index >= n->first_index) &&
+    REALM_ASSERT((level_needed <= n->level) && (index >= n->first_index) &&
            (index <= n->last_index));
 #endif
 
     // now walk tree, populating the path we need
     while(n_level > 0) {
 #ifdef DEBUG_REALM
-      assert(n_level == n->level);
+      REALM_ASSERT(n_level == n->level);
 #endif
       // intermediate nodes
       typename ALLOCATOR::INNER_TYPE *inner =
@@ -378,7 +378,7 @@ namespace Realm {
       IT i = ((index >> (ALLOCATOR::LEAF_BITS + (n->level - 1) * ALLOCATOR::INNER_BITS)) &
               ((((IT)1) << ALLOCATOR::INNER_BITS) - 1));
 #ifdef DEBUG_REALM
-      assert(((size_t)i) < ALLOCATOR::INNER_TYPE::SIZE);
+      REALM_ASSERT(((size_t)i) < ALLOCATOR::INNER_TYPE::SIZE);
 #endif
 
       NodeBase *child = inner->elems[i].load_acquire();
@@ -406,7 +406,7 @@ namespace Realm {
         inner->lock.unlock();
       }
 #ifdef DEBUG_REALM
-      assert((child != 0) && (child->level == (n_level - 1)) &&
+      REALM_ASSERT((child != 0) && (child->level == (n_level - 1)) &&
              (index >= child->first_index) && (index <= child->last_index));
 #endif
       n = child;
@@ -440,7 +440,7 @@ namespace Realm {
     , first_free(0)
     , next_alloc(0)
   {
-    assert((parent_list == nullptr) || (parent_list->parent_list == nullptr));
+    REALM_ASSERT((parent_list == nullptr) || (parent_list->parent_list == nullptr));
     ALLOCATOR::register_freelist(this);
   }
 
@@ -448,7 +448,7 @@ namespace Realm {
   void
   DynamicTableFreeList<ALLOCATOR>::push_front(DynamicTableFreeList<ALLOCATOR>::ET *entry)
   {
-    assert(entry->next_free == nullptr);
+    REALM_ASSERT(entry->next_free == nullptr);
     // no need for lock - use compare and swap to push item onto front of
     //  free list (no ABA problem because the popper is mutex'd)
     DynamicTableFreeList<ALLOCATOR>::ET *old_free = first_free.load_acquire();
@@ -532,7 +532,7 @@ namespace Realm {
       // Can't use dummy here since it may have been already allocated and used elsewhere.
       // Only the items pushed in the free list as a symptom of the lookup are freely
       // available.
-      assert(dummy != 0);
+      REALM_ASSERT(dummy != 0);
       (void)dummy;
       // No one is using the returned list, so we can freely pop the head off and push the
       // rest onto this list for later

--- a/src/realm/dynamic_templates.inl
+++ b/src/realm/dynamic_templates.inl
@@ -121,7 +121,7 @@ namespace Realm {
     template <typename T1>
     inline /*static*/ void TypeListTerm::DemuxHelper<TARGET, N>::demux(int index, T1 arg1)
     {
-      assert(0);
+      abort();
     }
 
     template <typename TARGET, int N>
@@ -129,7 +129,7 @@ namespace Realm {
     inline /*static*/ void TypeListTerm::DemuxHelper<TARGET, N>::demux(int index, T1 arg1,
                                                                        T2 arg2)
     {
-      assert(0);
+      abort();
     }
 
     template <typename TARGET, int N>
@@ -137,7 +137,7 @@ namespace Realm {
     inline /*static*/ void TypeListTerm::DemuxHelper<TARGET, N>::demux(int index, T1 arg1,
                                                                        T2 arg2, T3 arg3)
     {
-      assert(0);
+      abort();
     }
 
     template <typename TARGET, int N>
@@ -146,7 +146,7 @@ namespace Realm {
                                                                        T2 arg2, T3 arg3,
                                                                        T4 arg4)
     {
-      assert(0);
+      abort();
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -157,7 +157,7 @@ namespace Realm {
     template <typename TARGET, typename T1>
     inline /*static*/ void IntList<MIN, MAX>::demux(int index, T1 arg1)
     {
-      assert((MIN <= index) && (index <= MAX));
+      REALM_ASSERT((MIN <= index) && (index <= MAX));
       IntDemuxHelper<TARGET, MIN, MAX - MIN>::template demux<T1>(index, arg1);
     }
 
@@ -165,7 +165,7 @@ namespace Realm {
     template <typename TARGET, typename T1, typename T2>
     inline /*static*/ void IntList<MIN, MAX>::demux(int index, T1 arg1, T2 arg2)
     {
-      assert((MIN <= index) && (index <= MAX));
+      REALM_ASSERT((MIN <= index) && (index <= MAX));
       IntDemuxHelper<TARGET, MIN, MAX - MIN>::template demux<T1, T2>(index, arg1, arg2);
     }
 
@@ -173,7 +173,7 @@ namespace Realm {
     template <typename TARGET, typename T1, typename T2, typename T3>
     inline /*static*/ void IntList<MIN, MAX>::demux(int index, T1 arg1, T2 arg2, T3 arg3)
     {
-      assert((MIN <= index) && (index <= MAX));
+      REALM_ASSERT((MIN <= index) && (index <= MAX));
       IntDemuxHelper<TARGET, MIN, MAX - MIN>::template demux<T1, T2, T3>(index, arg1,
                                                                          arg2, arg3);
     }
@@ -183,7 +183,7 @@ namespace Realm {
     inline /*static*/ void IntList<MIN, MAX>::demux(int index, T1 arg1, T2 arg2, T3 arg3,
                                                     T4 arg4)
     {
-      assert((MIN <= index) && (index <= MAX));
+      REALM_ASSERT((MIN <= index) && (index <= MAX));
       IntDemuxHelper<TARGET, MIN, MAX - MIN>::template demux<T1, T2, T3, T4>(
           index, arg1, arg2, arg3, arg4);
     }


### PR DESCRIPTION
Start from `activemsg.cc` to `dynamic_templates.inl`, except for the barrier, which is in another PR https://github.com/StanfordLegion/realm/pull/352.