### PR TITLE
Fix Event Triggering Race

### DIFF
--- a/src/realm/event_impl.cc
+++ b/src/realm/event_impl.cc
@@ -900,9 +900,12 @@ namespace Realm {
         if(free_event) {
           get_runtime()->local_event_free_list->free_entry(event_impl);
         }
-      }
-
-      {
+        // NOTE: do NOT access event_impl after this point - it may have
+        // been returned to the free list and recycled by another thread
+      } else {
+        // an early poison already triggered this event while the merger
+        // was still active, which deferred the free-list insertion -
+        // handle that deferred insertion now
         AutoLock<> a(event_impl->mutex);
         if(event_impl->free_list_insertion_delayed) {
           event_impl->free_list_insertion_delayed = false;


### PR DESCRIPTION
Fixes a race condition in EventMerger::precondition_triggered() that can return a GenEventImpl to the free list twice, causing heap corruption.
                                                                                                                                                                      
  The Bug
                                                                                                                                                                      
  When the last precondition of a merge event fires, precondition_triggered() has two code paths that can free the underlying GenEventImpl:                           
  
  1. Normal trigger path (lines 897-903): When no early poison occurred (faults_observed == 0), calls trigger() which frees the event back to the DynamicTableFreeList pool.                                                    
  2. Delayed insertion path (lines 905-915): Unconditionally checks event_impl->free_list_insertion_delayed under the event's mutex and frees if set.                 
                                                                                                                                                                      
  These two paths are intended to be mutually exclusive — path 1 handles the common case (no poison), and path 2 handles the case where an early poison already triggered the event while the merger was still active (which defers the free via the free_list_insertion_delayed flag). However, path 2 runs unconditionally after path 1, creating a use-after-free window on the pooled event object.                                                                                                
                                                            
  The Race                                                                                                                                                            
  
  1. Thread A is the last trigger for merge event E (generation G). No faults were observed, so the normal trigger path fires and returns E to the free list.         
  2. Thread B calls create_genevent(), pops E from the free list, and reuses it (now generation G+1) for a new merge with multiple preconditions.
  3. Thread B (or one of its precondition callbacks) triggers a poisoned precondition on E. Inside GenEventImpl::trigger(), since the merger is still active (merger.is_active() is true), it sets free_list_insertion_delayed = true under E's mutex and returns free_event = false.                                            
  4. Thread A reaches the delayed insertion check, acquires E's mutex, reads free_list_insertion_delayed = true — a value set by Thread B's completely unrelated merge — and frees E back to the pool a second time.                                                                                                                      
                                                            
  The double-free corrupts the DynamicTableFreeList by creating a self-loop via the next_free pointer (the debug-only assert(entry->next_free == nullptr) in push_front would catch this, but is compiled out in release builds). On the next two allocations, the same GenEventImpl is handed out to two different users simultaneously, causing data races on all event fields. In particular, both users' trigger() calls will invoke current_trigger_op->remove_reference(), prematurely freeing Task objects and corrupting heap metadata. This manifests as malloc(): mismatching next->prev_size (unsorted) on a subsequent allocation — in the reported crash, during Task::operator new in the shutdown flush path.

  The Fix

  Move the free_list_insertion_delayed check into the else branch of the faults check, making the two freeing paths structurally mutually exclusive:                  
  
  - No faults / ignore_faults (if branch): Normal trigger fires and may free the event. The delayed insertion check is skipped entirely — no access to the potentially-recycled event.                               
  - Faults observed (else branch): The normal trigger is skipped (an early poison already triggered the event). The delayed insertion check runs and handles the deferred free.                                                                                                                                                      
  
  This is correct because free_list_insertion_delayed is only ever set when an early poison calls trigger() while the merger is still active — which requires !ignore_faults && faults_observed > 0, exactly the condition that routes to the else branch.