### PR TITLE
Background Copy Planning

### DIFF
--- a/src/realm/bgwork.cc
+++ b/src/realm/bgwork.cc
@@ -389,22 +389,24 @@ namespace Realm {
                        << " slot=" << index;
 #ifdef DEBUG_REALM
     State old_state = state.exchange(STATE_ACTIVE);
-    if(old_state != STATE_IDLE) {
-      log_bgwork.debug() << "double make_active: item=" << ((void *)this) << " name='"
-                         << name << "' oldstate=" << old_state;
+    if(old_state == STATE_SHUTDOWN) {
+      log_bgwork.fatal() << "make_active on shutdown item: item=" << ((void *)this)
+                         << " name='" << name << "'";
+      abort();
     }
 #endif
     manager->advertise_work(index);
   }
 
 #ifdef DEBUG_REALM
-  // called immediately before 'do_work'
+  // called immediately before 'do_work' - may observe STATE_IDLE if
+  //  an external make_active raced with another worker's make_inactive
   void BackgroundWorkItem::make_inactive(void)
   {
     State old_state = state.exchange(STATE_IDLE);
-    if(old_state != STATE_ACTIVE) {
-      log_bgwork.fatal() << "invalid make_inactive: item=" << ((void *)this) << " name='"
-                         << name << "' oldstate=" << old_state;
+    if(old_state == STATE_SHUTDOWN) {
+      log_bgwork.fatal() << "make_inactive on shutdown item: item=" << ((void *)this)
+                         << " name='" << name << "'";
       abort();
     }
   }

--- a/src/realm/bgwork.h
+++ b/src/realm/bgwork.h
@@ -154,8 +154,10 @@ namespace Realm {
 
 #ifdef DEBUG_REALM
   public:
-    // in debug mode, we'll track the state of a work item to avoid
-    //  duplicate activations or activations after shutdown
+    // in debug mode, we'll track the state of a work item to detect
+    //  activations or work performed after shutdown - duplicate
+    //  activations are permitted and may occur when an external thread
+    //  calls make_active while a worker is between claim and do_work
     enum State
     {
       STATE_IDLE,

--- a/src/realm/deppart/byfield.cc
+++ b/src/realm/deppart/byfield.cc
@@ -23,6 +23,7 @@
 #include "realm/deppart/rectlist.h"
 #include "realm/deppart/inst_helper.h"
 #include "realm/logging.h"
+#include "realm/runtime_impl.h"
 
 namespace Realm {
 

--- a/src/realm/deppart/image.cc
+++ b/src/realm/deppart/image.cc
@@ -24,6 +24,7 @@
 #include "realm/deppart/inst_helper.h"
 #include "realm/deppart/preimage.h"
 #include "realm/logging.h"
+#include "realm/runtime_impl.h"
 
 namespace Realm {
 

--- a/src/realm/deppart/preimage.cc
+++ b/src/realm/deppart/preimage.cc
@@ -24,6 +24,7 @@
 #include "realm/deppart/inst_helper.h"
 #include "realm/deppart/image.h"
 #include "realm/logging.h"
+#include "realm/runtime_impl.h"
 #include <ctime>
 
 namespace Realm {

--- a/src/realm/deppart/setops.cc
+++ b/src/realm/deppart/setops.cc
@@ -24,6 +24,7 @@
 #include "realm/deppart/inst_helper.h"
 #include "realm/deppart/image.h"
 #include "realm/logging.h"
+#include "realm/runtime_impl.h"
 
 namespace Realm {
 

--- a/src/realm/deppart/sparsity_impl.inl
+++ b/src/realm/deppart/sparsity_impl.inl
@@ -23,8 +23,6 @@
 // NOP, but useful for IDEs
 #include "realm/deppart/sparsity_impl.h"
 
-#include "realm/runtime_impl.h"
-
 namespace Realm {
 
   ////////////////////////////////////////////////////////////////////////

--- a/src/realm/runtime_impl.cc
+++ b/src/realm/runtime_impl.cc
@@ -2945,6 +2945,7 @@ namespace Realm {
 
 #ifdef DEBUG_REALM
     event_triggerer.shutdown_work_item();
+    copy_analyzer.shutdown_work_item();
 #endif
     bgwork.stop_dedicated_workers();
 

--- a/src/realm/runtime_impl.cc
+++ b/src/realm/runtime_impl.cc
@@ -1953,6 +1953,7 @@ namespace Realm {
 #endif
 
     event_triggerer.add_to_manager(&bgwork);
+    copy_analyzer.add_to_manager(&bgwork);
 
     // initialize barrier timestamp
     BarrierImpl::barrier_adjustment_timestamp.store(

--- a/src/realm/runtime_impl.h
+++ b/src/realm/runtime_impl.h
@@ -55,6 +55,8 @@
 #include "realm/shm.h"
 #include "realm/hardware_topology.h"
 
+#include "realm/transfer/transfer.h"
+
 #include <optional>
 #include <unordered_map>
 #include <memory>
@@ -407,6 +409,7 @@ namespace Realm {
     BackgroundWorkManager bgwork;
     IncomingMessageManager *message_manager;
     EventTriggerNotifier event_triggerer;
+    CopyAnalyzer copy_analyzer;
 
     OperationTable optable;
 

--- a/src/realm/transfer/address_list.h
+++ b/src/realm/transfer/address_list.h
@@ -21,6 +21,7 @@
 #include "realm/realm_config.h"
 #include "realm/indexspace.h"
 #include "realm/id.h"
+#include "realm/deppart/sparsity_impl.h"
 
 #include <array>
 #include <cstring>

--- a/src/realm/transfer/channel.h
+++ b/src/realm/transfer/channel.h
@@ -37,7 +37,6 @@
 #include <string.h>
 
 #include "realm/id.h"
-#include "realm/runtime_impl.h"
 #include "realm/mem_impl.h"
 #include "realm/inst_impl.h"
 #include "realm/bgwork.h"

--- a/src/realm/transfer/channel_disk.cc
+++ b/src/realm/transfer/channel_disk.cc
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#include "realm/runtime_impl.h"
 #include "realm/transfer/channel_common.h"
 #include "realm/transfer/memcpy_channel.h"
 #include "realm/transfer/channel_disk.h"

--- a/src/realm/transfer/ib_memory.cc
+++ b/src/realm/transfer/ib_memory.cc
@@ -19,6 +19,7 @@
 
 #include "realm/transfer/ib_memory.h"
 
+#include "realm/runtime_impl.h"
 #include "realm/transfer/transfer.h"
 
 namespace Realm {

--- a/src/realm/transfer/memcpy_channel.cc
+++ b/src/realm/transfer/memcpy_channel.cc
@@ -21,7 +21,6 @@
 #define NOMINMAX
 #endif
 
-#include "realm/shm.h"
 #include "realm/transfer/channel_common.h"
 #include "realm/transfer/memcpy_channel.h"
 #include "realm/transfer/transfer.h"

--- a/src/realm/transfer/memcpy_channel.cc
+++ b/src/realm/transfer/memcpy_channel.cc
@@ -21,6 +21,7 @@
 #define NOMINMAX
 #endif
 
+#include "realm/shm.h"
 #include "realm/transfer/channel_common.h"
 #include "realm/transfer/memcpy_channel.h"
 #include "realm/transfer/transfer.h"

--- a/src/realm/transfer/memcpy_channel.h
+++ b/src/realm/transfer/memcpy_channel.h
@@ -22,6 +22,7 @@
 
 #include "realm/mem_impl.h"
 #include "realm/bgwork.h"
+#include "realm/shm.h"
 #include "realm/transfer/channel.h"
 
 namespace Realm {

--- a/src/realm/transfer/transfer.cc
+++ b/src/realm/transfer/transfer.cc
@@ -4328,7 +4328,7 @@ namespace Realm {
       return;
     }
     if(poisoned) {
-      handle_poisoned_precondition(precondition);
+      handle_poisoned_precondition(defer);
       return;
     }
     // Add ourselves to the copy analysis queue

--- a/src/realm/transfer/transfer.cc
+++ b/src/realm/transfer/transfer.cc
@@ -4252,6 +4252,7 @@ namespace Realm {
   bool CopyAnalyzer::do_work(TimeLimit until)
   {
     // Always do at least one to guarantee forward progress
+    bool done;
     do {
       TransferOperation *op;
       {
@@ -4261,10 +4262,11 @@ namespace Realm {
         }
         op = pending_copies.front();
         pending_copies.pop_front();
+        done = pending_copies.empty();
       }
       op->analyze();
     } while(!until.is_expired());
-    return true;
+    return !done;
   }
 
   ////////////////////////////////////////////////////////////////////////

--- a/src/realm/transfer/transfer.cc
+++ b/src/realm/transfer/transfer.cc
@@ -3652,12 +3652,6 @@ namespace Realm {
 
   void TransferDesc::perform_analysis(TransferOperation *op)
   {
-    // make sure we haven't been cancelled
-    bool ok_to_run = op->mark_ready();
-    if(!ok_to_run) {
-      op->mark_finished(false /*!successful*/);
-      return;
-    }
     // Only here if we're successful now
 
     // initialize profiling data
@@ -4341,8 +4335,13 @@ namespace Realm {
       handle_poisoned_precondition(defer);
       return;
     }
-    // Add ourselves to the copy analysis queue
-    get_runtime()->copy_analyzer.analyze_copy(this);
+    // Check that nobody cancelled us
+    if(mark_ready()) {
+      // Add ourselves to the copy analysis queue
+      get_runtime()->copy_analyzer.analyze_copy(this);
+    } else {
+      mark_finished(false /*successful*/);
+    }
   }
 
   bool TransferOperation::mark_ready(void)
@@ -4949,9 +4948,11 @@ namespace Realm {
     // TODO: respect time limit
     if(poisoned) {
       op->handle_poisoned_precondition(precondition);
-    } else {
+    } else if(op->mark_ready()) {
       // Add ourselves to the copy analysis queue
       get_runtime()->copy_analyzer.analyze_copy(op);
+    } else {
+      op->mark_finished(false /*successful*/);
     }
   }
 

--- a/src/realm/transfer/transfer.cc
+++ b/src/realm/transfer/transfer.cc
@@ -4337,6 +4337,8 @@ namespace Realm {
     }
     // Check that nobody cancelled us
     if(mark_ready()) {
+      // analyzing copies before dispatching them is expensive so we have a
+      // background worker item for doing that
       // Add ourselves to the copy analysis queue
       get_runtime()->copy_analyzer.analyze_copy(this);
     } else {

--- a/src/realm/transfer/transfer.cc
+++ b/src/realm/transfer/transfer.cc
@@ -4251,8 +4251,9 @@ namespace Realm {
 
   bool CopyAnalyzer::do_work(TimeLimit until)
   {
-    // Always do at least one to guarantee forward progress
     bool done;
+    bool first = true;
+    // Always do at least one to guarantee forward progress
     do {
       TransferOperation *op;
       {
@@ -4263,6 +4264,15 @@ namespace Realm {
         op = pending_copies.front();
         pending_copies.pop_front();
         done = pending_copies.empty();
+      }
+      // If there are more pending copies on the first invocation
+      // then reenable this background work item for other threads
+      // to be able to invoke it in parallel
+      if(first) {
+        if(!done) {
+          make_active();
+        }
+        first = false;
       }
       op->analyze();
     } while(!until.is_expired());

--- a/src/realm/transfer/transfer.cc
+++ b/src/realm/transfer/transfer.cc
@@ -3545,14 +3545,15 @@ namespace Realm {
       }
     }
 
-    std::set<RegionInstance> insts_seen;
-    for(size_t i = 0; i < srcs.size(); i++) {
-      if(srcs[i].inst.exists()) {
-        if(insts_seen.count(srcs[i].inst) > 0) {
+    std::vector<RegionInstance> insts_seen;
+    for(const CopySrcDstField &src : srcs) {
+      if(src.inst.exists()) {
+        auto finder = std::lower_bound(insts_seen.begin(), insts_seen.end(), src.inst);
+        if((finder != insts_seen.end()) && (*finder == src.inst)) {
           continue;
         }
-        insts_seen.insert(srcs[i].inst);
-        RegionInstanceImpl *impl = get_runtime()->get_instance_impl(srcs[i].inst);
+        insts_seen.insert(finder, src.inst);
+        RegionInstanceImpl *impl = get_runtime()->get_instance_impl(src.inst);
         Event e = impl->request_metadata();
         if(e.exists()) {
           preconditions.push_back(e);
@@ -3560,13 +3561,14 @@ namespace Realm {
       }
     }
 
-    for(size_t i = 0; i < dsts.size(); i++) {
-      if(dsts[i].inst.exists()) {
-        if(insts_seen.count(dsts[i].inst) > 0) {
+    for(const CopySrcDstField &dst : dsts) {
+      if(dst.inst.exists()) {
+        auto finder = std::lower_bound(insts_seen.begin(), insts_seen.end(), dst.inst);
+        if((finder != insts_seen.end()) && (*finder == dst.inst)) {
           continue;
         }
-        insts_seen.insert(dsts[i].inst);
-        RegionInstanceImpl *impl = get_runtime()->get_instance_impl(dsts[i].inst);
+        insts_seen.insert(finder, dst.inst);
+        RegionInstanceImpl *impl = get_runtime()->get_instance_impl(dst.inst);
         Event e = impl->request_metadata();
         if(e.exists()) {
           preconditions.push_back(e);
@@ -3650,6 +3652,14 @@ namespace Realm {
 
   void TransferDesc::perform_analysis(TransferOperation *op)
   {
+    // make sure we haven't been cancelled
+    bool ok_to_run = op->mark_ready();
+    if(!ok_to_run) {
+      op->mark_finished(false /*!successful*/);
+      return;
+    }
+    // Only here if we're successful now
+
     // initialize profiling data
     prof_usage.source = Memory::NO_MEMORY;
     prof_usage.target = Memory::NO_MEMORY;
@@ -4368,15 +4378,6 @@ namespace Realm {
 
   void TransferOperation::allocate_ibs()
   {
-    // make sure we haven't been cancelled
-    bool ok_to_run = mark_ready();
-    if(!ok_to_run) {
-      mark_finished(false /*!successful*/);
-      return;
-    }
-
-    // Only here if we're successful now
-
     const TransferGraph &tg = desc.graph;
 
     if(!tg.ib_edges.empty()) {

--- a/src/realm/transfer/transfer.cc
+++ b/src/realm/transfer/transfer.cc
@@ -3518,23 +3518,7 @@ namespace Realm {
     }
   }
 
-  bool TransferDesc::request_analysis(TransferOperation *op)
-  {
-    // early out without lock
-    if(analysis_complete.load_acquire()) {
-      return true;
-    }
-
-    AutoLock<> al(mutex);
-    if(analysis_complete.load()) {
-      return true;
-    } else {
-      pending_ops.push_back(op);
-      return false;
-    }
-  }
-
-  void TransferDesc::check_analysis_preconditions()
+  void TransferDesc::check_analysis_preconditions(std::vector<Event> &preconditions) const
   {
     log_xplan.info() << "created: plan=" << (void *)this << " domain=" << *domain
                      << " srcs=" << srcs.size() << " dsts=" << dsts.size();
@@ -3552,8 +3536,6 @@ namespace Realm {
                           << "]=" << *indirects[i];
       }
     }
-
-    std::vector<Event> preconditions;
 
     // we need metadata for the domain and every instance
     {
@@ -3598,18 +3580,6 @@ namespace Realm {
         preconditions.push_back(e);
       }
     }
-
-    if(!preconditions.empty()) {
-      Event merged = Event::merge_events(preconditions);
-      if(merged.exists()) {
-        deferred_analysis.precondition = merged;
-        EventImpl::add_waiter(merged, &deferred_analysis);
-        return;
-      }
-    }
-
-    // no (untriggered) preconditions, so we fall through to immediate analysis
-    perform_analysis();
   }
 
   static size_t compute_ib_size(size_t combined_field_size, size_t domain_size,
@@ -3678,7 +3648,7 @@ namespace Realm {
     const std::vector<TransferGraph::IBInfo> &edges;
   };
 
-  void TransferDesc::perform_analysis()
+  void TransferDesc::perform_analysis(TransferOperation *op)
   {
     // initialize profiling data
     prof_usage.source = Memory::NO_MEMORY;
@@ -3688,20 +3658,8 @@ namespace Realm {
     // quick check - if the domain is empty, there's nothing to actually do
     if(domain->empty()) {
       log_xplan.debug() << "analysis: plan=" << (void *)this << " empty";
-
-      // well, we still have to poke pending ops
-      std::vector<TransferOperation *> to_alloc;
-      {
-        AutoLock<> al(mutex);
-        to_alloc.swap(pending_ops);
-        // release before the mutex is released so to_alloc is visible before the
-        // analysis_complete flag is set
-        analysis_complete.store_release(true);
-      }
-
-      for(size_t i = 0; i < to_alloc.size(); i++) {
-        to_alloc[i]->allocate_ibs();
-      }
+      // well, we still have to allocate ibs
+      op->allocate_ibs();
       return;
     }
 
@@ -4242,70 +4200,71 @@ namespace Realm {
       }
     }
 
-    // mark that the analysis is complete and see if there are any pending
-    //  ops that can start allocating ibs
-    std::vector<TransferOperation *> to_alloc;
-    {
-      AutoLock<> al(mutex);
-      to_alloc.swap(pending_ops);
-      analysis_successful = true;
-      // release before the mutex is released so to_alloc is visible before the
-      // analysis_complete flag is set
-      analysis_complete.store_release(true);
-    }
-
-    for(size_t i = 0; i < to_alloc.size(); i++) {
-      to_alloc[i]->allocate_ibs();
-    }
-  }
-
-  void TransferDesc::cancel_analysis(Event failed_precondition)
-  {
-    // mark that the analysis is failed and see if there are any pending
-    //  ops that need to also fail
-    std::vector<TransferOperation *> to_alloc;
-    {
-      AutoLock<> al(mutex);
-      to_alloc.swap(pending_ops);
-      analysis_successful = false;
-      // release before the mutex is released so to_alloc is visible before the
-      // analysis_complete flag is set
-      analysis_complete.store_release(true);
-    }
-
-    for(size_t i = 0; i < to_alloc.size(); i++) {
-      to_alloc[i]->handle_poisoned_precondition(failed_precondition);
-    }
+    // start allocating intermediate buffers
+    op->allocate_ibs();
   }
 
   ////////////////////////////////////////////////////////////////////////
   //
-  // class TransferDesc::DeferredAnalysis
+  // class CopyAnalyzer
   //
 
-  TransferDesc::DeferredAnalysis::DeferredAnalysis(TransferDesc *_desc)
-    : desc(_desc)
+  CopyAnalyzer::CopyAnalyzer(void)
+    : BackgroundWorkItem("copy analyzer")
   {}
 
-  void TransferDesc::DeferredAnalysis::event_triggered(bool poisoned,
-                                                       TimeLimit work_until)
+  void CopyAnalyzer::analyze_copy(TransferOperation *op)
   {
-    // TODO: respect time limit
-    if(poisoned) {
-      desc->cancel_analysis(precondition);
-    } else {
-      desc->perform_analysis();
+    bool activate = false;
+    {
+      AutoLock<> al(mutex);
+      if(pending_copies.empty()) {
+        pending_copies.push_back(op);
+        activate = true;
+      } else {
+        // Need to insert in the right place in the queue by priority
+        const int priority = op->get_priority();
+        if(priority <= pending_copies.back()->get_priority()) {
+          // Same or lower priority as the back goes on the back
+          pending_copies.push_back(op);
+        } else if(pending_copies.front()->get_priority() < priority) {
+          // Higher priority than the front goes on the front
+          pending_copies.push_front(op);
+        } else {
+          // Insert it at the right place in the deque
+          pending_copies.insert(
+              std::lower_bound(
+                  pending_copies.begin(), pending_copies.end(), op,
+                  [](const TransferOperation *lhs, const TransferOperation *rhs) {
+                    // Only goes to the left in the deque if it has strictly
+                    // higher priority than the right
+                    return lhs->get_priority() > rhs->get_priority();
+                  }),
+              op);
+        }
+      }
+    }
+    if(activate) {
+      make_active();
     }
   }
 
-  void TransferDesc::DeferredAnalysis::print(std::ostream &os) const
+  bool CopyAnalyzer::do_work(TimeLimit until)
   {
-    os << "deferred_analysis(" << (void *)desc << ")";
-  }
-
-  Event TransferDesc::DeferredAnalysis::get_finish_event(void) const
-  {
-    return Event::NO_EVENT;
+    // Always do at least one to guarantee forward progress
+    do {
+      TransferOperation *op;
+      {
+        AutoLock<> al(mutex);
+        if(pending_copies.empty()) {
+          return false;
+        }
+        op = pending_copies.front();
+        pending_copies.pop_front();
+      }
+      op->analyze();
+    } while(!until.is_expired());
+    return true;
   }
 
   ////////////////////////////////////////////////////////////////////////
@@ -4339,24 +4298,29 @@ namespace Realm {
                    << " created - plan=" << (void *)&desc << " before=" << precondition
                    << " after=" << get_finish_event();
 
+    std::vector<Event> preconditions;
+    desc.check_analysis_preconditions(preconditions);
+    Event defer;
+    if(!preconditions.empty()) {
+      if(precondition.exists())
+        preconditions.push_back(precondition);
+      defer = Event::merge_events(preconditions);
+    } else {
+      defer = precondition;
+    }
+
     bool poisoned;
-    if(!precondition.has_triggered_faultaware(poisoned)) {
-      deferred_start.precondition = precondition;
-      EventImpl::add_waiter(precondition, &deferred_start);
+    if(!defer.has_triggered_faultaware(poisoned)) {
+      deferred_start.precondition = defer;
+      EventImpl::add_waiter(defer, &deferred_start);
       return;
     }
     if(poisoned) {
       handle_poisoned_precondition(precondition);
       return;
     }
-
-    // see if we need to wait for the transfer description analysis
-    if(desc.request_analysis(this)) {
-      // it's ready - go ahead and do ib creation
-      allocate_ibs();
-    } else {
-      // do nothing - the TransferDesc will call us when it's ready
-    }
+    // Add ourselves to the copy analysis queue
+    get_runtime()->copy_analyzer.analyze_copy(this);
   }
 
   bool TransferOperation::mark_ready(void)
@@ -4399,11 +4363,7 @@ namespace Realm {
       return;
     }
 
-    // if the transfer analysis was not successful, we can't continue
-    if(!desc.analysis_successful) {
-      mark_terminated(0, ByteArray());
-      return;
-    }
+    // Only here if we're successful now
 
     const TransferGraph &tg = desc.graph;
 
@@ -4977,13 +4937,8 @@ namespace Realm {
     if(poisoned) {
       op->handle_poisoned_precondition(precondition);
     } else {
-      // see if we need to wait for the transfer description analysis
-      if(op->desc.request_analysis(op)) {
-        // it's ready - go ahead and do ib creation
-        op->allocate_ibs();
-      } else {
-        // do nothing - the TransferDesc will call us when it's ready
-      }
+      // Add ourselves to the copy analysis queue
+      get_runtime()->copy_analyzer.analyze_copy(op);
     }
   }
 

--- a/src/realm/transfer/transfer.h
+++ b/src/realm/transfer/transfer.h
@@ -20,12 +20,15 @@
 #ifndef REALM_TRANSFER_H
 #define REALM_TRANSFER_H
 
+#include "realm/bgwork.h"
 #include "realm/event.h"
 #include "realm/memory.h"
 #include "realm/indexspace.h"
+#include "realm/inst_impl.h"
 #include "realm/atomics.h"
 #include "realm/network.h"
 #include "realm/operation.h"
+#include "realm/transfer/address_list.h"
 #include "realm/transfer/channel.h"
 #include "realm/profiling.h"
 
@@ -35,6 +38,7 @@ namespace Realm {
   //  type of IndexSpace that is driving the transfer, so we need a widget that
   //  can hold an arbitrary IndexSpace and dispatch based on its type
 
+  struct Node;
   class XferDes;
   class AddressList;
 
@@ -410,11 +414,6 @@ namespace Realm {
     void add_reference();
     void remove_reference();
 
-    // returns true if the analysis is complete, and ib allocation can proceed
-    // if the analysis isn't, returns false and op->allocate_ibs() will be
-    //   called once it is
-    bool request_analysis(TransferOperation *op);
-
     struct FieldInfo {
       FieldID id;
       size_t offset, size;
@@ -424,21 +423,8 @@ namespace Realm {
   protected:
     atomic<int> refcount;
 
-    void check_analysis_preconditions();
-    void perform_analysis();
-    void cancel_analysis(Event failed_precondition);
-
-    class DeferredAnalysis : public EventWaiter {
-    public:
-      DeferredAnalysis(TransferDesc *_desc);
-      virtual void event_triggered(bool poisoned, TimeLimit work_until);
-      virtual void print(std::ostream &os) const;
-      virtual Event get_finish_event(void) const;
-
-      TransferDesc *desc;
-      Event precondition;
-    };
-    DeferredAnalysis deferred_analysis;
+    void check_analysis_preconditions(std::vector<Event> &preconditions) const;
+    void perform_analysis(TransferOperation *op);
 
     friend class TransferOperation;
 
@@ -448,9 +434,6 @@ namespace Realm {
     ProfilingRequestSet prs;
 
     Mutex mutex;
-    atomic<bool> analysis_complete;
-    bool analysis_successful;
-    std::vector<TransferOperation *> pending_ops;
     TransferGraph graph;
     std::vector<int> dim_order;
     std::vector<FieldInfo> src_fields, dst_fields;
@@ -458,6 +441,21 @@ namespace Realm {
     size_t fill_size;
     ProfilingMeasurements::OperationMemoryUsage prof_usage;
     ProfilingMeasurements::OperationCopyInfo prof_cpinfo;
+  };
+
+  // analyzing copies before dispatching them is expensive so we have a
+  // background worker item for doing that
+  class CopyAnalyzer : public BackgroundWorkItem {
+  public:
+    CopyAnalyzer(void);
+
+    void analyze_copy(TransferOperation *op);
+
+    virtual bool do_work(TimeLimit work_until) override;
+
+  protected:
+    Mutex mutex;
+    std::deque<TransferOperation *> pending_copies;
   };
 
   class IndirectionInfo {
@@ -598,6 +596,9 @@ namespace Realm {
                       int priority);
 
     ~TransferOperation();
+
+    inline int get_priority(void) const { return priority; }
+    inline void analyze(void) { desc.perform_analysis(this); }
 
     virtual void print(std::ostream &os) const;
 

--- a/src/realm/transfer/transfer.h
+++ b/src/realm/transfer/transfer.h
@@ -443,8 +443,6 @@ namespace Realm {
     ProfilingMeasurements::OperationCopyInfo prof_cpinfo;
   };
 
-  // analyzing copies before dispatching them is expensive so we have a
-  // background worker item for doing that
   class CopyAnalyzer : public BackgroundWorkItem {
   public:
     CopyAnalyzer(void);

--- a/src/realm/transfer/transfer.inl
+++ b/src/realm/transfer/transfer.inl
@@ -181,12 +181,9 @@ namespace Realm {
       const std::vector<const typename CopyIndirection<N, T>::Base *> &_indirects,
       const ProfilingRequestSet &requests, std::true_type)
     : refcount(1)
-    , deferred_analysis(this)
     , srcs(std::forward<SrcVec>(_srcs))
     , dsts(std::forward<DstVec>(_dsts))
     , prs(requests)
-    , analysis_complete(false)
-    , analysis_successful(false)
     , fill_data(0)
     , fill_size(0)
   {
@@ -196,8 +193,6 @@ namespace Realm {
     for(size_t i = 0; i < _indirects.size(); i++) {
       indirects[i] = _indirects[i]->create_info(_is);
     }
-
-    check_analysis_preconditions();
   }
 
   inline void TransferDesc::add_reference() { refcount.fetch_add_acqrel(1); }

--- a/tests/unit_tests/address_list_test.cc
+++ b/tests/unit_tests/address_list_test.cc
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#include "realm/runtime_impl.h"
 #include "realm/transfer/address_list.h"
 #include <gtest/gtest.h>
 #include <cstdlib>

--- a/tests/unit_tests/addrsplit_channel_test.cc
+++ b/tests/unit_tests/addrsplit_channel_test.cc
@@ -16,6 +16,7 @@
  */
 
 #include "realm/mem_impl.h"
+#include "realm/runtime_impl.h"
 #include "realm/transfer/addrsplit_channel.h"
 #include "test_common.h"
 #include <tuple>

--- a/tests/unit_tests/gather_scatter_test.cc
+++ b/tests/unit_tests/gather_scatter_test.cc
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
+#include "realm/runtime_impl.h"
 #include "realm/transfer/transfer.h"
-
 #include "realm/transfer/ib_memory.h"
 #include <tuple>
 #include <gtest/gtest.h>

--- a/tests/unit_tests/memcpy_channel_test.cc
+++ b/tests/unit_tests/memcpy_channel_test.cc
@@ -16,6 +16,7 @@
  */
 
 #include "realm/bgwork.h"
+#include "realm/runtime_impl.h"
 #include "realm/transfer/channel.h"
 #include "realm/transfer/memcpy_channel.h"
 #include "test_common.h"

--- a/tests/unit_tests/test_mock.h
+++ b/tests/unit_tests/test_mock.h
@@ -33,6 +33,7 @@ public:
   {
 #ifdef DEBUG_REALM
     event_triggerer.shutdown_work_item();
+    copy_analyzer.shutdown_work_item();
 #endif
   }
 

--- a/tests/unit_tests/transfer_utils_test.cc
+++ b/tests/unit_tests/transfer_utils_test.cc
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#include "realm/runtime_impl.h"
 #include "realm/transfer/transfer_utils.h"
 #include <variant>
 #include <vector>


### PR DESCRIPTION
This pull request moves all copy planning into a background work item so that all copy launches appear as close to O(1) as possible and do not consume any client execution time for doing things like path planning. The only analysis that is done currently in the client's thread is the analysis to determine if there are any additional events that need to be folded into the precondition for the copy before it is deferred or started.