### PR TITLE
Fix Transfer Descriptor Lifetime

### DIFF
--- a/src/realm/transfer/transfer.cc
+++ b/src/realm/transfer/transfer.cc
@@ -3963,6 +3963,11 @@ namespace Realm {
       Event merged = Event::merge_events(preconditions);
       if(merged.exists()) {
         deferred_analysis.precondition = merged;
+        // hold a reference until deferred_analysis fires - otherwise the only
+        //  references to this desc are held by TransferOperations, which can
+        //  go away (e.g. via a poisoned wait_on) before the analysis
+        //  precondition triggers, leaving &deferred_analysis dangling
+        add_reference();
         EventImpl::add_waiter(merged, &deferred_analysis);
         return;
       }
@@ -4684,11 +4689,16 @@ namespace Realm {
                                                        TimeLimit work_until)
   {
     // TODO: respect time limit
+    // stash desc locally - remove_reference() below may delete *desc, and
+    //  `this` is a member of *desc, so we must not touch either afterwards
+    TransferDesc *descriptor = desc;
     if(poisoned) {
-      desc->cancel_analysis(precondition);
+      descriptor->cancel_analysis(precondition);
     } else {
-      desc->perform_analysis(TimeLimit());
+      descriptor->perform_analysis(TimeLimit());
     }
+    // matches the add_reference() in check_analysis_preconditions
+    descriptor->remove_reference();
   }
 
   void TransferDesc::DeferredAnalysis::print(std::ostream &os) const


### PR DESCRIPTION
Fix a use-after-free of TransferDesc that can manifest as an UnfairMutex::unlock_slow() assertion failure inside TransferDesc::perform_analysis.      
   
  Bug                                                                                                                                                   
                                                            
  TransferDesc::check_analysis_preconditions registers &deferred_analysis (a member of the TransferDesc) as an EventWaiter on the merged metadata-precondition event without taking a reference on the desc. The desc's lifetime is held only by its TransferOperation(s) via add_reference in the op constructor.                                                                                                                                   
                                                            
  If the only TransferOperation is destroyed before the analysis precondition fires — e.g. its wait_on is poisoned, so DeferredStart::event_triggered runs handle_poisoned_precondition → mark_finished → ~TransferOperation → desc.remove_reference() — the desc's refcount drops to zero and it is deleted while &deferred_analysis is still queued in the event's waiter list. When the precondition later triggers, EventTriggerNotifier::do_work invokes event_triggered on the dangling waiter, and perform_analysis runs on freed memory. The corrupted mutex.state then trips the `((prev & 1) != 0) && (prev >= 3)` assertion in unlock_slow.

  The same pattern can also fire if an op is destroyed concurrently while perform_analysis holds the desc's mutex.                                      
  
  Fix                                                                                                                                                   
                                                            
  Treat the queued &deferred_analysis waiter as a reference holder:                                                                                     
  
  - check_analysis_preconditions: call add_reference() immediately before EventImpl::add_waiter(merged, &deferred_analysis).                            
  - DeferredAnalysis::event_triggered: stash desc in a local and call remove_reference() after perform_analysis/cancel_analysis returns. The local is required because remove_reference() may delete *desc, and this is a member of *desc.                                                                  
                                                            
  The other paths in check_analysis_preconditions (no preconditions, or merged event already triggered) call perform_analysis inline from the constructor and rely on the caller's existing reference, so they need no change.