### PR TITLE
Only auto-detect CUDA when driver is also available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -859,7 +859,7 @@ add_feature_info(
 #region Source lists
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src)
 
-if(REALM_ENABLE_CUDA)
+if(REALM_USE_CUDA)
   add_library(realm_cuda_fatbin OBJECT ${REALM_CUDA_SOURCES})
   target_compile_options(
     realm_cuda_fatbin
@@ -957,21 +957,25 @@ target_include_directories(
   realm_obj
   PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> $<BUILD_INTERFACE:${REALM_SOURCE_DIR}/..>
          $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
-  PRIVATE $<$<TARGET_EXISTS:CUDA::cuda_driver>:${CUDAToolkit_CUPTI_INCLUDE_DIR}>
-          $<$<TARGET_EXISTS:CUDA::cuda_driver>:${CUDAToolkit_INCLUDE_DIR}>
-          $<$<TARGET_EXISTS:Python3::Python>:${Python_INCLUDE_DIRS}>
+  PRIVATE $<$<TARGET_EXISTS:Python3::Python>:${Python_INCLUDE_DIRS}>
           $<$<TARGET_EXISTS:hip::host>:${HIP_INCLUDE_DIR}>
 )
 target_include_directories(
   Realm
   PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> $<BUILD_INTERFACE:${REALM_SOURCE_DIR}/..>
          $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
-  PRIVATE $<$<TARGET_EXISTS:CUDA::cuda_driver>:${CUDAToolkit_CUPTI_INCLUDE_DIR}>
-          $<$<TARGET_EXISTS:CUDA::cuda_driver>:${CUDAToolkit_INCLUDE_DIR}>
-          $<$<TARGET_EXISTS:Python3::Python>:${Python_INCLUDE_DIRS}>
+  PRIVATE $<$<TARGET_EXISTS:Python3::Python>:${Python_INCLUDE_DIRS}>
           $<$<TARGET_EXISTS:hip::host>:${HIP_INCLUDE_DIR}>
 )
-if(REALM_ENABLE_GASNETEX)
+if(REALM_USE_CUDA)
+  target_include_directories(
+    realm_obj PRIVATE ${CUDAToolkit_CUPTI_INCLUDE_DIR} ${CUDAToolkit_INCLUDE_DIR}
+  )
+  target_include_directories(
+    Realm PRIVATE ${CUDAToolkit_CUPTI_INCLUDE_DIR} ${CUDAToolkit_INCLUDE_DIR}
+  )
+endif()
+if(REALM_USE_GASNETEX)
   # Force the creation of the export header for the wrapper we need, but nothing else
   add_dependencies(Realm realm_gex_wrapper_objs)
   add_dependencies(realm_obj realm_gex_wrapper_objs)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -461,9 +461,11 @@ target_link_libraries(c_external_inst ${TEST_GPU_LIBS})
 
 add_integration_test(c_event_poisoned "${REALM_TEST_DIR}/c/test_event_poisoned.cc")
 
-target_link_libraries(
-  machine_config_test ${TEST_GPU_LIBS} $<TARGET_NAME_IF_EXISTS:CUDA::cuda_driver>
-)
+if(REALM_USE_CUDA)
+  target_link_libraries(
+    machine_config_test ${TEST_GPU_LIBS} $<TARGET_NAME_IF_EXISTS:CUDA::cuda_driver>
+  )
+endif()
 target_link_libraries(test_profiling ${TEST_GPU_LIBS})
 if(REALM_USE_LIBDL)
   target_link_libraries(taskreg ${CMAKE_DL_LIBS})


### PR DESCRIPTION
Attempt to address bug exhibited in https://gitlab.com/StanfordLegion/legion/-/pipelines/2340657971 where CUDA is automatically enabled when toolkit is detected but driver is not present.

The user can still explicitly request that Realm build with (or without) CUDA. This only impacts the behavior of the auto-detect.