### PR TITLE
realm: Remove file descriptor fallback if fabric handles don't work

### DIFF
--- a/src/realm/cuda/cuda_module.cc
+++ b/src/realm/cuda/cuda_module.cc
@@ -2393,18 +2393,9 @@ namespace Realm {
           alloc = GPUAllocation::allocate_mmap(gpu, mem_prop, size, 0,
                                                /*peer_enabled=*/true);
         }
-        if(alloc == nullptr) {
-#if defined(REALM_ON_WINDOWS)
-          mem_prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_WIN32;
-#else
-          mem_prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+      }
 #endif
-          alloc = GPUAllocation::allocate_mmap(gpu, mem_prop, size, 0,
-                                               /*peer_enabled=*/true);
-        }
-      } else
-#endif
-      {
+      if(alloc == nullptr) {
         alloc = GPUAllocation::allocate_dev(gpu, size, /*peer_enabled=*/true,
                                             /*shareable=*/true);
       }


### PR DESCRIPTION
Remove the file descriptor fallback path for allocation, as sharing with file descriptors is not implemented just yet.  If fabric handle allocation fails, just fallback to cudaipc.