### PR TITLE
Fix Latent Get Address Bug

### DIFF
--- a/src/realm/transfer/lowlevel_dma.cc
+++ b/src/realm/transfer/lowlevel_dma.cc
@@ -852,23 +852,22 @@ namespace Realm {
   {
     nonaffine = 0;
 
-    // add a very tall 2d "rectangle" that uses a stride of 0 for the
-    //  line pitch (flow control will prevent any given copy from touching
-    //  the same location twice)
+    // represent the FIFO as a 2D "rectangle": `size` contiguous bytes per
+    // line, with `lines` copies all sharing the same base (stride 0).  Flow
+    // control prevents any single copy from touching the same byte twice.
+    // We use 2D unconditionally — even when `lines == 1` (a FIFO larger than
+    // ~1 GiB), a 2D entry with count=1, stride=0 is equivalent to a 1D span
+    // and keeps the header / slot layout uniform with begin_entry(2).
     size_t lines = std::max<size_t>((1 << 30) / size, 1);
-    int dim = (lines > 1) ? 2 : 1;
-    size_t *data = addrlist.begin_entry(dim);
+    size_t *data = addrlist.begin_entry(2);
     if(!data)
       return true; // can't add more until some is consumed
 
-    // 1-D span from [base,base+size)
-    data[0] = (size << 4) + 2 /*dim*/;
+    data[0] = (size << 4) + 2;
     data[1] = base;
-    if(dim == 2) {
-      data[2] = lines;
-      data[3] = 0; // stride
-    }
-    addrlist.commit_entry(dim, size * lines);
+    data[2] = lines;
+    data[3] = 0; // stride 0 — all "lines" alias the same FIFO buffer
+    addrlist.commit_entry(2, size * lines);
 
     return false; // we can add more if asked
   }


### PR DESCRIPTION
WrappingFIFOIterator::get_addresses (src/realm/transfer/lowlevel_dma.cc) had a latent inconsistency between the address-list slots it reserved, the slots it actually wrote, and the dimensionality it advertised in the entry header:

```
  size_t lines = std::max<size_t>((1 << 30) / size, 1);
  int dim = (lines > 1) ? 2 : 1;
  size_t *data = addrlist.begin_entry(dim);
  ...
  data[0] = (size << 4) + 2 /*dim*/;   // header always claims act_dim=2
  data[1] = base;
  if(dim == 2) {
    data[2] = lines;
    data[3] = 0;
  }
  addrlist.commit_entry(dim, size * lines);
```

  When size > (1 << 30) (a >1 GiB FIFO buffer), lines == 1 so dim == 1. In that branch:

  - begin_entry(1) reserves 2 slots.
  - commit_entry(1) advances write_pointer by 2.
  - But data[0] declares act_dim = 2, and slots data[2] / data[3] (count[1], stride[1] for a 2-dim entry) are never written — they hold either uninitialized data or the start of the next entry.
  - A subsequent reader sees act_dim = 2, reads garbage from those slots, and AddressListCursor::advance bumps read_pointer by count_index(2) = 4 — over-reading the actual entry by 2 slots.

  This is the same class of "reservation / commit / header disagree" bug recently diagnosed in TransferIteratorBase::get_addresses (which we now catch deterministically via the new commit_entry assertion). In WrappingFIFOIterator the symptom is slightly different (under-reservation + lying header rather than over-commit), but the corruption mode is the same: the reader walks past the entry's actual extent into adjacent slots and total_bytes accounting drifts.

  The bug is latent in practice because it only triggers when the wrapping FIFO buffer is larger than ~1 GiB — uncommon for intermediate buffers — but the failure mode is silent corruption rather than a clean abort, so it could surface unpredictably under fuzzing or large-buffer workloads.

  Fix

  Use a uniform 2D representation regardless of lines. The FIFO's semantics map naturally onto a 2D entry where the outer dim has stride = 0 (every "line" aliases the same physical buffer); when lines == 1, the 2D form degenerates correctly to a single-line "rectangle" behaviorally identical to the would-be 1D entry.
  
```
  size_t lines = std::max<size_t>((1 << 30) / size, 1);
  size_t *data = addrlist.begin_entry(2);
  if(!data)
    return true;
  
  data[0] = (size << 4) + 2;
  data[1] = base;
  data[2] = lines;
  data[3] = 0;  // stride 0 — all "lines" alias the same FIFO buffer
  addrlist.commit_entry(2, size * lines);
```

  The dim branch is gone, the misleading "1-D span" comment is replaced, and begin_entry / write / commit_entry / header all agree on act_dim = 2.

  Risk / scope
  
  - Local to a single iterator method.
  - For the common case (size ≤ 1 GiB, so lines > 1), behavior is unchanged — the code already took the 2D path. Only the previously-broken size > 1 GiB path changes, from "produce a malformed entry" to "produce a well-formed 2D entry with lines = 1".
  - Consumers (e.g. MemfillXferDes::progress_xd) already handle 2D entries uniformly; making the 1D case go through the same shape costs at most one extra stride/count read per entry.
  - With the companion commit_entry invariant assertion added in the address-list fix, any future regression of this class will fail loudly at the point of corruption rather than as a delayed read_entry overshoot.

  Related
  
  This is a follow-up to the TransferIteratorBase::get_addresses overrun fix in the same area. Both bugs share the underlying lesson: begin_entry(N) / commit_entry(M) callers must keep N, M, and the header's act_dim field in sync, and the address-list API now asserts this invariant on commit.