### PR TITLE
Fix Address List Crash

### DIFF
--- a/src/realm/transfer/address_list.cc
+++ b/src/realm/transfer/address_list.cc
@@ -116,6 +116,11 @@ namespace Realm {
   void AddressList::commit_entry(int act_dim, size_t bytes)
   {
     size_t entries_used = detail::count_index(act_dim);
+    // catch callers whose act_dim exceeds the max_dim they reserved with
+    // begin_entry — otherwise the overshoot corrupts adjacent slots (and the
+    // heap if it crosses data.size()) and only surfaces later as a stale
+    // header in read_entry
+    assert(write_pointer + entries_used <= data.size());
     write_pointer += entries_used;
     total_bytes += bytes * (field_block ? field_block->count : 1);
   }

--- a/src/realm/transfer/transfer.cc
+++ b/src/realm/transfer/transfer.cc
@@ -522,8 +522,10 @@ namespace Realm {
       }
 
       // we may be able to compact dimensions, but ask for space to write a
-      //  an address record of the maximum possible dimension (i.e. N)
-      size_t *addr_data = addrlist.begin_entry(N);
+      //  an address record of the maximum possible dimension.  Worst case is
+      //  N + 1: 1 "contig" slot (used even when no dim compacts with
+      //  field_size) plus up to N stride-dim slots.
+      size_t *addr_data = addrlist.begin_entry(N + 1);
       if(!addr_data) {
         return true; // out of space for now
       }


### PR DESCRIPTION
A fuzzer crash surfaced as an assertion failure in AddressList::read_entry():

  Assertion `read_pointer == max_entries' failed.
    in: const size_t* Realm::AddressList::read_entry()
    at: realm/transfer/address_list.cc:152

  with read_pointer = 1002, max_entries = 1000. The crashing thread was a MemfillXferDes consuming addresses from a TransferIteratorIndexSpace<1, long long>.

  Root cause

  In TransferIteratorBase<N, T>::get_addresses (transfer.cc:526), space for the next address entry is reserved with addrlist.begin_entry(N) — i.e. 2*N slots. But the inline entry-building code at transfer.cc:584-640 can produce an entry with cur_dim = N + 1 slots when the first dim's affine stride does not match field_size:
  
  1. The contig-compaction for loop breaks immediately on stride mismatch — no contig dim is folded in, but cur_dim is already 1.
  2. The outer while loop then adds up to N stride dims, taking cur_dim to as much as N + 1.

  For an N=1 iterator with a stride-mismatched first dim, that's cur_dim = 2 — a 4-slot entry written into a 2-slot reservation. When this happens near the end of the buffer (e.g. write_pointer = 998, max_entries = data.size() = 1000):

  - The writer writes slots 998, 999 in-bounds and slots 1000, 1001 past data.size() and past capacity — out-of-bounds heap writes.
  - commit_entry(2, …) advances write_pointer by 4 to 1002.
  - The next begin_entry call wraps. Its zero-fill loop is while(write_pointer < max_entries) — a no-op when write_pointer ≥ max_entries, so slot 998 keeps its bogus act_dim=2 header (value 0x82).
  - A subsequent cycle of 1D entries from the writer reaches write_pointer = 992. The reader, walking 1D entries from slot 0, eventually lands on read_pointer = 998 (past the current writer), reads the stale act_dim=2 header, advances by count_index(2) = 4, and overshoots to read_pointer = 1002. The next read_entry() aborts.

  The corruption was actually catchable at the moment the writer overshot: pre-refactor (d48b3e7342), commit_nd_entry contained assert(write_pointer == MAX_ENTRIES) after the increment, which would have fired immediately on the bad commit. The refactor removed that assert, so the bug now manifests later as a stale-header read in an unrelated cycle.
  
  Fixes

  1. Reserve worst-case slot count in TransferIteratorBase::get_addresses (src/realm/transfer/transfer.cc):

```
  - size_t *addr_data = addrlist.begin_entry(N);
  + size_t *addr_data = addrlist.begin_entry(N + 1);
```

  cur_dim produced by the surrounding compaction logic is at most N + 1 (one contig slot, even when nothing compacted, plus up to N stride-dim slots). Reserving (N+1) dims is sufficient. Over-reservation is benign: commit_entry advances by the actual cur_dim, so the next entry starts immediately after the real one.
  
  2. Add a commit-side sanity check (src/realm/transfer/address_list.cc):

```
  void AddressList::commit_entry(int act_dim, size_t bytes)
  {
    size_t entries_used = detail::count_index(act_dim);
  + // catch callers whose act_dim exceeds the max_dim they reserved with
  + // begin_entry — otherwise the overshoot corrupts adjacent slots (and the
  + // heap if it crosses data.size()) and only surfaces later as a stale
  + // header in read_entry
  + assert(write_pointer + entries_used <= data.size());
    write_pointer += entries_used;
    total_bytes += bytes * (field_block ? field_block->count : 1);
  }
```

  This restores (a sharper version of) the pre-refactor invariant. The assert fires deterministically at the offending commit if any future caller's act_dim exceeds the max_dim they reserved, rather than letting the corruption propagate into stale headers and out-of-bounds heap writes.