### PR TITLE
Make advanced/transpose CUDA reduction kernels optional in register_reduction

### DIFF
--- a/src/realm/cuda/cuda_internal.cc
+++ b/src/realm/cuda/cuda_internal.cc
@@ -653,7 +653,7 @@ namespace Realm {
 
       // 1) Outer loop - iterate over all the addresses for each request
       while(true) {
-        XferPort *in_port = 0, *out_port = 0;
+        XferPort *in_port = nullptr, *out_port = nullptr;
         size_t in_span_start = 0, out_span_start = 0;
         GPU *in_gpu = 0, *out_gpu = 0;
         const GPU::CudaIpcMapping *out_mapping = 0;
@@ -1068,7 +1068,7 @@ namespace Realm {
         const InstanceLayoutPieceBase *in_nonaffine, *out_nonaffine;
 
         size_t in_span_start = 0, out_span_start = 0;
-        XferPort *in_port = 0, *out_port = 0;
+        XferPort *in_port = nullptr, *out_port = nullptr;
         GPU *in_gpu = 0, *out_gpu = 0;
         bool out_is_ipc = false;
 
@@ -2686,9 +2686,9 @@ namespace Realm {
         uintptr_t src_base, src_stride;
         uintptr_t count;
       };
-      KernelArgs *args = 0; // allocate on demand
-      size_t args_size = sizeof(KernelArgs) + redop->sizeof_userdata;
-      bool has_fast_kernels =
+      KernelArgs *args = nullptr; // allocate on demand
+      const size_t args_size = sizeof(KernelArgs) + redop->sizeof_userdata;
+      const bool has_fast_kernels =
           (kernel_advanced != 0 || kernel_host_proxy_advanced != nullptr) &&
           (kernel_transpose != 0 || kernel_host_proxy_transpose != nullptr);
       const size_t min_xfer_size = 4096; // TODO: make controllable
@@ -2701,7 +2701,7 @@ namespace Realm {
         if(max_bytes == 0) {
           break;
         }
-        XferPort *in_port = 0, *out_port = 0;
+        XferPort *in_port = nullptr, *out_port = nullptr;
         size_t in_span_start = 0, out_span_start = 0;
         if(input_control.current_io_port >= 0) {
           in_port = &input_ports[input_control.current_io_port];
@@ -2781,8 +2781,8 @@ namespace Realm {
                 AddressListCursor &in_alc = in_port->addrcursor;
                 AddressListCursor &out_alc = out_port->addrcursor;
 
-                uintptr_t in_offset = in_alc.get_offset();
-                uintptr_t out_offset = out_alc.get_offset();
+                const uintptr_t in_offset = in_alc.get_offset();
+                const uintptr_t out_offset = out_alc.get_offset();
 
                 // the reported dim is reduced for partially consumed address
                 //  ranges - whatever we get can be assumed to be regular
@@ -2813,8 +2813,8 @@ namespace Realm {
                   ostride = out_elem_size;
                 }
 
-                size_t elems_left = max_elems - total_elems;
-                size_t elems = std::min(std::min(icount, ocount), elems_left);
+                const size_t elems_left = max_elems - total_elems;
+                const size_t elems = std::min(std::min(icount, ocount), elems_left);
                 assert(elems > 0);
 
                 // allocate kernel arg structure if this is our first call
@@ -2830,8 +2830,8 @@ namespace Realm {
                 args->src_stride = istride;
                 args->count = elems;
 
-                size_t threads_per_block = 256;
-                size_t blocks_per_grid =
+                const size_t threads_per_block = 256;
+                const size_t blocks_per_grid =
                     std::min(1 + ((elems - 1) / threads_per_block),
                              static_cast<size_t>(CUDA_MAX_BLOCKS_PER_GRID));
 

--- a/src/realm/cuda/cuda_internal.cc
+++ b/src/realm/cuda/cuda_internal.cc
@@ -2688,8 +2688,11 @@ namespace Realm {
       };
       KernelArgs *args = 0; // allocate on demand
       size_t args_size = sizeof(KernelArgs) + redop->sizeof_userdata;
+      bool has_fast_kernels =
+          (kernel_advanced != 0 || kernel_host_proxy_advanced != nullptr) &&
+          (kernel_transpose != 0 || kernel_host_proxy_transpose != nullptr);
+      const size_t min_xfer_size = 4096; // TODO: make controllable
       while(true) {
-        size_t min_xfer_size = 4096; // TODO: make controllable
         const InstanceLayoutPieceBase *in_nonaffine = nullptr;
         const InstanceLayoutPieceBase *out_nonaffine = nullptr;
         size_t max_bytes =
@@ -2710,11 +2713,8 @@ namespace Realm {
         }
         // add optimized kernels if the condition is satisfied
         // TODO: support different elem sizes
-        bool has_fast_kernels =
-            (kernel_advanced != 0 || kernel_host_proxy_advanced != nullptr) &&
-            (kernel_transpose != 0 || kernel_host_proxy_transpose != nullptr);
-        if(in_port && out_port && !non_affine &&
-           (redop->sizeof_rhs == redop->sizeof_lhs) && has_fast_kernels) {
+        if(in_port && out_port && !non_affine && (in_elem_size == out_elem_size) &&
+           has_fast_kernels) {
           done = fast_reduction_kernel_mode(channel, max_bytes, in_port, out_port,
                                             in_span_start, out_span_start);
           did_work = true;
@@ -2882,15 +2882,15 @@ namespace Realm {
                                 elems * ((out_dim == 1) ? out_elem_size : 1));
 
 #ifdef DEBUG_REALM
-              assert(elems <= elems_left);
+                assert(elems <= elems_left);
 #endif
-              total_elems += elems;
+                total_elems += elems;
 
-              // stop if it's been too long, but make sure we do at least the
-              //  minimum number of bytes
-              if(((total_elems * in_elem_size) >= min_xfer_size) &&
-                 work_until.is_expired())
-                break;
+                // stop if it's been too long, but make sure we do at least the
+                //  minimum number of bytes
+                if(((total_elems * in_elem_size) >= min_xfer_size) &&
+                   work_until.is_expired())
+                  break;
               }
             } else {
               // input but no output, so skip input bytes

--- a/src/realm/cuda/cuda_internal.cc
+++ b/src/realm/cuda/cuda_internal.cc
@@ -2493,6 +2493,9 @@ namespace Realm {
           }
         }
       }
+      if(host_proxy == nullptr) {
+        return false;
+      }
       if(redop->cudaGetFuncBySymbol_fn != 0) {
         // Resolve host symbol → CUfunction within the correct GPU context
         gpu->push_context();
@@ -2509,7 +2512,6 @@ namespace Realm {
       } else {
         // Fall back to runtime launch via cudaLaunchKernel
         assert(redop->cudaLaunchKernel_fn != 0);
-        assert(host_proxy != nullptr);
         return false;
       }
     }
@@ -2708,8 +2710,11 @@ namespace Realm {
         }
         // add optimized kernels if the condition is satisfied
         // TODO: support different elem sizes
+        bool has_fast_kernels =
+            (kernel_advanced != 0 || kernel_host_proxy_advanced != nullptr) &&
+            (kernel_transpose != 0 || kernel_host_proxy_transpose != nullptr);
         if(in_port && out_port && !non_affine &&
-           (redop->sizeof_rhs == redop->sizeof_lhs)) {
+           (redop->sizeof_rhs == redop->sizeof_lhs) && has_fast_kernels) {
           done = fast_reduction_kernel_mode(channel, max_bytes, in_port, out_port,
                                             in_span_start, out_span_start);
           did_work = true;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -430,6 +430,13 @@ if(TEST_USE_GPU)
     target_link_libraries(cuda_memcpy_test CUDA::cudart)
     target_link_libraries(cuda_scatter_test CUDA::cudart)
     target_link_libraries(test_cuhook CUDA::cudart)
+    set(cuda_reduce_basic_ARGS -ll:gpu 1)
+    set(cuda_reduce_basic_RESOURCE_LOCK gpu)
+    add_integration_test(
+      cuda_reduce_basic "${REALM_TEST_DIR}/cuda_reduce_basic.cc"
+                        "${REALM_TEST_DIR}/cuda_reduce_basic_gpu.cu"
+    )
+    target_link_libraries(cuda_reduce_basic CUDA::cudart)
     set(multifield_transfer_ARGS -ll:gpu 1)
     set(multifield_transfer_RESOURCE_LOCK gpu)
     add_integration_test(multifield_transfer "${REALM_TEST_DIR}/multifield_transfer.cc")
@@ -482,6 +489,7 @@ set_target_properties(taskreg PROPERTIES ENABLE_EXPORTS TRUE)
 set_target_properties(scatter PROPERTIES ENABLE_EXPORTS TRUE)
 if(REALM_USE_CUDA)
   set_target_properties(cuda_scatter_test PROPERTIES ENABLE_EXPORTS TRUE)
+  set_target_properties(cuda_reduce_basic PROPERTIES ENABLE_EXPORTS TRUE)
 endif()
 
 set_tests_properties(

--- a/tests/cuda_reduce_basic.cc
+++ b/tests/cuda_reduce_basic.cc
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2025 Stanford University, NVIDIA Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Test that GPU reductions work correctly when only the basic 4 CUDA kernels
+// (apply_excl, apply_nonexcl, fold_excl, fold_nonexcl) are registered with
+// register_reduction, leaving the advanced/transpose slots null.
+//
+// ReductionOpAdd has LHS == RHS (both uint32_t), so sizeof_lhs == sizeof_rhs
+// and the fast-path condition in progress_xd is satisfied.  The
+// has_fast_kernels guard (the change under test) then causes the dispatch to
+// fall back to the basic stride loop rather than crashing.
+
+#include "realm.h"
+#include "realm/cmdline.h"
+
+#include <cassert>
+#include <cstdlib>
+
+#include "cuda_reduce_basic.h"
+
+using namespace Realm;
+
+Logger log_app("app");
+
+enum
+{
+  TOP_LEVEL_TASK = Processor::TASK_ID_FIRST_AVAILABLE + 0,
+};
+
+enum
+{
+  FID_DATA = 44,
+};
+
+enum
+{
+  REDOP_BASIC = 99,
+};
+
+typedef ReductionOpAdd::LHS T; // uint32_t, same as RHS
+
+// Runs apply and fold reductions with src and dst both in gpu_mem.
+// Results are copied to cpu_mem for verification.
+template <int N, typename PT>
+bool test_reduce_dim(Rect<N, PT> domain, Memory gpu_mem, Memory cpu_mem)
+{
+  std::map<FieldID, size_t> fields;
+  fields[FID_DATA] = sizeof(T);
+
+  IndexSpace<N, PT> is(domain);
+
+  RegionInstance src_inst, dst_inst, cpu_inst;
+  RegionInstance::create_instance(src_inst, gpu_mem, is, fields, 0,
+                                  ProfilingRequestSet())
+      .wait();
+  RegionInstance::create_instance(dst_inst, gpu_mem, is, fields, 0,
+                                  ProfilingRequestSet())
+      .wait();
+  RegionInstance::create_instance(cpu_inst, cpu_mem, is, fields, 0,
+                                  ProfilingRequestSet())
+      .wait();
+
+  size_t errors = 0;
+
+  // --- apply test ---
+  // src = 3, dst = 10 -> expected 10 + 3 = 13
+  {
+    std::vector<CopySrcDstField> srcs(1), dsts(1);
+    srcs[0].set_fill<T>(3);
+    dsts[0].set_field(src_inst, FID_DATA, sizeof(T));
+    is.copy(srcs, dsts, ProfilingRequestSet()).wait();
+  }
+  {
+    std::vector<CopySrcDstField> srcs(1), dsts(1);
+    srcs[0].set_fill<T>(10);
+    dsts[0].set_field(dst_inst, FID_DATA, sizeof(T));
+    is.copy(srcs, dsts, ProfilingRequestSet()).wait();
+  }
+  {
+    std::vector<CopySrcDstField> srcs(1), dsts(1);
+    srcs[0].set_field(src_inst, FID_DATA, sizeof(T));
+    dsts[0].set_field(dst_inst, FID_DATA, sizeof(T));
+    dsts[0].set_redop(REDOP_BASIC, false /*!is_fold*/);
+    is.copy(srcs, dsts, ProfilingRequestSet()).wait();
+  }
+  {
+    std::vector<CopySrcDstField> srcs(1), dsts(1);
+    srcs[0].set_field(dst_inst, FID_DATA, sizeof(T));
+    dsts[0].set_field(cpu_inst, FID_DATA, sizeof(T));
+    is.copy(srcs, dsts, ProfilingRequestSet()).wait();
+  }
+  {
+    AffineAccessor<T, N, PT> acc(cpu_inst, FID_DATA);
+    for(IndexSpaceIterator<N, PT> it(is); it.valid; it.step())
+      for(PointInRectIterator<N, PT> it2(it.rect); it2.valid; it2.step()) {
+        T actual = acc[it2.p];
+        if(actual != 13) {
+          if(++errors < 5)
+            log_app.error() << "apply mismatch at " << it2.p << ": got " << actual
+                            << " expected 13";
+        }
+      }
+  }
+
+  // --- fold test ---
+  // src = 3, dst = 5 -> expected 5 + 3 = 8
+  {
+    std::vector<CopySrcDstField> srcs(1), dsts(1);
+    srcs[0].set_fill<T>(5);
+    dsts[0].set_field(dst_inst, FID_DATA, sizeof(T));
+    is.copy(srcs, dsts, ProfilingRequestSet()).wait();
+  }
+  {
+    std::vector<CopySrcDstField> srcs(1), dsts(1);
+    srcs[0].set_field(src_inst, FID_DATA, sizeof(T));
+    dsts[0].set_field(dst_inst, FID_DATA, sizeof(T));
+    dsts[0].set_redop(REDOP_BASIC, true /*is_fold*/);
+    is.copy(srcs, dsts, ProfilingRequestSet()).wait();
+  }
+  {
+    std::vector<CopySrcDstField> srcs(1), dsts(1);
+    srcs[0].set_field(dst_inst, FID_DATA, sizeof(T));
+    dsts[0].set_field(cpu_inst, FID_DATA, sizeof(T));
+    is.copy(srcs, dsts, ProfilingRequestSet()).wait();
+  }
+  {
+    AffineAccessor<T, N, PT> acc(cpu_inst, FID_DATA);
+    for(IndexSpaceIterator<N, PT> it(is); it.valid; it.step())
+      for(PointInRectIterator<N, PT> it2(it.rect); it2.valid; it2.step()) {
+        T actual = acc[it2.p];
+        if(actual != 8) {
+          if(++errors < 5)
+            log_app.error() << "fold mismatch at " << it2.p << ": got " << actual
+                            << " expected 8";
+        }
+      }
+  }
+
+  src_inst.destroy();
+  dst_inst.destroy();
+  cpu_inst.destroy();
+
+  return (errors == 0);
+}
+
+void top_level_task(const void *data, size_t datalen, const void *userdata,
+                    size_t userlen, Processor p)
+{
+  Memory gpu_mem = Memory::NO_MEMORY;
+  Machine::MemoryQuery mq(Machine::get_machine());
+  mq.only_kind(Memory::GPU_FB_MEM).has_capacity(1);
+  for(Memory m : mq) {
+    gpu_mem = m;
+    break;
+  }
+
+  if(!gpu_mem.exists()) {
+    log_app.warning() << "no GPU FB memory found, skipping test";
+    Runtime::get_runtime().shutdown(Event::NO_EVENT, 0);
+    return;
+  }
+
+  Memory cpu_mem =
+      Machine::MemoryQuery(Machine::get_machine()).has_affinity_to(p).first();
+  assert(cpu_mem.exists());
+
+  bool ok = true;
+
+  if(ok) {
+    Rect<1> r(0, 15);
+    ok = test_reduce_dim(r, gpu_mem, cpu_mem);
+    if(!ok)
+      log_app.error() << "1-D basic reduce test FAILED";
+  }
+
+  if(ok) {
+    Rect<2> r(Point<2>(0, 0), Point<2>(7, 7));
+    ok = test_reduce_dim(r, gpu_mem, cpu_mem);
+    if(!ok)
+      log_app.error() << "2-D basic reduce test FAILED";
+  }
+
+  if(ok) {
+    Rect<3> r(Point<3>(0, 0, 0), Point<3>(3, 3, 3));
+    ok = test_reduce_dim(r, gpu_mem, cpu_mem);
+    if(!ok)
+      log_app.error() << "3-D basic reduce test FAILED";
+  }
+
+  if(ok)
+    log_app.info() << "all basic reduce tests PASSED";
+
+  Runtime::get_runtime().shutdown(Event::NO_EVENT, ok ? 0 : 1);
+}
+
+extern void register_basic_gpu_reduction(Realm::Runtime &realm,
+                                         Realm::ReductionOpID redop_id);
+
+int main(int argc, char **argv)
+{
+  Runtime rt;
+  rt.init(&argc, &argv);
+
+  register_basic_gpu_reduction(rt, REDOP_BASIC);
+
+  rt.register_task(TOP_LEVEL_TASK, top_level_task);
+
+  Processor p = Machine::ProcessorQuery(Machine::get_machine())
+                    .only_kind(Processor::LOC_PROC)
+                    .first();
+  assert(p.exists());
+
+  rt.collective_spawn(p, TOP_LEVEL_TASK, 0, 0);
+  return rt.wait_for_shutdown();
+}

--- a/tests/cuda_reduce_basic.cc
+++ b/tests/cuda_reduce_basic.cc
@@ -64,14 +64,11 @@ bool test_reduce_dim(Rect<N, PT> domain, Memory gpu_mem, Memory cpu_mem)
   IndexSpace<N, PT> is(domain);
 
   RegionInstance src_inst, dst_inst, cpu_inst;
-  RegionInstance::create_instance(src_inst, gpu_mem, is, fields, 0,
-                                  ProfilingRequestSet())
+  RegionInstance::create_instance(src_inst, gpu_mem, is, fields, 0, ProfilingRequestSet())
       .wait();
-  RegionInstance::create_instance(dst_inst, gpu_mem, is, fields, 0,
-                                  ProfilingRequestSet())
+  RegionInstance::create_instance(dst_inst, gpu_mem, is, fields, 0, ProfilingRequestSet())
       .wait();
-  RegionInstance::create_instance(cpu_inst, cpu_mem, is, fields, 0,
-                                  ProfilingRequestSet())
+  RegionInstance::create_instance(cpu_inst, cpu_mem, is, fields, 0, ProfilingRequestSet())
       .wait();
 
   size_t errors = 0;

--- a/tests/cuda_reduce_basic.h
+++ b/tests/cuda_reduce_basic.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 Stanford University, NVIDIA Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CUDA_REDUCE_BASIC_H
+#define CUDA_REDUCE_BASIC_H
+
+#include <cstdint>
+
+// Same-type integer add reduction: LHS == RHS == uint32_t.
+// sizeof_lhs == sizeof_rhs satisfies the fast-path condition in progress_xd,
+// so the has_fast_kernels guard (the change under test) is actually reached.
+class ReductionOpAdd {
+public:
+  typedef uint32_t LHS;
+  typedef uint32_t RHS;
+
+  static const RHS identity = 0;
+
+  template <bool EXCL>
+  REALM_CUDA_HD void apply(LHS &lhs, const RHS &rhs) const
+  {
+    if(EXCL) {
+      lhs += rhs;
+    } else {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+      atomicAdd(&lhs, rhs);
+#else
+      __atomic_add_fetch(&lhs, rhs, __ATOMIC_SEQ_CST);
+#endif
+    }
+  }
+
+  template <bool EXCL>
+  REALM_CUDA_HD void fold(RHS &rhs1, const RHS &rhs2) const
+  {
+    if(EXCL) {
+      rhs1 += rhs2;
+    } else {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+      atomicAdd(&rhs1, rhs2);
+#else
+      __atomic_add_fetch(&rhs1, rhs2, __ATOMIC_SEQ_CST);
+#endif
+    }
+  }
+
+#if defined(REALM_USE_CUDA) && defined(__CUDACC__)
+  static const bool has_cuda_reductions = false; // registered manually below
+
+  template <bool EXCL>
+  __device__ void apply_cuda(LHS &lhs, const RHS &rhs) const
+  {
+    apply<EXCL>(lhs, rhs);
+  }
+
+  template <bool EXCL>
+  __device__ void fold_cuda(RHS &rhs1, const RHS &rhs2) const
+  {
+    fold<EXCL>(rhs1, rhs2);
+  }
+#endif
+};
+
+#endif // CUDA_REDUCE_BASIC_H

--- a/tests/cuda_reduce_basic_gpu.cu
+++ b/tests/cuda_reduce_basic_gpu.cu
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 Stanford University, NVIDIA Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Registers ReductionOpAdd with only the 4 basic CUfunctions
+// (apply_excl, apply_nonexcl, fold_excl, fold_nonexcl).  The advanced and
+// transpose slots in CudaRedOpDesc are left null.  This exercises the path
+// where resolve_kernel_slot returns false for a null host_proxy and
+// progress_xd skips fast_reduction_kernel_mode via the has_fast_kernels guard.
+//
+// ReductionOpAdd has LHS == RHS (both uint32_t), so sizeof_lhs == sizeof_rhs
+// and the fast-path condition is actually reached before the guard fires.
+
+#include "realm.h"
+#include "realm/cuda/cuda_module.h"
+#include "cuda_reduce_basic.h"
+
+extern Realm::Logger log_app;
+
+static void check_cudart(cudaError_t err, const char *tok, const char *file, int line)
+{
+  if(err != cudaSuccess) {
+    log_app.fatal("%s(%d): Error in %s = %d", file, line, tok, (int)err);
+    abort();
+  }
+}
+
+#define CHECK_CURT(x) check_cudart((x), #x, __FILE__, __LINE__)
+
+void register_basic_gpu_reduction(Realm::Runtime &realm, Realm::ReductionOpID redop_id)
+{
+  if(!realm.register_reduction<ReductionOpAdd>(redop_id)) {
+    log_app.fatal("Failed to register reduction op");
+    abort();
+  }
+
+  Realm::Cuda::CudaModule *cuda = realm.get_module<Realm::Cuda::CudaModule>("cuda");
+  if(cuda == nullptr)
+    return;
+
+  Realm::Machine::ProcessorQuery pq =
+      Realm::Machine::ProcessorQuery(Realm::Machine::get_machine())
+          .only_kind(Realm::Processor::TOC_PROC);
+
+  std::vector<Realm::Cuda::CudaRedOpDesc> descs;
+  for(Realm::Processor proc : pq) {
+    int devid = 0;
+    if(!cuda->get_cuda_device_id(proc, &devid))
+      continue;
+
+    CHECK_CURT(cudaSetDevice(devid));
+
+    Realm::Cuda::CudaRedOpDesc desc;
+    desc.proc = proc;
+    desc.redop_id = redop_id;
+
+    // Register only the 4 basic kernels.  Advanced and transpose slots remain
+    // null (their CudaRedOpDesc defaults), so the dispatch falls back to the
+    // basic stride-based path via the has_fast_kernels guard.
+    CHECK_CURT(cudaGetFuncBySymbol(
+        static_cast<cudaFunction_t *>(&desc.apply_excl),
+        reinterpret_cast<const void *>(
+            Realm::Cuda::ReductionKernels::apply_cuda_kernel<ReductionOpAdd, true>)));
+    CHECK_CURT(cudaGetFuncBySymbol(
+        static_cast<cudaFunction_t *>(&desc.apply_nonexcl),
+        reinterpret_cast<const void *>(
+            Realm::Cuda::ReductionKernels::apply_cuda_kernel<ReductionOpAdd, false>)));
+    CHECK_CURT(cudaGetFuncBySymbol(
+        static_cast<cudaFunction_t *>(&desc.fold_excl),
+        reinterpret_cast<const void *>(
+            Realm::Cuda::ReductionKernels::fold_cuda_kernel<ReductionOpAdd, true>)));
+    CHECK_CURT(cudaGetFuncBySymbol(
+        static_cast<cudaFunction_t *>(&desc.fold_nonexcl),
+        reinterpret_cast<const void *>(
+            Realm::Cuda::ReductionKernels::fold_cuda_kernel<ReductionOpAdd, false>)));
+
+    descs.push_back(desc);
+  }
+
+  if(descs.empty())
+    return;
+
+  Realm::Event e = Realm::Event::NO_EVENT;
+  if(!cuda->register_reduction(e, descs.data(), descs.size())) {
+    log_app.fatal("Failed to register basic GPU reduction kernels");
+    abort();
+  }
+  e.wait();
+}


### PR DESCRIPTION
## Summary

  - Guard `resolve_kernel_slot` against a null `host_proxy` so callers
    can omit the advanced and transpose `CUfunction` slots in
    `CudaRedOpDesc` without crashing.
  - Skip `fast_reduction_kernel_mode` in `progress_xd` when advanced/
    transpose kernels are absent (`has_fast_kernels` guard), falling back
    to the basic stride-based dispatch path instead.
  - Add `cuda_reduce_basic` integration test that registers a same-type
    redop (`LHS == RHS == uint32_t`) with only the 4 basic kernels,
    verifying correct apply and fold results across 1-D, 2-D, and 3-D
    GPU FB reductions.
  - Relates to issue #438

  ## Motivation

  `register_reduction` previously required all 12 kernel variants
  (4 basic + 4 advanced affine + 4 transpose) to be provided.  Callers
  who only have the basic kernels available (e.g. loading a pre-compiled
  cubin via the driver API) had no safe path — passing null advanced/
  transpose slots would crash at dispatch time when
  `fast_reduction_kernel_mode` was entered for equal-size reductions.

  With this change, the advanced and transpose slots in `CudaRedOpDesc`
  are genuinely optional.  When absent, the runtime silently falls back
  to the basic 1-D/2-D stride-based kernel path, which handles all
  dimensionalities correctly via the address cursor.

  ## Test plan

  - [ ] Build with `REALM_ENABLE_CUDA=ON REALM_BUILD_TESTS=ON`
  - [ ] Run `ctest -R cuda_reduce_basic` on a GPU node and confirm pass
  - [ ] Run `ctest -R simple_reduce` to confirm existing full-kernel path is unaffected