### PR TITLE
Copy Planning Timeout

### DIFF
--- a/src/realm/transfer/transfer.cc
+++ b/src/realm/transfer/transfer.cc
@@ -3534,6 +3534,19 @@ namespace Realm {
     }
   }
 
+  TransferDesc::TransferDesc(TestTag, TransferDomain *_domain)
+    : refcount(1)
+    , deferred_analysis(this)
+    , prs()
+    , analysis_complete(false)
+    , analysis_successful(false)
+    , fill_data(0)
+    , fill_size(0)
+    , analysis_init_done(false)
+  {
+    domain = _domain;
+  }
+
   void TransferDesc::check_analysis_preconditions()
   {
     log_xplan.info() << "created: plan=" << (void *)this << " domain=" << *domain

--- a/src/realm/transfer/transfer.cc
+++ b/src/realm/transfer/transfer.cc
@@ -3609,7 +3609,7 @@ namespace Realm {
     }
 
     // no (untriggered) preconditions, so we fall through to immediate analysis
-    perform_analysis();
+    perform_analysis(TimeLimit());
   }
 
   static size_t compute_ib_size(size_t combined_field_size, size_t domain_size,
@@ -3678,65 +3678,81 @@ namespace Realm {
     const std::vector<TransferGraph::IBInfo> &edges;
   };
 
-  void TransferDesc::perform_analysis()
+  bool TransferDesc::perform_analysis(TimeLimit work_until)
   {
-    // initialize profiling data
-    prof_usage.source = Memory::NO_MEMORY;
-    prof_usage.target = Memory::NO_MEMORY;
-    prof_usage.size = 0;
+    if(!analysis_init_done) {
+      // initialize profiling data
+      prof_usage.source = Memory::NO_MEMORY;
+      prof_usage.target = Memory::NO_MEMORY;
+      prof_usage.size = 0;
 
-    // quick check - if the domain is empty, there's nothing to actually do
-    if(domain->empty()) {
-      log_xplan.debug() << "analysis: plan=" << (void *)this << " empty";
+      // quick check - if the domain is empty, there's nothing to actually do
+      if(domain->empty()) {
+        log_xplan.debug() << "analysis: plan=" << (void *)this << " empty";
 
-      // well, we still have to poke pending ops
-      std::vector<TransferOperation *> to_alloc;
-      {
-        AutoLock<> al(mutex);
-        to_alloc.swap(pending_ops);
-        // release before the mutex is released so to_alloc is visible before the
-        // analysis_complete flag is set
-        analysis_complete.store_release(true);
+        // well, we still have to poke pending ops
+        std::vector<TransferOperation *> to_alloc;
+        {
+          AutoLock<> al(mutex);
+          to_alloc.swap(pending_ops);
+          // release before the mutex is released so to_alloc is visible before the
+          // analysis_complete flag is set
+          analysis_complete.store_release(true);
+        }
+
+        for(size_t i = 0; i < to_alloc.size(); i++) {
+          to_alloc[i]->allocate_ibs();
+        }
+        return true;
       }
 
-      for(size_t i = 0; i < to_alloc.size(); i++) {
-        to_alloc[i]->allocate_ibs();
+      // first, scan over the sources and figure out how much space we need
+      //  for fill data - don't need to know field order yet
+      for(size_t i = 0; i < srcs.size(); i++) {
+        if(srcs[i].field_id == FieldID(-1)) {
+          fill_size += srcs[i].size;
+        }
       }
-      return;
+
+      if(fill_size > 0) {
+        fill_data = malloc(fill_size);
+        assert(fill_data);
+      }
+
+      // for now, pick a global dimension ordering
+      // TODO: allow this to vary for independent subgraphs (or dependent ones
+      //   with transposes in line)
+      domain->choose_dim_order(dim_order, srcs, dsts, indirects,
+                               false /*!force_fortran_order*/, 65536 /*max_stride*/);
+
+      src_fields.resize(srcs.size());
+      dst_fields.resize(dsts.size());
+
+      analysis_init_done = true;
+      analysis_field_idx = 0;
+      analysis_fld_start = 0;
+      analysis_fill_ofs = 0;
+      analysis_field_done.assign(srcs.size(), false);
     }
 
     size_t domain_size = domain->volume();
 
-    // first, scan over the sources and figure out how much space we need
-    //  for fill data - don't need to know field order yet
-    for(size_t i = 0; i < srcs.size(); i++) {
-      if(srcs[i].field_id == FieldID(-1)) {
-        fill_size += srcs[i].size;
-      }
-    }
-
-    size_t fill_ofs = 0;
-    if(fill_size > 0) {
-      fill_data = malloc(fill_size);
-      assert(fill_data);
-    }
-
-    // for now, pick a global dimension ordering
-    // TODO: allow this to vary for independent subgraphs (or dependent ones
-    //   with transposes in line)
-    domain->choose_dim_order(dim_order, srcs, dsts, indirects,
-                             false /*!force_fortran_order*/, 65536 /*max_stride*/);
-
-    src_fields.resize(srcs.size());
-    dst_fields.resize(dsts.size());
-
     // TODO: look at layouts and decide if fields should be grouped into
     //  a smaller number of copies
     assert(srcs.size() == dsts.size());
-    std::vector<bool> field_done(srcs.size(), false);
+    size_t fill_ofs = analysis_fill_ofs;
+    size_t fld_start = analysis_fld_start;
+    auto &field_done = analysis_field_done;
     // fields will get reordered to be contiguous per xd subgraph
-    size_t fld_start = 0;
-    for(size_t i = 0; i < srcs.size(); i++) {
+    for(size_t i = analysis_field_idx; i < srcs.size(); i++) {
+      // check time limit between field iterations
+      if(work_until.is_expired()) {
+        analysis_fill_ofs = fill_ofs;
+        analysis_fld_start = fld_start;
+        analysis_field_idx = i;
+        return false;
+      }
+
       // did this field already get grouped into a previous path?
       if(field_done[i]) {
         continue;
@@ -4257,6 +4273,7 @@ namespace Realm {
     for(size_t i = 0; i < to_alloc.size(); i++) {
       to_alloc[i]->allocate_ibs();
     }
+    return true;
   }
 
   void TransferDesc::cancel_analysis(Event failed_precondition)
@@ -4294,7 +4311,7 @@ namespace Realm {
     if(poisoned) {
       desc->cancel_analysis(precondition);
     } else {
-      desc->perform_analysis();
+      desc->perform_analysis(TimeLimit());
     }
   }
 

--- a/src/realm/transfer/transfer.cc
+++ b/src/realm/transfer/transfer.cc
@@ -3537,6 +3537,7 @@ namespace Realm {
   TransferDesc::TransferDesc(TestTag, TransferDomain *_domain)
     : refcount(1)
     , deferred_analysis(this)
+    , domain(_domain)
     , prs()
     , analysis_complete(false)
     , analysis_successful(false)
@@ -3544,7 +3545,6 @@ namespace Realm {
     , fill_size(0)
     , analysis_init_done(false)
   {
-    domain = _domain;
   }
 
   void TransferDesc::check_analysis_preconditions()

--- a/src/realm/transfer/transfer.cc
+++ b/src/realm/transfer/transfer.cc
@@ -3892,8 +3892,7 @@ namespace Realm {
     , fill_data(0)
     , fill_size(0)
     , analysis_init_done(false)
-  {
-  }
+  {}
 
   void TransferDesc::check_analysis_preconditions()
   {
@@ -4088,8 +4087,8 @@ namespace Realm {
       // for now, pick a global dimension ordering
       // TODO: allow this to vary for independent subgraphs (or dependent ones
       //   with transposes in line)
-      domain->choose_dim_order(dim_order, srcs, dsts, indirects,
-                               (domain->volume() == 1), 65536 /*max_stride*/);
+      domain->choose_dim_order(dim_order, srcs, dsts, indirects, (domain->volume() == 1),
+                               65536 /*max_stride*/);
 
       src_fields.resize(srcs.size());
       dst_fields.resize(dsts.size());

--- a/src/realm/transfer/transfer.h
+++ b/src/realm/transfer/transfer.h
@@ -426,6 +426,11 @@ namespace Realm {
   protected:
     atomic<int> refcount;
 
+    // test-only constructor: creates a TransferDesc with the given domain,
+    // bypassing check_analysis_preconditions and TransferDomain::construct
+    struct TestTag {};
+    TransferDesc(TestTag, TransferDomain *_domain);
+
     void check_analysis_preconditions();
     bool perform_analysis(TimeLimit work_until);
     void cancel_analysis(Event failed_precondition);

--- a/src/realm/transfer/transfer.h
+++ b/src/realm/transfer/transfer.h
@@ -29,6 +29,8 @@
 #include "realm/transfer/channel.h"
 #include "realm/profiling.h"
 
+class PerformAnalysisTest;
+
 namespace Realm {
 
   // the data transfer engine has too much code to have it all be templated on the
@@ -441,6 +443,7 @@ namespace Realm {
     DeferredAnalysis deferred_analysis;
 
     friend class TransferOperation;
+    friend class ::PerformAnalysisTest;
 
     TransferDomain *domain;
     std::vector<CopySrcDstField> srcs, dsts;

--- a/src/realm/transfer/transfer.h
+++ b/src/realm/transfer/transfer.h
@@ -425,7 +425,7 @@ namespace Realm {
     atomic<int> refcount;
 
     void check_analysis_preconditions();
-    void perform_analysis();
+    bool perform_analysis(TimeLimit work_until);
     void cancel_analysis(Event failed_precondition);
 
     class DeferredAnalysis : public EventWaiter {
@@ -456,6 +456,11 @@ namespace Realm {
     std::vector<FieldInfo> src_fields, dst_fields;
     void *fill_data;
     size_t fill_size;
+    bool analysis_init_done;
+    size_t analysis_field_idx;
+    size_t analysis_fld_start;
+    size_t analysis_fill_ofs;
+    std::vector<bool> analysis_field_done;
     ProfilingMeasurements::OperationMemoryUsage prof_usage;
     ProfilingMeasurements::OperationCopyInfo prof_cpinfo;
   };

--- a/src/realm/transfer/transfer.h
+++ b/src/realm/transfer/transfer.h
@@ -29,8 +29,6 @@
 #include "realm/transfer/channel.h"
 #include "realm/profiling.h"
 
-class PerformAnalysisTest;
-
 namespace Realm {
 
   // the data transfer engine has too much code to have it all be templated on the
@@ -512,7 +510,6 @@ namespace Realm {
     DeferredAnalysis deferred_analysis;
 
     friend class TransferOperation;
-    friend class ::PerformAnalysisTest;
 
     TransferDomain *domain;
     std::vector<CopySrcDstField> srcs, dsts;

--- a/src/realm/transfer/transfer.h
+++ b/src/realm/transfer/transfer.h
@@ -464,10 +464,10 @@ namespace Realm {
     std::vector<FieldInfo> src_fields, dst_fields;
     void *fill_data;
     size_t fill_size;
-    bool analysis_init_done;
-    size_t analysis_field_idx;
-    size_t analysis_fld_start;
-    size_t analysis_fill_ofs;
+    bool analysis_init_done = false;
+    size_t analysis_field_idx = 0;
+    size_t analysis_fld_start = 0;
+    size_t analysis_fill_ofs = 0;
     std::vector<bool> analysis_field_done;
     ProfilingMeasurements::OperationMemoryUsage prof_usage;
     ProfilingMeasurements::OperationCopyInfo prof_cpinfo;

--- a/src/realm/transfer/transfer.inl
+++ b/src/realm/transfer/transfer.inl
@@ -189,6 +189,7 @@ namespace Realm {
     , analysis_successful(false)
     , fill_data(0)
     , fill_size(0)
+    , analysis_init_done(false)
   {
     domain = TransferDomain::construct(_is);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -112,6 +112,7 @@ list(
   nodeset_test.cc
   transfer_iterator_test.cc
   lowlevel_dma_test.cc
+  perform_analysis_test.cc
   circ_queue_test.cc
   gather_scatter_test.cc
   sparsity_map_test.cc

--- a/tests/unit_tests/perform_analysis_test.cc
+++ b/tests/unit_tests/perform_analysis_test.cc
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2025 Stanford University, NVIDIA Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "realm/transfer/transfer.h"
+#include "realm/timers.h"
+#include <gtest/gtest.h>
+
+using namespace Realm;
+
+// PerformAnalysisTest is a friend of TransferDesc, allowing direct access to
+// protected members for testing the incremental analysis behavior.
+class PerformAnalysisTest : public ::testing::Test {
+protected:
+  // Helper to construct a TransferDesc with an empty domain and no fields.
+  // The constructor calls check_analysis_preconditions -> perform_analysis,
+  // which returns immediately for an empty domain (no runtime needed).
+  static TransferDesc *create_empty_desc()
+  {
+    IndexSpace<1, int> empty_is = IndexSpace<1, int>::make_empty();
+    std::vector<CopySrcDstField> srcs;
+    std::vector<CopySrcDstField> dsts;
+    std::vector<const CopyIndirection<1, int>::Base *> indirects;
+    ProfilingRequestSet prs;
+    TransferDesc *desc = new TransferDesc(empty_is, srcs, dsts, indirects, prs);
+    return desc;
+  }
+
+  // Reset a TransferDesc's analysis state so perform_analysis can be called
+  // again with a non-empty domain and dummy fields.
+  static void reset_for_nonempty_analysis(TransferDesc *desc, size_t num_fields)
+  {
+    // Replace the empty domain with a non-empty 1D domain
+    delete desc->domain;
+    IndexSpace<1, int> nonempty_is(Rect<1, int>(0, 9));
+    desc->domain = TransferDomain::construct(nonempty_is);
+
+    // Reset analysis state
+    desc->analysis_complete.store(false);
+    desc->analysis_successful = false;
+    desc->analysis_init_done = false;
+    desc->analysis_field_idx = 0;
+    desc->analysis_fld_start = 0;
+    desc->analysis_fill_ofs = 0;
+    desc->analysis_field_done.clear();
+
+    // Reset graph
+    desc->graph.xd_nodes.clear();
+    desc->graph.ib_edges.clear();
+    desc->graph.ib_alloc_order.clear();
+
+    // Reset fields
+    desc->dim_order.clear();
+    desc->src_fields.clear();
+    desc->dst_fields.clear();
+    if(desc->fill_data) {
+      free(desc->fill_data);
+      desc->fill_data = nullptr;
+    }
+    desc->fill_size = 0;
+
+    // Set up dummy src/dst field pairs. Use NO_INST so that
+    // choose_dim_order skips the preferred_dim_order call (which requires
+    // the runtime). The loop body won't execute in timeout tests since
+    // is_expired() fires before any per-field work.
+    desc->srcs.clear();
+    desc->dsts.clear();
+    for(size_t i = 0; i < num_fields; i++) {
+      CopySrcDstField src;
+      src.set_field(RegionInstance::NO_INST, FieldID(i), /*size=*/8);
+      CopySrcDstField dst;
+      dst.set_field(RegionInstance::NO_INST, FieldID(i), /*size=*/8);
+      desc->srcs.push_back(src);
+      desc->dsts.push_back(dst);
+    }
+  }
+
+  // Accessors for protected members (friendship is not inherited by TEST_F
+  // subclasses, so all access must go through PerformAnalysisTest methods).
+  static bool call_perform_analysis(TransferDesc *desc, TimeLimit work_until)
+  {
+    return desc->perform_analysis(work_until);
+  }
+  static bool get_analysis_complete(TransferDesc *desc)
+  {
+    return desc->analysis_complete.load();
+  }
+  static bool get_analysis_init_done(TransferDesc *desc)
+  {
+    return desc->analysis_init_done;
+  }
+  static size_t get_analysis_field_idx(TransferDesc *desc)
+  {
+    return desc->analysis_field_idx;
+  }
+  static size_t get_dim_order_size(TransferDesc *desc)
+  {
+    return desc->dim_order.size();
+  }
+  static const int *get_dim_order_data(TransferDesc *desc)
+  {
+    return desc->dim_order.data();
+  }
+  static size_t get_src_fields_size(TransferDesc *desc)
+  {
+    return desc->src_fields.size();
+  }
+  static size_t get_dst_fields_size(TransferDesc *desc)
+  {
+    return desc->dst_fields.size();
+  }
+};
+
+// Test that perform_analysis returns true immediately for an empty domain.
+TEST_F(PerformAnalysisTest, EmptyDomainCompletesImmediately)
+{
+  TransferDesc *desc = create_empty_desc();
+
+  // The constructor already ran perform_analysis, which completed for the
+  // empty domain case.
+  EXPECT_TRUE(get_analysis_complete(desc));
+
+  desc->remove_reference();
+}
+
+// Test that perform_analysis with an immediately-expired TimeLimit returns
+// false (timed out) without completing the analysis.
+TEST_F(PerformAnalysisTest, ExpiredTimeLimitCausesTimeout)
+{
+  TransferDesc *desc = create_empty_desc();
+  ASSERT_TRUE(get_analysis_complete(desc));
+
+  // Reset state for a non-empty analysis with multiple fields
+  const size_t num_fields = 5;
+  reset_for_nonempty_analysis(desc, num_fields);
+  ASSERT_FALSE(get_analysis_complete(desc));
+  ASSERT_FALSE(get_analysis_init_done(desc));
+
+  // Call perform_analysis with an already-expired time limit.
+  // The init phase runs (it doesn't check the time limit), but the loop
+  // should immediately detect the expired limit and return false.
+  bool completed = call_perform_analysis(desc, TimeLimit::relative(0));
+
+  EXPECT_FALSE(completed);
+  // Init should have completed
+  EXPECT_TRUE(get_analysis_init_done(desc));
+  // But the field loop should not have progressed
+  EXPECT_EQ(get_analysis_field_idx(desc), 0u);
+  // analysis_complete should still be false
+  EXPECT_FALSE(get_analysis_complete(desc));
+
+  desc->remove_reference();
+}
+
+// Test that after a timeout, calling perform_analysis again with an expired
+// TimeLimit preserves the init state (doesn't redo it).
+TEST_F(PerformAnalysisTest, InitStatePreservedAcrossTimeoutCalls)
+{
+  TransferDesc *desc = create_empty_desc();
+
+  const size_t num_fields = 3;
+  reset_for_nonempty_analysis(desc, num_fields);
+
+  // First call: times out immediately
+  bool completed = call_perform_analysis(desc, TimeLimit::relative(0));
+  ASSERT_FALSE(completed);
+  ASSERT_TRUE(get_analysis_init_done(desc));
+
+  // Verify that dim_order was set during init (1D domain -> single entry)
+  EXPECT_EQ(get_dim_order_size(desc), 1u);
+  // Verify src/dst fields were resized during init
+  EXPECT_EQ(get_src_fields_size(desc), num_fields);
+  EXPECT_EQ(get_dst_fields_size(desc), num_fields);
+
+  // Second call: also times out, but init should not be redone.
+  // Capture dim_order pointer to verify it's the same vector (not reallocated).
+  const int *dim_order_data = get_dim_order_data(desc);
+  completed = call_perform_analysis(desc, TimeLimit::relative(0));
+  EXPECT_FALSE(completed);
+  EXPECT_TRUE(get_analysis_init_done(desc));
+  // dim_order should not have been modified (init was skipped)
+  EXPECT_EQ(get_dim_order_data(desc), dim_order_data);
+
+  desc->remove_reference();
+}

--- a/tests/unit_tests/perform_analysis_test.cc
+++ b/tests/unit_tests/perform_analysis_test.cc
@@ -22,8 +22,6 @@
 using namespace Realm;
 
 // Minimal TransferDomain implementation that avoids runtime dependencies.
-// Used to replace the empty domain after construction so that perform_analysis
-// takes the non-empty path and enters the main field loop.
 class MockTransferDomain : public TransferDomain {
 public:
   TransferDomain *clone() const override { return new MockTransferDomain; }
@@ -65,137 +63,112 @@ public:
   void print(std::ostream &os) const override { os << "MockTransferDomain"; }
 };
 
-// PerformAnalysisTest is a friend of TransferDesc, allowing direct access to
-// protected members for testing the incremental analysis behavior.
-class PerformAnalysisTest : public ::testing::Test {
-protected:
-  // Helper to construct a TransferDesc using the test-only constructor.
-  // This bypasses TransferDomain::construct and check_analysis_preconditions,
-  // avoiding runtime dependencies.
-  static TransferDesc *create_desc(TransferDomain *domain)
-  {
-    return new TransferDesc(TransferDesc::TestTag{}, domain);
-  }
+// Test subclass that exposes TransferDesc's protected members for testing.
+// Uses the TestTag constructor to bypass check_analysis_preconditions (which
+// requires the runtime).
+class TestableTransferDesc : public TransferDesc {
+public:
+  TestableTransferDesc(TransferDomain *domain)
+    : TransferDesc(TestTag{}, domain)
+  {}
 
-  // Set up dummy src/dst field pairs on a TransferDesc. Uses NO_INST so that
-  // choose_dim_order skips the preferred_dim_order call (which requires
-  // the runtime). The loop body won't execute in timeout tests since
-  // is_expired() fires before any per-field work.
-  static void setup_dummy_fields(TransferDesc *desc, size_t num_fields)
+  using TransferDesc::perform_analysis;
+
+  // Accessors for protected state
+  bool get_analysis_complete() const { return analysis_complete.load(); }
+  bool get_analysis_init_done() const { return analysis_init_done; }
+  size_t get_analysis_field_idx() const { return analysis_field_idx; }
+  size_t get_dim_order_size() const { return dim_order.size(); }
+  const int *get_dim_order_data() const { return dim_order.data(); }
+  size_t get_src_fields_size() const { return src_fields.size(); }
+  size_t get_dst_fields_size() const { return dst_fields.size(); }
+
+  // Set up dummy src/dst field pairs. Uses NO_INST so that choose_dim_order
+  // skips the preferred_dim_order call (which requires the runtime). The
+  // loop body won't execute in timeout tests since is_expired() fires
+  // before any per-field work.
+  void add_dummy_fields(size_t num_fields)
   {
     for(size_t i = 0; i < num_fields; i++) {
       CopySrcDstField src;
       src.set_field(RegionInstance::NO_INST, FieldID(i), /*size=*/8);
       CopySrcDstField dst;
       dst.set_field(RegionInstance::NO_INST, FieldID(i), /*size=*/8);
-      desc->srcs.push_back(src);
-      desc->dsts.push_back(dst);
+      srcs.push_back(src);
+      dsts.push_back(dst);
     }
-  }
-
-  // Accessors for protected members (friendship is not inherited by TEST_F
-  // subclasses, so all access must go through PerformAnalysisTest methods).
-  static bool call_perform_analysis(TransferDesc *desc, TimeLimit work_until)
-  {
-    return desc->perform_analysis(work_until);
-  }
-  static bool get_analysis_complete(TransferDesc *desc)
-  {
-    return desc->analysis_complete.load();
-  }
-  static bool get_analysis_init_done(TransferDesc *desc)
-  {
-    return desc->analysis_init_done;
-  }
-  static size_t get_analysis_field_idx(TransferDesc *desc)
-  {
-    return desc->analysis_field_idx;
-  }
-  static size_t get_dim_order_size(TransferDesc *desc) { return desc->dim_order.size(); }
-  static const int *get_dim_order_data(TransferDesc *desc)
-  {
-    return desc->dim_order.data();
-  }
-  static size_t get_src_fields_size(TransferDesc *desc)
-  {
-    return desc->src_fields.size();
-  }
-  static size_t get_dst_fields_size(TransferDesc *desc)
-  {
-    return desc->dst_fields.size();
   }
 };
 
 // Test that perform_analysis returns true immediately for an empty domain.
-TEST_F(PerformAnalysisTest, EmptyDomainCompletesImmediately)
+TEST(PerformAnalysisTest, EmptyDomainCompletesImmediately)
 {
-  // MockEmptyDomain returns empty() == true
   class MockEmptyDomain : public MockTransferDomain {
   public:
     bool empty() const override { return true; }
     size_t volume() const override { return 0; }
   };
 
-  TransferDesc *desc = create_desc(new MockEmptyDomain);
+  TestableTransferDesc *desc = new TestableTransferDesc(new MockEmptyDomain);
 
-  bool completed = call_perform_analysis(desc, TimeLimit());
+  bool completed = desc->perform_analysis(TimeLimit());
   EXPECT_TRUE(completed);
-  EXPECT_TRUE(get_analysis_complete(desc));
+  EXPECT_TRUE(desc->get_analysis_complete());
 
   desc->remove_reference();
 }
 
 // Test that perform_analysis with an immediately-expired TimeLimit returns
 // false (timed out) without completing the analysis.
-TEST_F(PerformAnalysisTest, ExpiredTimeLimitCausesTimeout)
+TEST(PerformAnalysisTest, ExpiredTimeLimitCausesTimeout)
 {
   const size_t num_fields = 5;
-  TransferDesc *desc = create_desc(new MockTransferDomain);
-  setup_dummy_fields(desc, num_fields);
+  TestableTransferDesc *desc = new TestableTransferDesc(new MockTransferDomain);
+  desc->add_dummy_fields(num_fields);
 
   // Call perform_analysis with an already-expired time limit.
   // The init phase runs (it doesn't check the time limit), but the loop
   // should immediately detect the expired limit and return false.
-  bool completed = call_perform_analysis(desc, TimeLimit::relative(0));
+  bool completed = desc->perform_analysis(TimeLimit::relative(0));
 
   EXPECT_FALSE(completed);
   // Init should have completed
-  EXPECT_TRUE(get_analysis_init_done(desc));
+  EXPECT_TRUE(desc->get_analysis_init_done());
   // But the field loop should not have progressed
-  EXPECT_EQ(get_analysis_field_idx(desc), 0u);
+  EXPECT_EQ(desc->get_analysis_field_idx(), 0u);
   // analysis_complete should still be false
-  EXPECT_FALSE(get_analysis_complete(desc));
+  EXPECT_FALSE(desc->get_analysis_complete());
 
   desc->remove_reference();
 }
 
 // Test that after a timeout, calling perform_analysis again with an expired
 // TimeLimit preserves the init state (doesn't redo it).
-TEST_F(PerformAnalysisTest, InitStatePreservedAcrossTimeoutCalls)
+TEST(PerformAnalysisTest, InitStatePreservedAcrossTimeoutCalls)
 {
   const size_t num_fields = 3;
-  TransferDesc *desc = create_desc(new MockTransferDomain);
-  setup_dummy_fields(desc, num_fields);
+  TestableTransferDesc *desc = new TestableTransferDesc(new MockTransferDomain);
+  desc->add_dummy_fields(num_fields);
 
   // First call: times out immediately
-  bool completed = call_perform_analysis(desc, TimeLimit::relative(0));
+  bool completed = desc->perform_analysis(TimeLimit::relative(0));
   ASSERT_FALSE(completed);
-  ASSERT_TRUE(get_analysis_init_done(desc));
+  ASSERT_TRUE(desc->get_analysis_init_done());
 
   // Verify that dim_order was set during init (1D domain -> single entry)
-  EXPECT_EQ(get_dim_order_size(desc), 1u);
+  EXPECT_EQ(desc->get_dim_order_size(), 1u);
   // Verify src/dst fields were resized during init
-  EXPECT_EQ(get_src_fields_size(desc), num_fields);
-  EXPECT_EQ(get_dst_fields_size(desc), num_fields);
+  EXPECT_EQ(desc->get_src_fields_size(), num_fields);
+  EXPECT_EQ(desc->get_dst_fields_size(), num_fields);
 
   // Second call: also times out, but init should not be redone.
   // Capture dim_order pointer to verify it's the same vector (not reallocated).
-  const int *dim_order_data = get_dim_order_data(desc);
-  completed = call_perform_analysis(desc, TimeLimit::relative(0));
+  const int *dim_order_data = desc->get_dim_order_data();
+  completed = desc->perform_analysis(TimeLimit::relative(0));
   EXPECT_FALSE(completed);
-  EXPECT_TRUE(get_analysis_init_done(desc));
+  EXPECT_TRUE(desc->get_analysis_init_done());
   // dim_order should not have been modified (init was skipped)
-  EXPECT_EQ(get_dim_order_data(desc), dim_order_data);
+  EXPECT_EQ(desc->get_dim_order_data(), dim_order_data);
 
   desc->remove_reference();
 }

--- a/tests/unit_tests/perform_analysis_test.cc
+++ b/tests/unit_tests/perform_analysis_test.cc
@@ -68,58 +68,20 @@ public:
 // protected members for testing the incremental analysis behavior.
 class PerformAnalysisTest : public ::testing::Test {
 protected:
-  // Helper to construct a TransferDesc with an empty domain and no fields.
-  // The constructor calls check_analysis_preconditions -> perform_analysis,
-  // which returns immediately for an empty domain (no runtime needed).
-  static TransferDesc *create_empty_desc()
+  // Helper to construct a TransferDesc using the test-only constructor.
+  // This bypasses TransferDomain::construct and check_analysis_preconditions,
+  // avoiding runtime dependencies.
+  static TransferDesc *create_desc(TransferDomain *domain)
   {
-    IndexSpace<1, int> empty_is = IndexSpace<1, int>::make_empty();
-    std::vector<CopySrcDstField> srcs;
-    std::vector<CopySrcDstField> dsts;
-    std::vector<const CopyIndirection<1, int>::Base *> indirects;
-    ProfilingRequestSet prs;
-    TransferDesc *desc = new TransferDesc(empty_is, srcs, dsts, indirects, prs);
-    return desc;
+    return new TransferDesc(TransferDesc::TestTag{}, domain);
   }
 
-  // Reset a TransferDesc's analysis state so perform_analysis can be called
-  // again with a non-empty domain and dummy fields.
-  static void reset_for_nonempty_analysis(TransferDesc *desc, size_t num_fields)
+  // Set up dummy src/dst field pairs on a TransferDesc. Uses NO_INST so that
+  // choose_dim_order skips the preferred_dim_order call (which requires
+  // the runtime). The loop body won't execute in timeout tests since
+  // is_expired() fires before any per-field work.
+  static void setup_dummy_fields(TransferDesc *desc, size_t num_fields)
   {
-    // Replace the empty domain with a non-empty mock domain
-    delete desc->domain;
-    desc->domain = new MockTransferDomain;
-
-    // Reset analysis state
-    desc->analysis_complete.store(false);
-    desc->analysis_successful = false;
-    desc->analysis_init_done = false;
-    desc->analysis_field_idx = 0;
-    desc->analysis_fld_start = 0;
-    desc->analysis_fill_ofs = 0;
-    desc->analysis_field_done.clear();
-
-    // Reset graph
-    desc->graph.xd_nodes.clear();
-    desc->graph.ib_edges.clear();
-    desc->graph.ib_alloc_order.clear();
-
-    // Reset fields
-    desc->dim_order.clear();
-    desc->src_fields.clear();
-    desc->dst_fields.clear();
-    if(desc->fill_data) {
-      free(desc->fill_data);
-      desc->fill_data = nullptr;
-    }
-    desc->fill_size = 0;
-
-    // Set up dummy src/dst field pairs. Use NO_INST so that
-    // choose_dim_order skips the preferred_dim_order call (which requires
-    // the runtime). The loop body won't execute in timeout tests since
-    // is_expired() fires before any per-field work.
-    desc->srcs.clear();
-    desc->dsts.clear();
     for(size_t i = 0; i < num_fields; i++) {
       CopySrcDstField src;
       src.set_field(RegionInstance::NO_INST, FieldID(i), /*size=*/8);
@@ -166,10 +128,17 @@ protected:
 // Test that perform_analysis returns true immediately for an empty domain.
 TEST_F(PerformAnalysisTest, EmptyDomainCompletesImmediately)
 {
-  TransferDesc *desc = create_empty_desc();
+  // MockEmptyDomain returns empty() == true
+  class MockEmptyDomain : public MockTransferDomain {
+  public:
+    bool empty() const override { return true; }
+    size_t volume() const override { return 0; }
+  };
 
-  // The constructor already ran perform_analysis, which completed for the
-  // empty domain case.
+  TransferDesc *desc = create_desc(new MockEmptyDomain);
+
+  bool completed = call_perform_analysis(desc, TimeLimit());
+  EXPECT_TRUE(completed);
   EXPECT_TRUE(get_analysis_complete(desc));
 
   desc->remove_reference();
@@ -179,14 +148,9 @@ TEST_F(PerformAnalysisTest, EmptyDomainCompletesImmediately)
 // false (timed out) without completing the analysis.
 TEST_F(PerformAnalysisTest, ExpiredTimeLimitCausesTimeout)
 {
-  TransferDesc *desc = create_empty_desc();
-  ASSERT_TRUE(get_analysis_complete(desc));
-
-  // Reset state for a non-empty analysis with multiple fields
   const size_t num_fields = 5;
-  reset_for_nonempty_analysis(desc, num_fields);
-  ASSERT_FALSE(get_analysis_complete(desc));
-  ASSERT_FALSE(get_analysis_init_done(desc));
+  TransferDesc *desc = create_desc(new MockTransferDomain);
+  setup_dummy_fields(desc, num_fields);
 
   // Call perform_analysis with an already-expired time limit.
   // The init phase runs (it doesn't check the time limit), but the loop
@@ -208,10 +172,9 @@ TEST_F(PerformAnalysisTest, ExpiredTimeLimitCausesTimeout)
 // TimeLimit preserves the init state (doesn't redo it).
 TEST_F(PerformAnalysisTest, InitStatePreservedAcrossTimeoutCalls)
 {
-  TransferDesc *desc = create_empty_desc();
-
   const size_t num_fields = 3;
-  reset_for_nonempty_analysis(desc, num_fields);
+  TransferDesc *desc = create_desc(new MockTransferDomain);
+  setup_dummy_fields(desc, num_fields);
 
   // First call: times out immediately
   bool completed = call_perform_analysis(desc, TimeLimit::relative(0));

--- a/tests/unit_tests/perform_analysis_test.cc
+++ b/tests/unit_tests/perform_analysis_test.cc
@@ -21,6 +21,49 @@
 
 using namespace Realm;
 
+// Minimal TransferDomain implementation that avoids runtime dependencies.
+// Used to replace the empty domain after construction so that perform_analysis
+// takes the non-empty path and enters the main field loop.
+class MockTransferDomain : public TransferDomain {
+public:
+  TransferDomain *clone() const override { return new MockTransferDomain; }
+  Event request_metadata() override { return Event::NO_EVENT; }
+  bool empty() const override { return false; }
+  size_t volume() const override { return 10; }
+  void choose_dim_order(std::vector<int> &dim_order,
+                        const std::vector<CopySrcDstField> &srcs,
+                        const std::vector<CopySrcDstField> &dsts,
+                        const std::vector<IndirectionInfo *> &indirects,
+                        bool force_fortran_order, size_t max_stride) const override
+  {
+    dim_order.clear();
+    dim_order.push_back(0);
+  }
+  void count_fragments(RegionInstance inst, const std::vector<int> &dim_order,
+                       const std::vector<FieldID> &fields,
+                       const std::vector<size_t> &fld_sizes,
+                       std::vector<size_t> &fragments) const override
+  {
+    fragments.clear();
+  }
+  TransferIterator *create_iterator(RegionInstance inst,
+                                    const std::vector<int> &dim_order,
+                                    const std::vector<FieldID> &fields,
+                                    const std::vector<size_t> &fld_offsets,
+                                    const std::vector<size_t> &fld_sizes) const override
+  {
+    return nullptr;
+  }
+  TransferIterator *create_iterator(RegionInstance inst, RegionInstance peer,
+                                    const std::vector<FieldID> &fields,
+                                    const std::vector<size_t> &fld_offsets,
+                                    const std::vector<size_t> &fld_sizes) const override
+  {
+    return nullptr;
+  }
+  void print(std::ostream &os) const override { os << "MockTransferDomain"; }
+};
+
 // PerformAnalysisTest is a friend of TransferDesc, allowing direct access to
 // protected members for testing the incremental analysis behavior.
 class PerformAnalysisTest : public ::testing::Test {
@@ -43,10 +86,9 @@ protected:
   // again with a non-empty domain and dummy fields.
   static void reset_for_nonempty_analysis(TransferDesc *desc, size_t num_fields)
   {
-    // Replace the empty domain with a non-empty 1D domain
+    // Replace the empty domain with a non-empty mock domain
     delete desc->domain;
-    IndexSpace<1, int> nonempty_is(Rect<1, int>(0, 9));
-    desc->domain = TransferDomain::construct(nonempty_is);
+    desc->domain = new MockTransferDomain;
 
     // Reset analysis state
     desc->analysis_complete.store(false);
@@ -106,10 +148,7 @@ protected:
   {
     return desc->analysis_field_idx;
   }
-  static size_t get_dim_order_size(TransferDesc *desc)
-  {
-    return desc->dim_order.size();
-  }
+  static size_t get_dim_order_size(TransferDesc *desc) { return desc->dim_order.size(); }
   static const int *get_dim_order_data(TransferDesc *desc)
   {
     return desc->dim_order.data();


### PR DESCRIPTION
 Summary                                                                                                                               
   
  - Modified TransferDesc::perform_analysis to accept a TimeLimit parameter and return a bool indicating whether analysis completed (true) or timed out (false)                                                                                                         
  - Added incremental state members (analysis_init_done, analysis_field_idx, analysis_fld_start, analysis_fill_ofs, analysis_field_done) to TransferDesc so that a timed-out analysis can be resumed from where it left off without recomputing prior work                    
  - Pre-loop initialization (profiling setup, fill data allocation, dimension ordering, field resizing) is guarded by analysis_init_done and only runs once across calls                                                                                                      
  - The main field loop checks work_until.is_expired() at each iteration, saving progress and returning false if the time limit is reached                                                                                                                               
  - Both existing callsites updated: check_analysis_preconditions passes an unbounded TimeLimit(), and DeferredAnalysis::event_triggered forwards its work_until parameter (previously ignored per the // TODO: respect time limit comment) 