### PR TITLE
Fix: Remove variable shadowing in MPI thread model initialization

### DIFF
--- a/src/realm/mpi/am_mpi.cc
+++ b/src/realm/mpi/am_mpi.cc
@@ -55,7 +55,6 @@ namespace Realm {
       if(pre_initialized) {
         MPI_Query_thread(&mpi_thread_model);
       } else {
-        int mpi_thread_model;
         MPI_Init_thread(NULL, NULL, MPI_THREAD_MULTIPLE, &mpi_thread_model);
       }
       if(mpi_thread_model < MPI_THREAD_MULTIPLE) {


### PR DESCRIPTION
Removed redundant variable declaration for mpi_thread_model when MPI is already initialized.