### PR TITLE
Link GEX wrapper target against GASNet

### DIFF
--- a/src/realm/gasnetex/gasnetex_wrapper/CMakeLists.txt
+++ b/src/realm/gasnetex/gasnetex_wrapper/CMakeLists.txt
@@ -65,6 +65,7 @@ target_include_directories(
          $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/exports>
 )
 target_link_libraries(realm_gex_wrapper_objs PUBLIC GASNet::GASNet)
+target_link_libraries(realm_gex_wrapper PRIVATE GASNet::GASNet)
 set_target_properties(realm_gex_wrapper_objs PROPERTIES POSITION_INDEPENDENT_CODE ON)
 set_target_properties(realm_gex_wrapper_objs PROPERTIES CXX_VISIBILITY_PRESET hidden)
 set_target_properties(realm_gex_wrapper_objs PROPERTIES VISIBILITY_INLINES_HIDDEN YES)


### PR DESCRIPTION
## Summary

Link the final `realm_gex_wrapper` target against `GASNet::GASNet`.

## Details

The wrapper shared library is built from `realm_gex_wrapper_objs`, which already links `GASNet::GASNet`, but the final shared-library target did not link GASNet directly. That can leave dependencies such as libfabric, PMI, hwloc, and CUDA to be resolved indirectly instead of appearing as direct dependencies of `librealm_gex_wrapper.so`.

Making the final target link explicit matches the wrapper's runtime dependency and addresses the Perlmutter/CXI failure mode reported in #338.

Fixes #338.