### PR TITLE
DO NOT MERGE: Debugging GASNetEX Module

### DIFF
--- a/src/realm/gasnetex/gasnetex_internal.cc
+++ b/src/realm/gasnetex/gasnetex_internal.cc
@@ -295,15 +295,22 @@ namespace Realm {
     return true;
   }
 
+  // debug instrumentation: global cross-buffer event ring definitions
+  GlobalEventRecord g_event_ring[GLOBAL_EVENT_RING_SIZE];
+  atomic<uint32_t> g_event_ring_seq{0};
+
   void OutbufMetadata::record_event(EventType type, void *caller_pc, void *xpair,
                                     void *first_pbuf_at, void *cur_pbuf_at,
                                     bool has_ready_at)
   {
+    uint64_t ts = __builtin_ia32_rdtsc();
+    uint64_t tid = static_cast<uint64_t>(syscall(SYS_gettid));
+
     uint32_t idx = event_ring_seq.fetch_add(1) & (EVENT_RING_SIZE - 1);
     EventRecord &ev = event_ring[idx];
-    ev.timestamp = __builtin_ia32_rdtsc();
+    ev.timestamp = ts;
     ev.caller = caller_pc;
-    ev.thread_id = static_cast<uint64_t>(syscall(SYS_gettid));
+    ev.thread_id = tid;
     ev.xpair = xpair;
     ev.first_pbuf = first_pbuf_at;
     ev.cur_pbuf = cur_pbuf_at;
@@ -315,10 +322,22 @@ namespace Realm {
     ev.state_at_event = state;
     ev.has_ready = has_ready_at;
     ev.event_type = type;
+
+    // also write to global cross-buffer ring for temporal correlation
+    uint32_t gidx = g_event_ring_seq.fetch_add(1) & (GLOBAL_EVENT_RING_SIZE - 1);
+    GlobalEventRecord &gev = g_event_ring[gidx];
+    gev.timestamp = ts;
+    gev.thread_id = tid;
+    gev.buffer = this;
+    gev.caller = caller_pc;
+    gev.event_type = static_cast<uint8_t>(type);
   }
 
   void OutbufMetadata::pktbuf_close()
   {
+    // debug instrumentation: increment entry counter BEFORE record_event so we
+    //  can detect if record_event is being elided (counter > CLOSE event count)
+    pktbuf_close_entries.fetch_add(1);
     // debug instrumentation: record close event before any state changes
     record_event(EVENT_CLOSE, __builtin_return_address(0));
     assert(state == STATE_PKTBUF);
@@ -571,6 +590,9 @@ namespace Realm {
 
   void OutbufManager::free_outbuf(OutbufMetadata *md)
   {
+    // debug instrumentation: increment entry counter BEFORE record_event so we
+    //  can detect if record_event is being elided (counter > FREE event count)
+    md->free_outbuf_entries.fetch_add(1);
     // debug instrumentation: record free event before state goes to IDLE
     md->record_event(OutbufMetadata::EVENT_FREE, __builtin_return_address(0));
     // overflow bufs should never get here

--- a/src/realm/gasnetex/gasnetex_internal.cc
+++ b/src/realm/gasnetex/gasnetex_internal.cc
@@ -301,6 +301,7 @@ namespace Realm {
   {
     uint32_t idx = event_ring_seq.fetch_add(1) & (EVENT_RING_SIZE - 1);
     EventRecord &ev = event_ring[idx];
+    ev.timestamp = __builtin_ia32_rdtsc();
     ev.caller = caller_pc;
     ev.thread_id = static_cast<uint64_t>(syscall(SYS_gettid));
     ev.xpair = xpair;
@@ -311,6 +312,7 @@ namespace Realm {
     ev.pktbuf_ready = pktbuf_ready_packets.load();
     ev.pktbuf_use_count = pktbuf_use_count;
     ev.remain_count = remain_count.load();
+    ev.state_at_event = state;
     ev.has_ready = has_ready_at;
     ev.event_type = type;
   }

--- a/src/realm/gasnetex/gasnetex_internal.cc
+++ b/src/realm/gasnetex/gasnetex_internal.cc
@@ -23,6 +23,10 @@
 #include "realm/mem_impl.h"
 #include "realm/logging.h"
 
+// for gettid() in OutbufMetadata free instrumentation
+#include <sys/syscall.h>
+#include <unistd.h>
+
 #ifdef REALM_USE_CUDA
 #include "realm/cuda/cuda_module.h"
 #include "realm/cuda/cuda_internal.h"
@@ -293,6 +297,13 @@ namespace Realm {
 
   void OutbufMetadata::pktbuf_close()
   {
+    // debug instrumentation: record counters at close time and the call site
+    last_free.close_caller = __builtin_return_address(0);
+    last_free.pktbuf_total_at_free = pktbuf_total_packets.load();
+    last_free.pktbuf_sent_at_free = pktbuf_sent_packets;
+    last_free.pktbuf_ready_at_free = pktbuf_ready_packets.load();
+    last_free.pktbuf_use_count_at_free = pktbuf_use_count;
+    last_free.remain_count_at_free = remain_count.load();
     assert(state == STATE_PKTBUF);
     if(is_overflow) {
       // update the use count on the realbuf, and then we can just delete
@@ -473,6 +484,7 @@ namespace Realm {
     if(REALM_LIKELY(md != nullptr)) {
       md->nextbuf = nullptr;
       md->set_state(state);
+      md->last_free.alloc_caller = __builtin_return_address(0);
       log_gex_obmgr.info() << "alloc outbuf: outbuf=" << md << " state=" << state
                            << " baseptr=" << std::hex << md->baseptr << std::dec;
       return md;
@@ -525,11 +537,13 @@ namespace Realm {
         // set up the realbuf as above
         realbuf->nextbuf = nullptr;
         realbuf->set_state(state);
+        realbuf->last_free.alloc_caller = __builtin_return_address(0);
         log_gex_obmgr.info() << "alloc outbuf(2): outbuf=" << realbuf
                              << " state=" << state << " baseptr=" << std::hex
                              << realbuf->baseptr << std::dec;
         return realbuf;
       } else {
+        md->last_free.alloc_caller = __builtin_return_address(0);
         log_gex_obmgr.info() << "alloc overflow: ovbuf=" << md << " state=" << state
                              << " baseptr=" << std::hex << md->baseptr << std::dec;
 
@@ -540,6 +554,9 @@ namespace Realm {
 
   void OutbufManager::free_outbuf(OutbufMetadata *md)
   {
+    // debug instrumentation: record free-side caller and thread
+    md->last_free.free_caller = __builtin_return_address(0);
+    md->last_free.thread_id = syscall(SYS_gettid);
     // overflow bufs should never get here
     assert(!md->is_overflow);
     log_gex_obmgr.info() << "free outbuf: outbuf=" << md << " state=" << md->state
@@ -1215,6 +1232,14 @@ namespace Realm {
           if(!has_ready_packets && (cur_pbuf == first_pbuf.load()) &&
              (cur_pbuf->pktbuf_sent_packets == cur_pbuf->pktbuf_total_packets.load())) {
             popped_head = first_pbuf.load();
+            // debug instrumentation: record pop-site state before the store
+            //  (and before mutex release).  pktbuf_close() will fill in the
+            //  counter snapshot - we just record the xpair-side conditions.
+            popped_head->last_free.xpair_at_free = this;
+            popped_head->last_free.first_pbuf_at_free = popped_head;
+            popped_head->last_free.cur_pbuf_at_free = cur_pbuf;
+            popped_head->last_free.has_ready_at_free = has_ready_packets;
+            popped_head->last_free.close_path = 1;
             first_pbuf.store(new_pbuf);
           } else
             cur_pbuf->nextbuf = new_pbuf;
@@ -2511,6 +2536,14 @@ namespace Realm {
             //  reason)
             new_head = head->nextbuf;
             first_pbuf.store(new_head);
+            // debug instrumentation: record xpair state at advance time on
+            //  the buffer about to be closed.  pktbuf_close() will fill in
+            //  the counter snapshot itself.
+            head->last_free.xpair_at_free = this;
+            head->last_free.first_pbuf_at_free = new_head;
+            head->last_free.cur_pbuf_at_free = cur_pbuf;
+            head->last_free.has_ready_at_free = has_ready_packets;
+            head->last_free.close_path = 2;
             assert(new_head);
             assert(new_head->state == OutbufMetadata::STATE_PKTBUF);
           }

--- a/src/realm/gasnetex/gasnetex_internal.cc
+++ b/src/realm/gasnetex/gasnetex_internal.cc
@@ -295,15 +295,30 @@ namespace Realm {
     return true;
   }
 
+  void OutbufMetadata::record_event(EventType type, void *caller_pc, void *xpair,
+                                    void *first_pbuf_at, void *cur_pbuf_at,
+                                    bool has_ready_at)
+  {
+    uint32_t idx = event_ring_seq.fetch_add(1) & (EVENT_RING_SIZE - 1);
+    EventRecord &ev = event_ring[idx];
+    ev.caller = caller_pc;
+    ev.thread_id = static_cast<uint64_t>(syscall(SYS_gettid));
+    ev.xpair = xpair;
+    ev.first_pbuf = first_pbuf_at;
+    ev.cur_pbuf = cur_pbuf_at;
+    ev.pktbuf_total = pktbuf_total_packets.load();
+    ev.pktbuf_sent = pktbuf_sent_packets;
+    ev.pktbuf_ready = pktbuf_ready_packets.load();
+    ev.pktbuf_use_count = pktbuf_use_count;
+    ev.remain_count = remain_count.load();
+    ev.has_ready = has_ready_at;
+    ev.event_type = type;
+  }
+
   void OutbufMetadata::pktbuf_close()
   {
-    // debug instrumentation: record counters at close time and the call site
-    last_free.close_caller = __builtin_return_address(0);
-    last_free.pktbuf_total_at_free = pktbuf_total_packets.load();
-    last_free.pktbuf_sent_at_free = pktbuf_sent_packets;
-    last_free.pktbuf_ready_at_free = pktbuf_ready_packets.load();
-    last_free.pktbuf_use_count_at_free = pktbuf_use_count;
-    last_free.remain_count_at_free = remain_count.load();
+    // debug instrumentation: record close event before any state changes
+    record_event(EVENT_CLOSE, __builtin_return_address(0));
     assert(state == STATE_PKTBUF);
     if(is_overflow) {
       // update the use count on the realbuf, and then we can just delete
@@ -484,7 +499,7 @@ namespace Realm {
     if(REALM_LIKELY(md != nullptr)) {
       md->nextbuf = nullptr;
       md->set_state(state);
-      md->last_free.alloc_caller = __builtin_return_address(0);
+      md->record_event(OutbufMetadata::EVENT_ALLOC, __builtin_return_address(0));
       log_gex_obmgr.info() << "alloc outbuf: outbuf=" << md << " state=" << state
                            << " baseptr=" << std::hex << md->baseptr << std::dec;
       return md;
@@ -537,13 +552,13 @@ namespace Realm {
         // set up the realbuf as above
         realbuf->nextbuf = nullptr;
         realbuf->set_state(state);
-        realbuf->last_free.alloc_caller = __builtin_return_address(0);
+        realbuf->record_event(OutbufMetadata::EVENT_ALLOC, __builtin_return_address(0));
         log_gex_obmgr.info() << "alloc outbuf(2): outbuf=" << realbuf
                              << " state=" << state << " baseptr=" << std::hex
                              << realbuf->baseptr << std::dec;
         return realbuf;
       } else {
-        md->last_free.alloc_caller = __builtin_return_address(0);
+        md->record_event(OutbufMetadata::EVENT_ALLOC, __builtin_return_address(0));
         log_gex_obmgr.info() << "alloc overflow: ovbuf=" << md << " state=" << state
                              << " baseptr=" << std::hex << md->baseptr << std::dec;
 
@@ -554,9 +569,8 @@ namespace Realm {
 
   void OutbufManager::free_outbuf(OutbufMetadata *md)
   {
-    // debug instrumentation: record free-side caller and thread
-    md->last_free.free_caller = __builtin_return_address(0);
-    md->last_free.thread_id = syscall(SYS_gettid);
+    // debug instrumentation: record free event before state goes to IDLE
+    md->record_event(OutbufMetadata::EVENT_FREE, __builtin_return_address(0));
     // overflow bufs should never get here
     assert(!md->is_overflow);
     log_gex_obmgr.info() << "free outbuf: outbuf=" << md << " state=" << md->state
@@ -1232,14 +1246,10 @@ namespace Realm {
           if(!has_ready_packets && (cur_pbuf == first_pbuf.load()) &&
              (cur_pbuf->pktbuf_sent_packets == cur_pbuf->pktbuf_total_packets.load())) {
             popped_head = first_pbuf.load();
-            // debug instrumentation: record pop-site state before the store
-            //  (and before mutex release).  pktbuf_close() will fill in the
-            //  counter snapshot - we just record the xpair-side conditions.
-            popped_head->last_free.xpair_at_free = this;
-            popped_head->last_free.first_pbuf_at_free = popped_head;
-            popped_head->last_free.cur_pbuf_at_free = cur_pbuf;
-            popped_head->last_free.has_ready_at_free = has_ready_packets;
-            popped_head->last_free.close_path = 1;
+            // debug instrumentation: record pop event with xpair-side state
+            popped_head->record_event(
+                OutbufMetadata::EVENT_POP_RESERVE, __builtin_return_address(0), this,
+                popped_head /*first_pbuf*/, cur_pbuf /*cur_pbuf*/, has_ready_packets);
             first_pbuf.store(new_pbuf);
           } else
             cur_pbuf->nextbuf = new_pbuf;
@@ -2536,14 +2546,10 @@ namespace Realm {
             //  reason)
             new_head = head->nextbuf;
             first_pbuf.store(new_head);
-            // debug instrumentation: record xpair state at advance time on
-            //  the buffer about to be closed.  pktbuf_close() will fill in
-            //  the counter snapshot itself.
-            head->last_free.xpair_at_free = this;
-            head->last_free.first_pbuf_at_free = new_head;
-            head->last_free.cur_pbuf_at_free = cur_pbuf;
-            head->last_free.has_ready_at_free = has_ready_packets;
-            head->last_free.close_path = 2;
+            // debug instrumentation: record pop event with xpair-side state
+            head->record_event(
+                OutbufMetadata::EVENT_POP_PUSH, __builtin_return_address(0), this,
+                new_head /*first_pbuf after store*/, cur_pbuf, has_ready_packets);
             assert(new_head);
             assert(new_head->state == OutbufMetadata::STATE_PKTBUF);
           }

--- a/src/realm/gasnetex/gasnetex_internal.h
+++ b/src/realm/gasnetex/gasnetex_internal.h
@@ -117,6 +117,31 @@ namespace Realm {
     int pktbuf_sent_packets;
     size_t pktbuf_sent_offset;
     int pktbuf_use_count;
+
+    // debug instrumentation: snapshot recorded at the moment this buffer was
+    //  last freed.  fields are overwritten on each free; alloc_caller is
+    //  refreshed on each alloc so we can tell if a re-alloc happened between
+    //  the free and a subsequent crash.  cost: ~10 stores + 1 syscall per
+    //  free_outbuf call - negligible compared to mutex acquire + list ops.
+    struct FreeSnapshot {
+      void *close_caller{
+          nullptr}; // PC of pktbuf_close call site (0 if free didn't go via close)
+      void *free_caller{nullptr}; // PC of free_outbuf call site
+      void *alloc_caller{
+          nullptr}; // PC of alloc that handed this buffer out most recently
+      void *xpair_at_free{nullptr}; // XmitSrcDestPair* that did the close
+      void *first_pbuf_at_free{nullptr};
+      void *cur_pbuf_at_free{nullptr};
+      uint64_t thread_id{0}; // gettid() at free time
+      int pktbuf_total_at_free{0};
+      int pktbuf_sent_at_free{0};
+      int pktbuf_ready_at_free{0};
+      int pktbuf_use_count_at_free{0};
+      int remain_count_at_free{0};
+      bool has_ready_at_free{false};
+      uint8_t close_path{0}; // 0=none, 1=reserve_helper, 2=push_packets advance
+    };
+    FreeSnapshot last_free;
   };
 
   class OutbufUsecountDec {

--- a/src/realm/gasnetex/gasnetex_internal.h
+++ b/src/realm/gasnetex/gasnetex_internal.h
@@ -118,30 +118,43 @@ namespace Realm {
     size_t pktbuf_sent_offset;
     int pktbuf_use_count;
 
-    // debug instrumentation: snapshot recorded at the moment this buffer was
-    //  last freed.  fields are overwritten on each free; alloc_caller is
-    //  refreshed on each alloc so we can tell if a re-alloc happened between
-    //  the free and a subsequent crash.  cost: ~10 stores + 1 syscall per
-    //  free_outbuf call - negligible compared to mutex acquire + list ops.
-    struct FreeSnapshot {
-      void *close_caller{
-          nullptr}; // PC of pktbuf_close call site (0 if free didn't go via close)
-      void *free_caller{nullptr}; // PC of free_outbuf call site
-      void *alloc_caller{
-          nullptr}; // PC of alloc that handed this buffer out most recently
-      void *xpair_at_free{nullptr}; // XmitSrcDestPair* that did the close
-      void *first_pbuf_at_free{nullptr};
-      void *cur_pbuf_at_free{nullptr};
-      uint64_t thread_id{0}; // gettid() at free time
-      int pktbuf_total_at_free{0};
-      int pktbuf_sent_at_free{0};
-      int pktbuf_ready_at_free{0};
-      int pktbuf_use_count_at_free{0};
-      int remain_count_at_free{0};
-      bool has_ready_at_free{false};
-      uint8_t close_path{0}; // 0=none, 1=reserve_helper, 2=push_packets advance
+    // debug instrumentation: ring buffer of recent lifecycle events on this
+    //  buffer (alloc / close / free / pop).  each event records the call
+    //  site PC, the thread that did it, a snapshot of the counters at that
+    //  moment, and (for close/pop events) the xpair-side state.  cost per
+    //  event: one cache-line write + one gettid() syscall (~50ns).
+    enum EventType : uint8_t
+    {
+      EVENT_NONE = 0,
+      EVENT_ALLOC = 1,       // alloc_outbuf returned this buffer
+      EVENT_CLOSE = 2,       // pktbuf_close entry (snapshot taken)
+      EVENT_FREE = 3,        // free_outbuf entry (state about to go IDLE)
+      EVENT_POP_RESERVE = 4, // popped via reserve_pbuf_helper pop branch
+      EVENT_POP_PUSH = 5,    // popped via push_packets advance
     };
-    FreeSnapshot last_free;
+    struct EventRecord {
+      void *caller{nullptr}; // PC of the call site of the recording function
+      uint64_t thread_id{0};
+      void *xpair{nullptr};      // XmitSrcDestPair* (close/pop events)
+      void *first_pbuf{nullptr}; // xpair->first_pbuf at the event
+      void *cur_pbuf{nullptr};   // xpair->cur_pbuf at the event
+      int pktbuf_total{0};
+      int pktbuf_sent{0};
+      int pktbuf_ready{0};
+      int pktbuf_use_count{0};
+      int remain_count{0};
+      bool has_ready{false};
+      EventType event_type{EVENT_NONE};
+    };
+    static const int EVENT_RING_SIZE = 16;
+    EventRecord event_ring[EVENT_RING_SIZE];
+    atomic<uint32_t> event_ring_seq{0};
+
+    // helper - records an event into the ring buffer.  defined in
+    //  gasnetex_internal.cc to keep this header free of syscall includes.
+    void record_event(EventType type, void *caller_pc, void *xpair = nullptr,
+                      void *first_pbuf_at = nullptr, void *cur_pbuf_at = nullptr,
+                      bool has_ready_at = false);
   };
 
   class OutbufUsecountDec {

--- a/src/realm/gasnetex/gasnetex_internal.h
+++ b/src/realm/gasnetex/gasnetex_internal.h
@@ -152,12 +152,38 @@ namespace Realm {
     EventRecord event_ring[EVENT_RING_SIZE];
     atomic<uint32_t> event_ring_seq{0};
 
+    // debug instrumentation: function-entry counters incremented as the very
+    //  first statement of pktbuf_close/free_outbuf respectively, BEFORE the
+    //  record_event call.  used to verify that record_event isn't being
+    //  elided - if entry counter > number of corresponding events in the ring,
+    //  record_event is being skipped somehow.
+    atomic<uint32_t> pktbuf_close_entries{0};
+    atomic<uint32_t> free_outbuf_entries{0};
+
     // helper - records an event into the ring buffer.  defined in
     //  gasnetex_internal.cc to keep this header free of syscall includes.
     void record_event(EventType type, void *caller_pc, void *xpair = nullptr,
                       void *first_pbuf_at = nullptr, void *cur_pbuf_at = nullptr,
                       bool has_ready_at = false);
   };
+
+  // debug instrumentation: global cross-buffer event ring.  every record_event
+  //  also writes a compact entry here, letting us correlate events across
+  //  buffers and threads at crash time.  sized to capture ~recent activity
+  //  across all buffers in the system.  event_type is the raw uint8_t value
+  //  of OutbufMetadata::EventType (which is protected, so we can't name it
+  //  directly here).
+  struct GlobalEventRecord {
+    uint64_t timestamp{0};
+    uint64_t thread_id{0};
+    void *buffer{nullptr}; // OutbufMetadata* this event was for
+    void *caller{nullptr};
+    uint8_t event_type{0}; // OutbufMetadata::EventType cast to uint8_t
+    uint8_t _pad[7]{};
+  };
+  static const int GLOBAL_EVENT_RING_SIZE = 8192;
+  extern GlobalEventRecord g_event_ring[GLOBAL_EVENT_RING_SIZE];
+  extern atomic<uint32_t> g_event_ring_seq;
 
   class OutbufUsecountDec {
   public:

--- a/src/realm/gasnetex/gasnetex_internal.h
+++ b/src/realm/gasnetex/gasnetex_internal.h
@@ -133,6 +133,7 @@ namespace Realm {
       EVENT_POP_PUSH = 5,    // popped via push_packets advance
     };
     struct EventRecord {
+      uint64_t timestamp{0}; // rdtsc at event time - lets us detect preemption gaps
       void *caller{nullptr}; // PC of the call site of the recording function
       uint64_t thread_id{0};
       void *xpair{nullptr};      // XmitSrcDestPair* (close/pop events)
@@ -143,10 +144,11 @@ namespace Realm {
       int pktbuf_ready{0};
       int pktbuf_use_count{0};
       int remain_count{0};
+      State state_at_event{STATE_IDLE}; // buffer state at the moment of recording
       bool has_ready{false};
       EventType event_type{EVENT_NONE};
     };
-    static const int EVENT_RING_SIZE = 16;
+    static const int EVENT_RING_SIZE = 256;
     EventRecord event_ring[EVENT_RING_SIZE];
     atomic<uint32_t> event_ring_seq{0};
 


### PR DESCRIPTION
Patch summary — six small additions to gasnetex_internal.h/.cc:

  1. gasnetex_internal.h: new FreeSnapshot struct as a member of OutbufMetadata.
  2. gasnetex_internal.cc: #include <sys/syscall.h> and <unistd.h> for gettid.
  3. OutbufMetadata::pktbuf_close: record close_caller PC + counter snapshot at the top.
  4. OutbufManager::free_outbuf: record free_caller PC + thread id at the top.
  5. OutbufManager::alloc_outbuf: record alloc_caller PC on each of the three return paths.
  6. Two close-site instrumentation points (inside the relevant xpair-mutex blocks, recording xpair-side state):
    - reserve_pbuf_helper: close_path=1 + xpair/first_pbuf/cur_pbuf/has_ready snapshot
    - push_packets:advance: close_path=2 + xpair/first_pbuf/cur_pbuf/has_ready snapshot

  On the next fuzzer crash, the gdb command is:

  p cur_pbuf->last_free     # for line 279 crashes (the freed cur_pbuf)
  p new_head->last_free     # for line 2515 crashes (the freed successor)

  That prints all the diagnostic fields. Then info symbol <addr> translates each PC. The combination of:

  - close_path (1 / 2 / 0=neither)
  - close_caller + free_caller PCs (which function/line)
  - counters at close time (was sent==total true? was use_count nonzero?)
  - xpair-side state (was the buffer really first_pbuf? cur_pbuf?)
  - alloc_caller (where was the last alloc from — was it after the free?)

  ...should pin the bug.