### PR TITLE
More Fast Reservation Fixes

### DIFF
--- a/src/realm/reservation.h
+++ b/src/realm/reservation.h
@@ -129,7 +129,8 @@ namespace Realm {
     // the fast path stores several things in a 32-bit word that can be
     //  atomically updated
     typedef uint32_t State;
-    static const State STATE_READER_COUNT_MASK = 0x03ffffff;
+    static const State STATE_READER_COUNT_MASK = 0x01ffffff;
+    static const State STATE_RELEASING = 0x02000000;
     static const State STATE_SLEEPER = 0x04000000;
     static const State STATE_WRITER = 0x08000000;
     static const State STATE_WRITER_WAITING = 0x10000000;

--- a/src/realm/rsrv_impl.cc
+++ b/src/realm/rsrv_impl.cc
@@ -938,6 +938,17 @@ namespace Realm {
       // read the current state to see if any exceptional conditions exist
       State cur_state = state.load_acquire();
 
+      // if the previous lock holder is in the middle of releasing the lock,
+      //  spin briefly until they finish.  We must not enter the mutex path
+      //  in this case because creating a new waiter_event would orphan it
+      //  (the releasing thread has already done its waiter_event handling).
+      //  STATE_RELEASING is only set transiently between the releaser's
+      //  mutex.unlock and their final state.fetch_sub.
+      if((cur_state & STATE_RELEASING) != 0) {
+        REALM_SPIN_YIELD();
+        continue;
+      }
+
       // if there are no exceptional conditions (sleepers, base_rsrv stuff),
       //  try to clear the WRITER_WAITING (if set), set WRITER, on the
       //  assumption that the READER_COUNT is 0 (i.e. we want the CAS to fail
@@ -987,6 +998,16 @@ namespace Realm {
         //  cannot change out from under us
         cur_state = state.load_acquire();
 
+        // STATE_RELEASING may have been set by a previous holder's
+        //  unlock_slow between our outer-loop check and our mutex
+        //  acquisition. If it's set, release the mutex and spin in the
+        //  outer loop instead of creating a waiter_event.
+        if((cur_state & STATE_RELEASING) != 0) {
+          frs.mutex.unlock();
+          REALM_SPIN_YIELD();
+          continue;
+        }
+
         // goal is to find (or possibly create) a condition we can wait
         //  on before trying again
         Event wait_for = Event::NO_EVENT;
@@ -998,13 +1019,29 @@ namespace Realm {
             break;
           }
 
-          // case 2: a current lock holder is sleeping
+          // case 2: the base reservation has requested the lock back
+          //  (mirrors rdlock_slow case 2)
+          if((cur_state & STATE_BASE_RSRV_WAITING) != 0) {
+            // a) if no holders, swap RSRV_WAITING for RSRV and give the
+            //     base reservation back to the requester
+            if((cur_state & (STATE_WRITER | STATE_READER_COUNT_MASK)) == 0) {
+              REALM_ASSERT((cur_state & STATE_BASE_RSRV) == 0);
+              state.fetch_sub(STATE_BASE_RSRV_WAITING - STATE_BASE_RSRV);
+              frs.rsrv_impl->release(TimeLimit::responsive());
+            }
+            // b) request the reservation back and wait on the grant
+            //     before we attempt to lock again
+            wait_for = frs.request_base_rsrv(*this);
+            break;
+          }
+
+          // case 3: a current lock holder is sleeping
           if((cur_state & STATE_SLEEPER) != 0) {
             wait_for = frs.sleeper_event;
             break;
           }
 
-          // case 3: if we're back to normal readers/writers, don't sleep
+          // case 4: if we're back to normal readers/writers, don't sleep
           //   after all
           if((cur_state &
               ~(STATE_READER_COUNT_MASK | STATE_WRITER | STATE_WRITER_WAITING)) == 0) {
@@ -1132,9 +1169,13 @@ namespace Realm {
       if(state.compare_exchange(cur_state, STATE_WRITER)) // updates cur_state
         return true;
 
-      // simple contention just causes us to return
-      if((cur_state & (STATE_READER_COUNT_MASK | STATE_WRITER | STATE_WRITER_WAITING)) !=
-         0)
+      // simple contention just causes us to return.  STATE_RELEASING
+      //  also counts as contention since the previous holder hasn't
+      //  fully released yet.  STATE_BASE_RSRV_WAITING also counts as
+      //  contention - we cannot cleanly acquire while a remote node has
+      //  demanded the base reservation back.
+      if((cur_state & (STATE_READER_COUNT_MASK | STATE_WRITER | STATE_WRITER_WAITING |
+                       STATE_RELEASING | STATE_BASE_RSRV_WAITING)) != 0)
         return false;
 
       // any other transition requires holding the fast reservation's mutex
@@ -1144,6 +1185,15 @@ namespace Realm {
         // resample the state - since we hold the lock, exceptional bits
         //  cannot change out from under us
         cur_state = state.load_acquire();
+
+        // if a previous holder is in the middle of releasing, or the base
+        //  reservation has been demanded back by a remote node, fail the
+        //  trylock attempt - either condition means we can't cleanly
+        //  acquire without waiting
+        if((cur_state & (STATE_RELEASING | STATE_BASE_RSRV_WAITING)) != 0) {
+          frs.mutex.unlock();
+          return false;
+        }
 
         bool event_needed = false;
 
@@ -1163,9 +1213,9 @@ namespace Realm {
           }
 
           // case 3: if we're back to normal readers/writers, don't sleep
-          //   after all
-          if((cur_state &
-              ~(STATE_READER_COUNT_MASK | STATE_WRITER | STATE_WRITER_WAITING)) == 0) {
+          //   after all (including the transient STATE_RELEASING state)
+          if((cur_state & ~(STATE_READER_COUNT_MASK | STATE_WRITER |
+                            STATE_WRITER_WAITING | STATE_RELEASING)) == 0) {
             break;
           }
 
@@ -1224,6 +1274,13 @@ namespace Realm {
       //  before trying to increment the count
       State cur_state = state.load_acquire();
 
+      // if the previous lock holder is in the middle of releasing the lock,
+      //  spin briefly until they finish.  See wrlock_slow for details.
+      if((cur_state & STATE_RELEASING) != 0) {
+        REALM_SPIN_YIELD();
+        continue;
+      }
+
       // if there are no exceptional conditions (sleeping writer (sleeping
       //  reader is ok), base_rsrv stuff), increment the
       //  reader count and then make sure we didn't race with some other
@@ -1268,6 +1325,16 @@ namespace Realm {
         // resample the state - since we hold the lock, exceptional bits
         //  cannot change out from under us
         cur_state = state.load_acquire();
+
+        // STATE_RELEASING may have been set by a previous holder's
+        //  unlock_slow between our outer-loop check and our mutex
+        //  acquisition. If it's set, release the mutex and spin in the
+        //  outer loop instead of creating a waiter_event.
+        if((cur_state & STATE_RELEASING) != 0) {
+          frs.mutex.unlock();
+          REALM_SPIN_YIELD();
+          continue;
+        }
 
         // goal is to find (or possibly create) a condition we can wait
         //  on before trying again
@@ -1498,14 +1565,26 @@ namespace Realm {
     //  hold exceptional conditions still and then modify state
     frs.mutex.lock();
 
+    // CRITICAL: the public lock release (the final state.fetch_sub that
+    //  clears WRITER or decrements the last reader to zero) must be the
+    //  LAST operation, after all frs.* accesses (including frs.mutex.unlock).
+    //  Once the public lock is released, the FastReservation may be
+    //  deallocated by an external owner, so accessing frs.mutex or
+    //  frs.waiter_event after the release is a use-after-free.
+
     // based on the current state, decide if we're undoing a write lock or
     //  a read lock
     State cur_state = state.load_acquire();
+
+    UserEvent to_trigger;
+    State bits_to_clear = 0;
+
     if((cur_state & STATE_WRITER) != 0) {
       // neither SLEEPER nor BASE_RSRV should be set here
       assert((cur_state & (STATE_SLEEPER | STATE_BASE_RSRV)) == 0);
 
-      // if the base reservation is waiting, give it back
+      // if the base reservation is waiting, give it back (state still has
+      //  STATE_WRITER, so the object cannot be deallocated yet)
       if((cur_state & STATE_BASE_RSRV_WAITING) != 0) {
         // swap RSRV_WAITING for RSRV - this requires BR to not already
         //  be set, otherwise the subtraction would underflow into the
@@ -1515,11 +1594,30 @@ namespace Realm {
         frs.rsrv_impl->release(TimeLimit::responsive());
       }
 
-      // now we can clear the WRITER and WRITER_WAITING bits and finish
-      State bits_to_clear = STATE_WRITER;
-      if((cur_state & STATE_WRITER_WAITING) != 0)
+      // capture waiter_event - writer unlock always frees the lock
+      if(frs.waiter_event.exists()) {
+        to_trigger = frs.waiter_event;
+        frs.waiter_event = UserEvent();
+      }
+
+      // Set STATE_RELEASING under the mutex.  This blocks any new
+      //  thread entering the mutex path (or the line-962 spinner CAS)
+      //  from creating a new waiter_event between our mutex.unlock and
+      //  our final fetch_sub.  Both wrlock_slow and rdlock_slow check
+      //  STATE_RELEASING at the top of their outer loops and spin
+      //  until it clears.  We then atomically clear STATE_WRITER,
+      //  STATE_RELEASING, and STATE_WRITER_WAITING (if set) in a
+      //  single fetch_sub.
+      // We use fetch_or's return value (the state immediately before
+      //  RELEASING was set) rather than the earlier cur_state load to
+      //  catch any STATE_WRITER_WAITING that a spinner may have set
+      //  via line-962 CAS between our load and this fetch_or.  After
+      //  RELEASING is set, no more spinner CASes can succeed, so this
+      //  captures every WW bit we need to clear.
+      State pre_release_state = state.fetch_or(STATE_RELEASING);
+      bits_to_clear = STATE_WRITER | STATE_RELEASING;
+      if((pre_release_state & STATE_WRITER_WAITING) != 0)
         bits_to_clear |= STATE_WRITER_WAITING;
-      state.fetch_sub_acqrel(bits_to_clear);
     } else {
       // we'd better be a reader then
       unsigned reader_count = (cur_state & STATE_READER_COUNT_MASK);
@@ -1540,29 +1638,50 @@ namespace Realm {
         frs.rsrv_impl->release(TimeLimit::responsive());
       }
 
-      // finally, decrement the read count
-      state.fetch_sub_acqrel(1);
+      // For the reader path, when we're not the last reader the lock
+      //  remains held after our decrement, so the object stays alive and
+      //  frs.mutex.unlock() afterward is safe. We do the decrement and
+      //  unlock under the mutex to keep concurrent reader unlocks
+      //  serialized correctly.
+      bool last_reader = (reader_count == 1) && ((cur_state & STATE_WRITER) == 0);
 
-      // only trigger waiter_event if we were the last reader (and no
-      //  writer) - otherwise the waiter can't acquire yet and would
-      //  just have to create a new event
-      if(reader_count > 1 || (cur_state & STATE_WRITER) != 0) {
+      if(!last_reader) {
+        state.fetch_sub_acqrel(1);
         frs.mutex.unlock();
         return;
       }
+
+      // we are the last reader; capture waiter_event, set STATE_RELEASING
+      //  (see writer-path comment), and defer the decrement until after
+      //  we release the mutex.  Use fetch_or's return value (pre-set
+      //  state) to also clear any STATE_WRITER_WAITING that a spinner
+      //  may have set between our cur_state load and this fetch_or -
+      //  see the writer-path comment for the full rationale.
+      if(frs.waiter_event.exists()) {
+        to_trigger = frs.waiter_event;
+        frs.waiter_event = UserEvent();
+      }
+      State pre_release_state = state.fetch_or(STATE_RELEASING);
+      bits_to_clear = 1 + STATE_RELEASING;
+      if((pre_release_state & STATE_WRITER_WAITING) != 0)
+        bits_to_clear |= STATE_WRITER_WAITING;
     }
 
-    // if any waiters are waiting on a spin-timeout event, trigger it
-    //  (writer unlock always gets here; reader unlock only if lock is
-    //  now free)
-    if(frs.waiter_event.exists()) {
-      UserEvent to_trigger = frs.waiter_event;
-      frs.waiter_event = UserEvent();
-      frs.mutex.unlock();
+    // release the mutex BEFORE the public lock release so the object is
+    //  guaranteed alive for our last access to frs.mutex
+    frs.mutex.unlock();
+
+    // release the public lock by atomically clearing all the bits we
+    //  set/owned (W or last reader, RELEASING, and WW if it was set in
+    //  cur_state).  RELEASING blocked any new waiter from entering the
+    //  mutex path during our window, so this fetch_sub cleanly transitions
+    //  the lock to fully released without orphaning anything.  After
+    //  this point the FastReservation may be deallocated.
+    state.fetch_sub_acqrel(bits_to_clear);
+
+    // trigger waiter_event (no frs access)
+    if(to_trigger.exists())
       to_trigger.trigger();
-    } else {
-      frs.mutex.unlock();
-    }
   }
 
   void FastReservation::advise_sleep_entry(UserEvent guard_event)


### PR DESCRIPTION
This is an incremental fix on top of the earlier `Fix Fast Reservations Again (#423)` work. It addresses three remaining bugs found via fuzzer crashes and code review.
                                                                                                                                
  ## Bugs fixed                                             

  ### 1. Use-after-free in `unlock_slow`                                                                                        
   
  The previous `unlock_slow` did its final `state.fetch_sub_acqrel(...)` (releasing the public lock) before `frs.mutex.unlock()`. After the public lock release, an external owner (e.g., a Legion `DistributedCollectable` observing the lock-free state) could deallocate the `FastReservation`. The subsequent `frs.mutex.unlock()` then operated on freed/reused memory, manifesting as `UnfairMutex` assertion failures and accumulating reader-count corruption.                             
                                                            
  ### 2. Orphaned `waiter_event` during the release window                                                                      
   
  After re-ordering `unlock_slow` to release the mutex before the public lock, a window opens where a new mutex-path entrant could take `frs.mutex`, create a new `waiter_event`, set `STATE_WRITER_WAITING`, and return waiting on it — only to be orphaned because the original lock holder's `state.fetch_sub` was about to clear the lock without triggering the new event.
                                                                                                                                
  ### 3. Missing BRW handler in `wrlock_slow`'s case switch (latent)                                                            
   
  `wrlock_slow`'s mutex-path case switch handled BR (case 1), SLEEPER (case 2), and clean R/W/WW (case 3), but had no handler for `STATE_BASE_RSRV_WAITING` set without BR or SLEEPER. `rdlock_slow` had this case (its case 2). When a writer's slow path encountered the BRW-only state — reachable when a remote node demands the base reservation back during writer contention — it hit the fatal "unexpected state" assert. Recently observed via fuzzer (likely also exposed indirectly by the corruption from bug 1, but is a latent bug regardless).                   

  ## Changes

  ### `src/realm/reservation.h`                                                                                                 
   
  - Added `STATE_RELEASING = 0x02000000` (bit 25). Reduced `STATE_READER_COUNT_MASK` to 25 bits (`0x01ffffff`, max ~33M concurrent readers).                                      
                                                                                                                                
  ### `src/realm/rsrv_impl.cc`                              

  **`unlock_slow` restructured to fix the UAF:**
                                                                                                                                
  - Releases `frs.mutex` BEFORE the final `state.fetch_sub_acqrel(...)`. All `frs.*` accesses (including `frs.mutex.unlock()`) now complete while the public lock is still held, ensuring the FastReservation is alive throughout. After the final           
  `fetch_sub_acqrel`, no `frs.*` access occurs.             
  - Snapshots `frs.waiter_event` under the mutex before the release; triggers it after `frs.mutex.unlock()` and `fetch_sub` (using only the local `to_trigger` UserEvent, not any `frs.*` field).                                                         
  - Reader path: non-last readers decrement under the mutex (preserves serialization across concurrent reader unlocks); only the last reader defers the decrement until after `frs.mutex.unlock()`.                                                           
                                                            
  **`STATE_RELEASING` mechanism to close the new-waiter orphan window:**                                                        
                                                                                                                                
  - `unlock_slow` sets `STATE_RELEASING` under the mutex via `state.fetch_or(STATE_RELEASING)`, then releases the mutex. New mutex-path entrants see `STATE_RELEASING` and spin instead of creating a `waiter_event`. `STATE_RELEASING` is cleared atomically with `STATE_WRITER` (or last reader's R count) in the final `fetch_sub_acqrel`, along with `STATE_WRITER_WAITING` if it was set.                                                                                                                
  - Uses the return value of `state.fetch_or(STATE_RELEASING)` (the pre-set state) to compute `bits_to_clear`, capturing any `STATE_WRITER_WAITING` that a spinner may have set between the initial `cur_state` load and our `fetch_or`. After `STATE_RELEASING` is set, no more spinner CASes can succeed.
  - Both `wrlock_slow` and `rdlock_slow` outer loops check `STATE_RELEASING` at the top of each iteration and spin if set.      
  - Both slow paths have a defensive secondary `STATE_RELEASING` check after acquiring `frs.mutex` (in case `STATE_RELEASING` was set between the outer-loop check and mutex acquisition).                                                                  
  - `trywrlock_slow` treats both `STATE_RELEASING` and `STATE_BASE_RSRV_WAITING` as contention (returns false) in both the outer fast-path check and the post-mutex-acquisition check.                                                                        
                                                            
  **`wrlock_slow` BRW handler:**                                                                                                
                                                                                                                                
  - Added a new case 2 to `wrlock_slow`'s mutex-path case switch (mirroring `rdlock_slow`'s case 2): handles 
  `STATE_BASE_RSRV_WAITING` by either swapping BRW→BR + releasing the base reservation (when no holders) or just calling `request_base_rsrv` to register a pending request, then returning the resulting event. Includes the `REALM_ASSERT((cur_state & STATE_BASE_RSRV) == 0)` guard before the BRW-swap arithmetic.                                                                
  - Renumbered the subsequent cases (old case 2 SLEEPER → case 3; old case 3 clean R/W/WW → case 4) for consistency with `rdlock_slow`.                                                                                                                
   
  ## Correctness                                                                                                                
                                                            
  Five-property static analysis was conducted to verify the fix:
                                                                                                                                
  1. **State-machine correctness**: every reachable `cur_state` at every program point now has a handler. The previous BRW gap in `wrlock_slow` is closed; `STATE_RELEASING` states are filtered by the outer-loop and mutex-path-entry checks before reaching the case switch.                                 
  2. **Invariant preservation**: 11 named invariants verified across every primitive state mutation, including new invariants I9 (RELEASING ⟹ W or R>0), I10 (at most one thread sets RELEASING at a time), I11 (state stable while RELEASING is set, except by the setter's `fetch_sub`).
  3. **Lifetime / memory safety**: every `frs.*` access (including `frs.mutex.unlock()`) happens while the FastReservation is   
  guaranteed alive (the public lock is still held).                                                                             
  4. **Deadlock freedom**: no lock-order cycles introduced; no re-entrancy issues; bounded RELEASING-spin.
  5. **Liveness**: the `STATE_RELEASING` mechanism eliminates the orphan-event hang that would otherwise be possible during the release window.                                                                                                               
                                                                                                                                
  ## Performance                                                                                                                
                                                            
  All changes are confined to slow paths or are no-op-equivalent constant changes:
                                                                                                                                
  - **Uncontended operations: zero overhead.**
  - **Contended operations with a registered waiter: zero overhead.**                                                           
  - **Reader count maximum reduced** from ~67M to ~33M (one bit reallocated to `STATE_RELEASING`). Realistic workloads are far below this limit. 