### PR TITLE
Fix GASNetEX Polling Bug

### DIFF
--- a/src/realm/gasnetex/gasnetex_internal.cc
+++ b/src/realm/gasnetex/gasnetex_internal.cc
@@ -899,9 +899,17 @@ namespace Realm {
         assert(grp_index < (1 << LOG2_MAXGROUPS));
       }
     }
-    // increment the num_groups - it's ok if these increments happen out of
-    //  order
-    num_groups.fetch_add(1);
+    // monotonically advance num_groups to at least grp_index + 1.  fetch_add
+    //  is incorrect here: when a concurrent allocator is preempted between
+    //  its successful CAS into groups[] and its update of num_groups, a later
+    //  allocator can read the stale num_groups, collide on the lower slot, and
+    //  win CAS at a higher grp_index.  if that higher-index thread then
+    //  finishes (with fetch_add it would advance num_groups by only 1) and
+    //  hands its newly-indexed completion to a caller that sends an AM, the
+    //  reply's lookup_completion sees grp_index >= num_groups and aborts even
+    //  though groups[grp_index] is fully populated.  fetch_max ensures
+    //  num_groups always covers the highest populated slot.
+    num_groups.fetch_max(grp_index + 1);
 
     // give all these new completions their indices and pointer to us
     for(size_t i = 0; i < (1 << PendingCompletionGroup::LOG2_GROUPSIZE); i++) {


### PR DESCRIPTION
Fixes a crash in PendingCompletionManager::lookup_completion (src/realm/gasnetex/gasnetex_internal.cc:953) where a valid completion index spuriously fails the grp_index >= num_groups bounds check and aborts.                                                                                            
                                                                                                                                                        
  The race                                                                                                                                              
                                                                                                                                                        
  PendingCompletionManager::get_available() allocates a new PendingCompletionGroup by:                                                                  
                                                            
  1. Loading num_groups as a starting hint for grp_index.                                                                                               
  2. Walking forward through groups[] with compare_exchange until it wins an empty slot.
  3. Calling num_groups.fetch_add(1) to advance the counter.                                                                                            
  4. Initializing the new group's entries and pushing all but the first onto the free list.                                                             
  5. Returning entries[0] to the caller, which fills in callbacks and sends an AM whose comp_info encodes the new entry's index.                        
                                                                                                                                                        
  When the AM reply comes back, handle_completion_reply calls lookup_completion(index), which checks grp_index < num_groups and aborts otherwise.       
                                                                                                                                                        
  The flaw is in step 3: fetch_add(1) advances num_groups by exactly one, but the scan in step 2 may have skipped past slots claimed by concurrent allocators. Two threads racing here can leave num_groups lower than the highest populated groups[] slot:
                                                                                                                                                        
  1. Thread A reads num_groups = 0, wins CAS at groups[0], is preempted before fetch_add.                                                               
  2. Thread B reads num_groups = 0 (still — A hasn't bumped it), loses CAS at groups[0], increments grp_index to 1, wins CAS at groups[1].
  3. Thread B does fetch_add(1), leaving num_groups = 1 even though groups[1] is its own newly populated slot.                                          
  4. Thread B initializes its entries (indices 256..511), returns entries[0] (index = 256) to its caller, which sends an AM.                            
  5. The reply arrives. lookup_completion(256) computes grp_index = 1, observes num_groups = 1, and aborts.                                             
  6. Thread A finally runs its fetch_add, bringing num_groups to 2 — which is what gdb sees after the abort has already fired.                          
                                                                                                                                                        
  This matches the observed crash exactly: index=256, grp_index=1, num_groups=2 at gdb time, with num_groups having advanced from 1 to 2 in the window between the bounds check and gdb attaching.                                                                                                           
                                                                                                                                                        
  The previous assert(grp_index < (1 << LOG2_MAXGROUPS)) check tolerated this race because it only validated against the static maximum; the recent tightening to check against num_groups exposed it.
                                                                                                                                                        
  The fix                                                   

  Replace num_groups.fetch_add(1) with num_groups.fetch_max(grp_index + 1). This makes num_groups a high-water mark over the highest populated groups[] index, so it correctly reflects which slots are addressable regardless of the order in which racing allocators complete. Other uses of num_groups (the destructor's iteration and the starting hint in step 1) work unchanged because they only require num_groups to bound the populated slots, not count them exactly.