### PR TITLE
Fix Use-After-Free Race in Push Packets

### DIFF
--- a/src/realm/gasnetex/gasnetex_internal.cc
+++ b/src/realm/gasnetex/gasnetex_internal.cc
@@ -1848,12 +1848,25 @@ namespace Realm {
     }
 
     // get the head of our pbuf list - if it's empty, something's wrong because
-    //  we shouldn't have gotten here
-    OutbufMetadata *head = first_pbuf.load_acquire();
-    assert(head);
+    //  we shouldn't have gotten here.  the load and state check happen under
+    //  the mutex so that they're serialized against any concurrent pop in
+    //  reserve_pbuf_helper - without this, an unsynchronized load_acquire can
+    //  race with the reserver's pop+close (which runs outside the mutex) and
+    //  observe a buffer whose state has been transitioned to STATE_IDLE
+    OutbufMetadata *head;
+    {
+      AutoLock<> al(mutex);
+      // we should only reach this point with has_ready_packets true - the
+      //  comp_reply and put_head paths above are supposed to return early
+      //  otherwise.  assert it so we catch any path that violates the
+      //  invariant the lifetime guarantee depends on
+      assert(has_ready_packets);
+      head = first_pbuf.load();
+      assert(head);
+      assert(head->state == OutbufMetadata::STATE_PKTBUF);
+    }
 
     while(true) {
-      assert(head->state == OutbufMetadata::STATE_PKTBUF);
 
       OutbufMetadata *realbuf;
       if(head->is_overflow) {
@@ -2483,9 +2496,15 @@ namespace Realm {
             requeue = put_head.load() || (comp_reply_count.load() != 0);
             push_mutex_check.unlock();
           } else {
-            // we can remove the head and work on the next one
+            // we can remove the head and work on the next one - verify the
+            //  successor's state under the same mutex that serializes pops,
+            //  so that the iter-N+1 invariant check is race-free (the old
+            //  top-of-loop assert at line 1856 has been removed for the same
+            //  reason)
             new_head = head->nextbuf;
             first_pbuf.store(new_head);
+            assert(new_head);
+            assert(new_head->state == OutbufMetadata::STATE_PKTBUF);
           }
         } else {
           // more stuff in this pktbuf - requeue if we see any have become


### PR DESCRIPTION
  Fix a rare use-after-free race in `XmitSrcDestPair::push_packets` that                                                                                
  manifests as the assertion `head->state == OutbufMetadata::STATE_PKTBUF`
  firing at gasnetex_internal.cc:1856.                                                                                                                  
                                                                                                                                                        
  ## The race                                                                                                                                           
                                                                                                                                                        
  `push_packets` reads the head of its pbuf chain with an atomic load that
  is **not** held under `xpair.mutex`:                                                                                                                  
                                                                                                                                                        
  ```cpp                                                                                                                                                
  OutbufMetadata *head = first_pbuf.load_acquire();   // line 1852                                                                                      
  assert(head);                                                                                                                                         
  while(true) {
    assert(head->state == OutbufMetadata::STATE_PKTBUF);  // line 1856 
```                                                                                 
                                                            
  Meanwhile, reserve_pbuf_helper (line 1207) and push_packets's own                                                                                     
  advance step (line 2487) both atomically swap a new pbuf into first_pbuf
  under xpair.mutex, drop the mutex, and then call                                                                                                      
  popped_head->pktbuf_close() outside the mutex. The close can transition                                                                               
  the popped buffer's state to STATE_IDLE and put it back on                                                                                            
  OutbufManager::first_available, where another alloc_outbuf may                                                                                        
  immediately re-claim it (calling set_state(STATE_PKTBUF) again, resetting                                                                             
  all its fields).                                                                                                                                      
                                                                                                                                                        
  The atomic on first_pbuf guarantees the pointer is consistent — every                                                                                 
  load returns either the old or the new value — but it doesn't extend the                                                                              
  object's lifetime past the publication of a new value. A reader who                                                                                   
  loads the old value can race with the publisher's close:                                                                                              
                                                                                                                                                        
  T1   pusher:    head = first_pbuf.load_acquire();             // got old X                                                                            
  T2   publisher: <mutex>; first_pbuf = newY; popped = X; <unmutex>;                                                                                    
  T3   publisher: X->pktbuf_close();   // X freed, state→IDLE                                                                                           
  T4   pusher:    head->state          // dereferences X — too late                                                                                     
                                                                                                                                                        
  This is the same shape as classic lock-free dequeue UAFs: the publication                                                                             
  of a new head is properly synchronized, but reclamation of the old head                                                                               
  isn't fenced against readers who already loaded its pointer.                                                                                          
                                                                                                                                                        
  The lifetime invariant the code already relies on — "while                                                                                            
  has_ready_packets == true, the reserver won't pop the head" — is sound                                                                                
  during the pusher's use of head (the inner work loop). The hole is                                                                                    
  strictly at the load itself: the load is unsynchronized with any pop                                                                                  
  that may have already happened or be about to happen.                                                                                                 
                                                                                                                                                        
##  The fix                                                                                                                                               
                                                            
  Take xpair.mutex around the line-1852 load and the initial state check.                                                                               
  This serializes the load against the reserver's pop:
                                                                                                                                                        
  - If a pop happens first, the pusher reads the new head (in-chain, safe).                                                                             
  - If the load happens first, the pusher reads the old head while                                                                                      
  has_ready_packets is still true under the same lock; the lifetime                                                                                     
  invariant takes over and keeps the buffer alive across the subsequent                                                                                 
  inner work loop.                                                                                                                                      
                                                                                                                                                        
  The iter-N+1 invariant assertion (the loop-top assert(head->state == ...)                                                                             
  that the compiler fuses with the post-pktbuf_close block) is moved into
  the advance step, where it now runs under the same xpair.mutex that                                                                                   
  publishes the new first_pbuf. That way every state check is race-free                                                                                 
  without needing to hold the mutex across pktbuf_close itself.                                                                                         
                                                                                                                                                        
  pktbuf_close() deliberately stays outside the mutex at both call                                                                                      
  sites (line 1233, line 2505). Holding xpair.mutex across it would                                                                                     
  serialize commits and reservations behind:                                                                                                            
                                                                                                                                                        
  - OutbufManager::mutex (free-list manipulation in free_outbuf),                                                                                       
  - make_active() (a bgwork wake-up — exactly the kind of nested locking                                                                                
  that bit this code in the past, see commit 30da2be37b),                                                                                               
  - and free() / delete this for overflow buffers (system allocator).                                                                                   
                                                                                                                                                        
  Keeping close outside the lock is fine because, after the fix, the only                                                                               
  reader who could observe a stale head pointer is a pusher whose load                                                                                  
  happened under the same mutex as the pop — and we've serialized those.                                                                                
                                                                                                                                                        
## Defensive assertion                                                                                                                                   
                                                                                                                                                        
  The fix also adds assert(has_ready_packets) immediately after the
  mutex-held load. The reasoning: every code path that reaches this point
  should have has_ready_packets == true (the comp-reply and put-header                                                                                  
  paths above are written to early-return otherwise), and the lifetime                                                                                  
  guarantee for the loaded head depends on that being true. If a future                                                                                 
  change introduces a path that reaches line 1850 with the flag false, the                                                                              
  assertion catches it immediately rather than producing a hard-to-debug                                                                                
  UAF later.