### PR TITLE
fixup the assert: we should check wether the REALM_ASSERT is used by a device function

### DIFF
--- a/src/realm/compiler_support.h
+++ b/src/realm/compiler_support.h
@@ -102,7 +102,8 @@ namespace Realm {
 
 // REALM_ASSERT(cond) - abort program if 'cond' is not true
 #ifdef NDEBUG
-#if (defined(__CUDACC__) && defined(__CUDA_ARCH__)) || (defined(__HIPCC__) && defined(__HIP_DEVICE_COMPILE__))
+#if(defined(__CUDACC__) && defined(__CUDA_ARCH__)) ||                                    \
+    (defined(__HIPCC__) && defined(__HIP_DEVICE_COMPILE__))
 #define REALM_ASSERT(cond)                                                               \
   do {                                                                                   \
     if(!(cond)) {                                                                        \


### PR DESCRIPTION
This PR fixes the error:
```
[ 94%] Building CUDA object tests/CMakeFiles/test_profiling.dir/test_profiling_gpu.cu.o
cd /home/weiwu/realm/build/tests && /usr/local/cuda/bin/nvcc -forward-unknown-to-host-compiler -DREALM_STATIC_DEFINE=1 --options-file CMakeFiles/test_profiling.dir/includes_CUDA.rsp -O3 -DNDEBUG "--generate-code=arch=compute_50,code=[sm_50]" "--generate-code=arch=compute_52,code=[sm_52]" "--generate-code=arch=compute_53,code=[sm_53]" "--generate-code=arch=compute_60,code=[sm_60]" "--generate-code=arch=compute_61,code=[sm_61]" "--generate-code=arch=compute_62,code=[sm_62]" "--generate-code=arch=compute_70,code=[sm_70]" "--generate-code=arch=compute_72,code=[sm_72]" "--generate-code=arch=compute_75,code=[sm_75]" "--generate-code=arch=compute_80,code=[sm_80]" "--generate-code=arch=compute_86,code=[sm_86]" "--generate-code=arch=compute_87,code=[sm_87]" "--generate-code=arch=compute_89,code=[sm_89]" "--generate-code=arch=compute_90,code=[sm_90]" "--generate-code=arch=compute_90,code=[compute_90]" -MD -MT tests/CMakeFiles/test_profiling.dir/test_profiling_gpu.cu.o -MF CMakeFiles/test_profiling.dir/test_profiling_gpu.cu.o.d -x cu -c /home/weiwu/realm/tests/test_profiling_gpu.cu -o CMakeFiles/test_profiling.dir/test_profiling_gpu.cu.o
/home/weiwu/realm/src/realm/../realm/sparsity.inl(90): error: calling a __device__ function("__trap") from a __host__ function("get_entries") is not allowed
      do { if(!(entries_valid.load_acquire())) { __trap(); } } while(0);
                                                 ^

/home/weiwu/realm/src/realm/../realm/sparsity.inl(98): error: calling a __device__ function("__trap") from a __host__ function("get_approx_rects") is not allowed
      do { if(!(approx_valid.load_acquire())) { __trap(); } } while(0);
                                                ^

/home/weiwu/realm/src/realm/../realm/indexspace.inl(491): error: calling a __device__ function("__trap") from a __host__ function("tighten") is not allowed
        do { if(!(impl->is_valid(precise))) { __trap(); } } while(0);
                                              ^

3 errors detected in the compilation of "/home/weiwu/realm/tests/test_profiling_gpu.cu".
```