### PR TITLE
Use __builtin_trap for HIP, __assert_fail is not publicly exposed

### DIFF
--- a/src/realm/realm_assert.h
+++ b/src/realm/realm_assert.h
@@ -32,7 +32,7 @@
 #define REALM_ASSERT(cond)                                                               \
   do {                                                                                   \
     if(!(cond)) {                                                                        \
-      __assert_fail(#cond, __FILE__, __LINE__, __func__);                                \
+      __builtin_trap();                                                                  \
     }                                                                                    \
   } while(0)
 


### PR DESCRIPTION
Fixes https://github.com/StanfordLegion/realm/issues/363 (again).

`__assert_fail` is not publicly exposed and results in error messages like:

```
/autofs/nccs-svm1_home1/ums036_auser/.jacamar-ci/builds/Z3LjburSV/000/ci/ums036/dev/legion/realm/src/realm/../realm/bytearray.inl:168:7: error: use of undeclared identifier '__assert_fail'
      REALM_ASSERT(array_base != 0);
      ^
/autofs/nccs-svm1_home1/ums036_auser/.jacamar-ci/builds/Z3LjburSV/000/ci/ums036/dev/legion/realm/src/realm/../realm/realm_assert.h:35:7: note: expanded from macro 'REALM_ASSERT'
      __assert_fail(#cond, __FILE__, __LINE__, __func__);                                \
      ^
```

https://code.olcf.ornl.gov/ci/ums036/dev/legion/-/jobs/138419

I'm not sure why we rejected `__builtin_trap` in the original issue, but this PR switches back to it.