### PR TITLE
Explicitly user-requested features become hard errors if not available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ check_ipo_supported(RESULT REALM_SUPPORTS_LTO LANGUAGES CXX C)
 
 #region Depedency auto-detection
 find_package(CUDAToolkit 11.7 QUIET)
+find_package(Doxygen QUIET)
 find_package(hip QUIET CONFIG)
 find_package(HDF5 QUIET)
 find_package(OpenMP QUIET COMPONENTS C CXX)
@@ -142,7 +143,11 @@ option(REALM_BUILD_TESTS "Build tests" ${PROJECT_IS_TOPLEVEL})
 option(REALM_BUILD_EXAMPLES "Build examples" ${PROJECT_IS_TOPLEVEL})
 option(REALM_BUILD_BENCHMARKS "Build benchmarks" ${PROJECT_IS_TOPLEVEL})
 option(REALM_BUILD_TUTORIALS "Build tutorials" ${PROJECT_IS_TOPLEVEL})
-option(REALM_BUILD_DOCS "Build documentation" ${PROJECT_IS_TOPLEVEL})
+if(Doxygen_FOUND)
+  option(REALM_BUILD_DOCS "Build documentation" ${PROJECT_IS_TOPLEVEL})
+else()
+  option(REALM_BUILD_DOCS "Build documentation" OFF)
+endif()
 
 cmake_dependent_option(REALM_ENABLE_RDTSC "Compile with RDTSC support" ON "NOT WIN32" OFF)
 option(REALM_ENABLE_CUDA "Compile with CUDA support" ${CUDAToolkit_FOUND})
@@ -1051,7 +1056,7 @@ add_feature_info(tutorials REALM_BUILD_TUTORIALS "Build tutorials")
 
 #region Documentation
 # TODO(cperry): fix me
-if(REALM_BUILD_DOCS AND DOXYGEN_FOUND)
+if(REALM_BUILD_DOCS)
   set(DOXYGEN_PROJECT_LOGO ${CMAKE_CURRENT_SOURCE_DIR}/doxygen/logo.png)
   set(DOXYGEN_PROJECT_NUMBER ${REALM_VERSION})
   set(DOXYGEN_GENERATE_HTML ${REALM_GENERATE_HTML})


### PR DESCRIPTION
This is one potential solution to #395.

Behavior implemented in this PR:

 * If a feature is off by default: turning it on will cause a hard error if any dependency is not available.
 * If a feature is auto-detect by default:
   * Attempt to auto-detect if the dependency/ies are available.
   * If available, enable the feature by default. (Any flags explicitly passed by the user will always take priority, if specified.)
   * If enabled, hard-require all dependencies.

This means that:

 * Any feature explicitly enabled by the user will hard-fail if not available.
 * Any optional feature will auto-detect the corresponding dependency and enable itself if that dependency is available (and the user does not otherwise explicitly enable or disable the feature).