### PR TITLE
Fix Runtime::create_configs

### DIFF
--- a/src/realm/runtime_impl.cc
+++ b/src/realm/runtime_impl.cc
@@ -3054,7 +3054,7 @@ namespace Realm {
   bool RuntimeImpl::create_configs(int argc, char **argv)
   {
     // initialize topology
-    if (!topology_init) {
+    if(!topology_init) {
       host_topology = HardwareTopology::create_topology();
       topology_init = true;
     }


### PR DESCRIPTION
This PR fixes the following use case:
```
runtime.create_configs();
init legion runtime // legion will call the create configs again
```