### PR TITLE
Fix GASNet Races

### DIFF
--- a/src/realm/gasnetex/gasnetex_internal.cc
+++ b/src/realm/gasnetex/gasnetex_internal.cc
@@ -2546,6 +2546,8 @@ namespace Realm {
                              << " old=" << prev << " new=" << (prev + count);
   }
 
+  void XmitSrcDestPair::cancel_push() { push_mutex_check.unlock(); }
+
   ////////////////////////////////////////////////////////////////////////
   //
   // class XmitSrc
@@ -2690,6 +2692,7 @@ namespace Realm {
   GASNetEXInjector::GASNetEXInjector(GASNetEXInternal *_internal)
     : BackgroundWorkItem("gex-inj")
     , internal(_internal)
+    , work_active(false)
   {}
 
   void GASNetEXInjector::add_ready_xpair(XmitSrcDestPair *xpair)
@@ -2708,10 +2711,19 @@ namespace Realm {
       make_active();
   }
 
+  void GASNetEXInjector::drain_xpairs()
+  {
+    AutoLock<> al(mutex);
+    while(!ready_xpairs.empty()) {
+      XmitSrcDestPair *xpair = ready_xpairs.pop_front();
+      xpair->cancel_push();
+    }
+  }
+
   bool GASNetEXInjector::has_work_remaining()
   {
     AutoLock<> al(mutex);
-    return !ready_xpairs.empty();
+    return !ready_xpairs.empty() || work_active.load();
   }
 
   bool GASNetEXInjector::do_work(TimeLimit work_until)
@@ -2728,6 +2740,7 @@ namespace Realm {
       AutoLock<> al(mutex);
       xpair = ready_xpairs.pop_front();
       more_work = !ready_xpairs.empty();
+      work_active.store(true);
     }
     assert(xpair);
     if(more_work)
@@ -2738,6 +2751,8 @@ namespace Realm {
     // now tell the xpair to inject as many packets as it can until it
     //   runs out of time or hits backpressure
     xpair->push_packets(true /*immediate_mode*/, work_until);
+
+    work_active.store(false);
 
     ThreadLocal::gex_work_until = nullptr;
 
@@ -2757,6 +2772,7 @@ namespace Realm {
     , shutdown_cond(mutex)
     , pollwait_flag(false)
     , pollwait_cond(mutex)
+    , work_active(false)
   {}
 
   void GASNetEXPoller::begin_polling()
@@ -2788,6 +2804,15 @@ namespace Realm {
     // no need to signal because the poller is always awake
   }
 
+  void GASNetEXPoller::drain_xpairs()
+  {
+    AutoLock<> al(mutex);
+    while(!critical_xpairs.empty()) {
+      XmitSrcDestPair *xpair = critical_xpairs.pop_front();
+      xpair->cancel_push();
+    }
+  }
+
   void GASNetEXPoller::add_pending_event(GASNetEXEvent *event)
   {
     // take mutex to enqueue event
@@ -2801,7 +2826,7 @@ namespace Realm {
   bool GASNetEXPoller::has_work_remaining()
   {
     AutoLock<> al(mutex);
-    return (!critical_xpairs.empty() || !pending_events.empty());
+    return (!critical_xpairs.empty() || !pending_events.empty() || work_active.load());
   }
 
   bool GASNetEXPoller::do_work(TimeLimit work_until)
@@ -2825,6 +2850,8 @@ namespace Realm {
       if(mutex.trylock()) {
         to_check.swap(pending_events);
         have_crit_xpairs = !critical_xpairs.empty();
+        if(!to_check.empty() || have_crit_xpairs)
+          work_active.store(true);
         mutex.unlock();
       }
 
@@ -2913,6 +2940,10 @@ namespace Realm {
       if(work_until.is_expired())
         break;
     }
+
+    // all dequeued work items have been processed or handed off - clear
+    //  the work_active flag so that quiescence checks can see we're idle
+    work_active.store(false);
 
     // sample pollwait flag before we perform gasnet_AMPoll
     bool pollwait_snapshot = pollwait_flag.load();
@@ -3422,6 +3453,12 @@ namespace Realm {
   void GASNetEXInternal::detach()
   {
     poller.end_polling();
+
+    // drain any xpairs that were enqueued (via request_push) but never
+    //  had push_packets called - this balances the push_mutex_check lock
+    //  that request_push acquired
+    poller.drain_xpairs();
+    injector.drain_xpairs();
 
 #ifdef DEBUG_REALM
     poller.shutdown_work_item();

--- a/src/realm/gasnetex/gasnetex_internal.h
+++ b/src/realm/gasnetex/gasnetex_internal.h
@@ -373,6 +373,11 @@ namespace Realm {
 
     long long time_since_failure() const;
 
+    // cancels a pending push that was enqueued via request_push but never
+    //  processed by push_packets - used during shutdown to balance the
+    //  push_mutex_check lock
+    void cancel_push();
+
     // used when cfg_am_limit is nonzero
     bool try_consume_am_credit();
     void return_am_credits(int count);
@@ -508,6 +513,10 @@ namespace Realm {
 
     void add_ready_xpair(XmitSrcDestPair *xpair);
 
+    // drains any xpairs remaining in the ready queue, cancelling their
+    //  pending pushes - called during shutdown
+    void drain_xpairs();
+
     bool has_work_remaining();
 
     virtual bool do_work(TimeLimit work_until);
@@ -515,6 +524,7 @@ namespace Realm {
   protected:
     GASNetEXInternal *internal;
     Mutex mutex;
+    atomic<bool> work_active; // set during do_work when xpairs are on stack
     XmitSrcDestPair::XmitPairList ready_xpairs;
   };
 
@@ -526,6 +536,10 @@ namespace Realm {
     void end_polling();
 
     void add_critical_xpair(XmitSrcDestPair *xpair);
+
+    // drains any xpairs remaining in the critical queue, cancelling their
+    //  pending pushes - called during shutdown
+    void drain_xpairs();
 
     void add_pending_event(GASNetEXEvent *event);
 
@@ -545,6 +559,7 @@ namespace Realm {
     Mutex::CondVar shutdown_cond;
     atomic<bool> pollwait_flag; // set/cleared inside mutex, but tested outside
     Mutex::CondVar pollwait_cond;
+    atomic<bool> work_active; // set during do_work when items are on stack
     XmitSrcDestPair::XmitPairList critical_xpairs;
     GASNetEXEvent::EventList pending_events;
   };


### PR DESCRIPTION
Fixes two related race conditions in the GASNet-EX network module that could cause spurious assertions during shutdown.               
                                                                                                                                        
  MutexChecker "xpair push" assertion at shutdown                                                                                       
                                                                                                                                        
  request_push() acquires the push_mutex_check lock and enqueues the xpair to the injector or poller queue, expecting a subsequent
  push_packets() call to release it. If shutdown occurs between enqueue and processing, push_packets() never runs, and ~MutexChecker()
  fires because cur_count is still 1.

  Fixed by adding:
  - XmitSrcDestPair::cancel_push() (gasnetex_internal.h:379, gasnetex_internal.cc:2549) — releases the push_mutex_check lock for an
  unprocessed push
  - GASNetEXInjector::drain_xpairs() (gasnetex_internal.h:518, gasnetex_internal.cc:2717) — pops remaining xpairs from ready_xpairs and
  calls cancel_push() on each
  - GASNetEXPoller::drain_xpairs() (gasnetex_internal.h:542, gasnetex_internal.cc:2810) — same for critical_xpairs
  - Both are called during GASNetEXInternal::detach() after end_polling() (gasnetex_internal.cc:3464-3465)

  TOCTOU in quiescence check

  The quiescence check (check_for_quiescence) calls has_work_remaining() on the poller, injector, and completer to verify all background
   work is idle. However, when a background worker's do_work() has dequeued items from the shared queue but hasn't finished processing
  them, the items are on the worker's stack — invisible to both the source queue (already popped) and the destination (not yet handed
  off). This allows the quiescence check to falsely declare quiescence while work is still in progress, which can lead to the
  ChunkedRecycler<GASNetEXEvent> assertion failure during destruction.

  Fixed by adding atomic<bool> work_active flags:
  - GASNetEXInjector (gasnetex_internal.h:527): set under mutex when xpair is popped in do_work() (gasnetex_internal.cc:2746), cleared
  after push_packets() returns (gasnetex_internal.cc:2758), checked in has_work_remaining() (gasnetex_internal.cc:2729)
  - GASNetEXPoller (gasnetex_internal.h:562): set under mutex when events or critical xpairs are taken in do_work()
  (gasnetex_internal.cc:2858), cleared after all items are processed or handed off (gasnetex_internal.cc:2950), checked in
  has_work_remaining() (gasnetex_internal.cc:2833)
  - GASNetEXCompleter: no changes needed — its existing has_work flag (gasnetex_internal.h:578) already covers this window