### PR TITLE
Fix IB Planning to Avoid Overflows

### DIFF
--- a/src/realm/transfer/ib_memory.cc
+++ b/src/realm/transfer/ib_memory.cc
@@ -78,7 +78,7 @@ namespace Realm {
       return this->size + ZERO_SIZE_INSTANCE_OFFSET;
     }
 
-    const size_t alignment = 256;
+    const size_t alignment = IB_ALLOC_ALIGNMENT;
 
     if(alignment > 0) {
       off_t leftover = size % alignment;
@@ -293,7 +293,7 @@ namespace Realm {
       return;
     }
 
-    const size_t alignment = 256;
+    const size_t alignment = IB_ALLOC_ALIGNMENT;
 
     if(alignment > 0) {
       off_t leftover = size % alignment;

--- a/src/realm/transfer/ib_memory.h
+++ b/src/realm/transfer/ib_memory.h
@@ -24,7 +24,31 @@
 
 #include "realm/mem_impl.h"
 
+#include <limits>
+
 namespace Realm {
+
+  // IBMemory::do_alloc rounds every allocation up to this alignment; planner-side
+  // size math must account for it so any plan the planner accepts is allocatable.
+  static constexpr size_t IB_ALLOC_ALIGNMENT = 256;
+
+  // round n up to the next multiple of mult (matches the semantics of the
+  // file-local roundup() in inst_impl.cc)
+  inline size_t ib_align_up(size_t n, size_t mult = IB_ALLOC_ALIGNMENT)
+  {
+    if(mult == 0) {
+      return n;
+    }
+    size_t leftover = n % mult;
+    if(leftover == 0) {
+      return n;
+    }
+    size_t extra = mult - leftover;
+    if(n > (std::numeric_limits<size_t>::max() - extra)) {
+      return std::numeric_limits<size_t>::max();
+    }
+    return n + extra;
+  }
 
   // a simple memory used for intermediate buffers in dma system
   class REALM_INTERNAL_API_EXTERNAL_LINKAGE IBMemory : public MemoryImpl {

--- a/src/realm/transfer/transfer.cc
+++ b/src/realm/transfer/transfer.cc
@@ -26,6 +26,10 @@
 #include "realm/transfer/ib_memory.h"
 #include "realm/inst_layout.h"
 
+#include <limits>
+#include <map>
+#include <numeric>
+
 #ifdef REALM_ON_WINDOWS
 #include <basetsd.h>
 typedef SSIZE_T ssize_t;
@@ -2997,11 +3001,22 @@ namespace Realm {
     , addrsplit_channel(_addrsplit_channel)
   {}
 
+  // non-static (exposed for unit testing); default lives on this declaration
+  size_t compute_ib_min_size(size_t combined_field_size, CustomSerdezID serdez_id,
+                             size_t max_needed = std::numeric_limits<size_t>::max());
+  size_t compute_ib_natural_size(size_t combined_field_size, size_t domain_size,
+                                 CustomSerdezID serdez_id);
+  static size_t compute_ib_granularity(size_t combined_field_size,
+                                       CustomSerdezID serdez_id);
+  static void init_ib_edge(TransferGraph::IBInfo &ibe, Memory memory, size_t size,
+                           size_t min_size, size_t size_granularity);
+
   static TransferGraph::XDTemplate::IO
   add_copy_path(std::vector<TransferGraph::XDTemplate> &xd_nodes,
                 std::vector<TransferGraph::IBInfo> &ib_edges,
                 TransferGraph::XDTemplate::IO start_edge, const MemPathInfo &info,
-                size_t ib_size = Config::ib_size_bytes)
+                size_t ib_size = Config::ib_size_bytes,
+                size_t ib_min_size = IB_ALLOC_ALIGNMENT, size_t ib_size_granularity = 1)
   {
     size_t hops = info.xd_channels.size();
 
@@ -3031,8 +3046,7 @@ namespace Realm {
       xdn.outputs[0] = TransferGraph::XDTemplate::mk_edge(ib_base + i);
 
       TransferGraph::IBInfo &ibe = ib_edges[ib_base + i];
-      ibe.memory = info.path[i + 1];
-      ibe.size = ib_size;
+      init_ib_edge(ibe, info.path[i + 1], ib_size, ib_min_size, ib_size_granularity);
     }
 
     // last edge we created is the output
@@ -3117,6 +3131,18 @@ namespace Realm {
     src_fields.push_back(TransferDesc::FieldInfo{field_id, 0, address_size(), 0});
     TransferGraph::XDTemplate::IO addr_edge =
         TransferGraph::XDTemplate::mk_inst(inst, addr_field_start, 1);
+    const size_t address_natural_size =
+        compute_ib_natural_size(address_size(), ind_domain_size, 0);
+    const size_t data_natural_size =
+        compute_ib_natural_size(bytes_per_element, ind_domain_size, serdez_id);
+    const size_t address_min_size =
+        compute_ib_min_size(address_size(), 0, address_natural_size);
+    const size_t address_granularity = compute_ib_granularity(address_size(), 0);
+    const size_t control_min_size = compute_ib_min_size(sizeof(unsigned), 0);
+    const size_t control_granularity = compute_ib_granularity(sizeof(unsigned), 0);
+    const size_t data_min_size =
+        compute_ib_min_size(bytes_per_element, serdez_id, data_natural_size);
+    const size_t data_granularity = compute_ib_granularity(bytes_per_element, serdez_id);
 
     // special case - a gather from a single source with no out of range
     //  accesses
@@ -3139,12 +3165,10 @@ namespace Realm {
                                        0 /*no serdez*/, 0 /*redop_id*/, addr_path,
                                        true /*skip_final_memcpy*/);
           assert(ok);
-          size_t aligned_ib_size =
-              Config::ib_size_bytes +
-              (address_size() - (Config::ib_size_bytes % address_size())) %
-                  address_size();
+          size_t aligned_ib_size = ib_align_up(Config::ib_size_bytes, address_size());
           addr_edge =
-              add_copy_path(xd_nodes, ib_edges, addr_edge, addr_path, aligned_ib_size);
+              add_copy_path(xd_nodes, ib_edges, addr_edge, addr_path, aligned_ib_size,
+                            address_min_size, address_granularity);
         }
       }
 
@@ -3178,8 +3202,9 @@ namespace Realm {
           xdn.outputs[0] = TransferGraph::XDTemplate::mk_edge(ib_idx + i);
 
           TransferGraph::IBInfo &ibe = ib_edges[ib_idx + i];
-          ibe.memory = path_infos[0].path[i + 1];
-          ibe.size = Config::ib_size_bytes; // 1 << 20; /*TODO*/
+          init_ib_edge(ibe, path_infos[0].path[i + 1],
+                       std::max(Config::ib_size_bytes, data_min_size), data_min_size,
+                       data_granularity);
         }
       }
     } else {
@@ -3248,7 +3273,9 @@ namespace Realm {
                                    0 /*no serdez*/, 0 /*redop_id*/, addr_path,
                                    true /*skip_final_memcpy*/);
       assert(ok);
-      addr_edge = add_copy_path(xd_nodes, ib_edges, addr_edge, addr_path);
+      addr_edge =
+          add_copy_path(xd_nodes, ib_edges, addr_edge, addr_path, Config::ib_size_bytes,
+                        address_min_size, address_granularity);
 
       std::vector<TransferGraph::XDTemplate::IO> decoded_addr_edges(spaces_size);
       TransferGraph::XDTemplate::IO ctrl_edge;
@@ -3271,14 +3298,14 @@ namespace Realm {
         for(size_t i = 0; i < spaces_size; i++) {
           xdn.outputs[i] = TransferGraph::XDTemplate::mk_edge(ib_base + i);
           decoded_addr_edges[i] = xdn.outputs[i];
-          ib_edges[ib_base + i].memory = addr_ib_mem;
-          ib_edges[ib_base + i].size = 65536; // TODO
+          init_ib_edge(ib_edges[ib_base + i], addr_ib_mem, 65536, address_min_size,
+                       address_granularity);
         }
         xdn.outputs[spaces_size] =
             TransferGraph::XDTemplate::mk_edge(ib_base + spaces_size);
         ctrl_edge = xdn.outputs[spaces_size];
-        ib_edges[ib_base + spaces_size].memory = addr_ib_mem;
-        ib_edges[ib_base + spaces_size].size = 65536; // TODO
+        init_ib_edge(ib_edges[ib_base + spaces_size], addr_ib_mem, 65536,
+                     control_min_size, control_granularity);
       }
 
       // next, see what work we need to get the addresses to where the
@@ -3292,7 +3319,8 @@ namespace Realm {
                                        0 /*no serdez*/, 0 /*redop_id*/, path);
           assert(ok);
           decoded_addr_edges[i] =
-              add_copy_path(xd_nodes, ib_edges, decoded_addr_edges[i], path);
+              add_copy_path(xd_nodes, ib_edges, decoded_addr_edges[i], path,
+                            Config::ib_size_bytes, address_min_size, address_granularity);
         }
       }
 
@@ -3303,7 +3331,9 @@ namespace Realm {
         bool ok = find_shortest_path(nodes_info, addr_ib_mem, dst_ib_mem, 0 /*no serdez*/,
                                      0 /*redop_id*/, path);
         assert(ok);
-        ctrl_edge = add_copy_path(xd_nodes, ib_edges, ctrl_edge, path);
+        ctrl_edge =
+            add_copy_path(xd_nodes, ib_edges, ctrl_edge, path, Config::ib_size_bytes,
+                          control_min_size, control_granularity);
       }
 
       // now any data paths with more than one hop need all but the last hop
@@ -3336,8 +3366,9 @@ namespace Realm {
             }
             xdn.outputs.resize(1);
             xdn.outputs[0] = TransferGraph::XDTemplate::mk_edge(ib_base + j);
-            ib_edges[ib_base + j].memory = mpi.path[j + 1];
-            ib_edges[ib_base + j].size = 65536; // TODO: pick size?
+            init_ib_edge(ib_edges[ib_base + j], mpi.path[j + 1],
+                         std::max<size_t>(65536, data_min_size), data_min_size,
+                         data_granularity);
           }
           data_edges[i] = TransferGraph::XDTemplate::mk_edge(ib_base + hops - 1);
         }
@@ -3439,6 +3470,18 @@ namespace Realm {
     src_fields.push_back(TransferDesc::FieldInfo{field_id, 0, address_size(), 0});
     TransferGraph::XDTemplate::IO addr_edge =
         TransferGraph::XDTemplate::mk_inst(inst, addr_field_start, 1);
+    const size_t address_natural_size =
+        compute_ib_natural_size(address_size(), ind_domain_size, 0);
+    const size_t data_natural_size =
+        compute_ib_natural_size(bytes_per_element, ind_domain_size, serdez_id);
+    const size_t address_min_size =
+        compute_ib_min_size(address_size(), 0, address_natural_size);
+    const size_t address_granularity = compute_ib_granularity(address_size(), 0);
+    const size_t control_min_size = compute_ib_min_size(sizeof(unsigned), 0);
+    const size_t control_granularity = compute_ib_granularity(sizeof(unsigned), 0);
+    const size_t data_min_size =
+        compute_ib_min_size(bytes_per_element, serdez_id, data_natural_size);
+    const size_t data_granularity = compute_ib_granularity(bytes_per_element, serdez_id);
 
     // special case - a scatter to a single destination with no out of
     //  range accesses
@@ -3462,11 +3505,9 @@ namespace Realm {
                                      ind_ib_mem, 0 /*no serdez*/, 0 /*redop_id*/,
                                      addr_path, true /*skip_final_memcpy*/);
         assert(ok);
-        size_t aligned_ib_size =
-            Config::ib_size_bytes +
-            (address_size() - (Config::ib_size_bytes % address_size())) % address_size();
-        addr_edge =
-            add_copy_path(xd_nodes, ib_edges, addr_edge, addr_path, aligned_ib_size);
+        size_t aligned_ib_size = ib_align_up(Config::ib_size_bytes, address_size());
+        addr_edge = add_copy_path(xd_nodes, ib_edges, addr_edge, addr_path,
+                                  aligned_ib_size, address_min_size, address_granularity);
       }
 
       size_t xd_idx = xd_nodes.size();
@@ -3500,8 +3541,9 @@ namespace Realm {
           xdn.outputs[0] = TransferGraph::XDTemplate::mk_edge(ib_idx + i);
 
           TransferGraph::IBInfo &ibe = ib_edges[ib_idx + i];
-          ibe.memory = path_infos[0].path[i + 1];
-          ibe.size = Config::ib_size_bytes; // 1 << 20; /*TODO*/
+          init_ib_edge(ibe, path_infos[0].path[i + 1],
+                       std::max(Config::ib_size_bytes, data_min_size), data_min_size,
+                       data_granularity);
         }
       }
     } else {
@@ -3554,7 +3596,9 @@ namespace Realm {
                                    0 /*no serdez*/, 0 /*redop_id*/, addr_path,
                                    true /*skip_final_memcpy*/);
       assert(ok);
-      addr_edge = add_copy_path(xd_nodes, ib_edges, addr_edge, addr_path);
+      addr_edge =
+          add_copy_path(xd_nodes, ib_edges, addr_edge, addr_path, Config::ib_size_bytes,
+                        address_min_size, address_granularity);
 
       std::vector<TransferGraph::XDTemplate::IO> decoded_addr_edges(spaces_size);
       TransferGraph::XDTemplate::IO ctrl_edge;
@@ -3578,14 +3622,14 @@ namespace Realm {
         for(size_t i = 0; i < spaces_size; i++) {
           xdn.outputs[i] = TransferGraph::XDTemplate::mk_edge(ib_base + i);
           decoded_addr_edges[i] = xdn.outputs[i];
-          ib_edges[ib_base + i].memory = addr_ib_mem;
-          ib_edges[ib_base + i].size = 65536; // TODO
+          init_ib_edge(ib_edges[ib_base + i], addr_ib_mem, 65536, address_min_size,
+                       address_granularity);
         }
         xdn.outputs[spaces_size] =
             TransferGraph::XDTemplate::mk_edge(ib_base + spaces_size);
         ctrl_edge = xdn.outputs[spaces_size];
-        ib_edges[ib_base + spaces_size].memory = addr_ib_mem;
-        ib_edges[ib_base + spaces_size].size = 65536; // TODO
+        init_ib_edge(ib_edges[ib_base + spaces_size], addr_ib_mem, 65536,
+                     control_min_size, control_granularity);
       }
 
       // control information has to get to the split at the start
@@ -3595,7 +3639,9 @@ namespace Realm {
         bool ok = find_shortest_path(get_runtime()->nodes, addr_ib_mem, src_ib_mem,
                                      0 /*no serdez*/, 0 /*redop_id*/, path);
         assert(ok);
-        ctrl_edge = add_copy_path(xd_nodes, ib_edges, ctrl_edge, path);
+        ctrl_edge =
+            add_copy_path(xd_nodes, ib_edges, ctrl_edge, path, Config::ib_size_bytes,
+                          control_min_size, control_granularity);
       }
 
       // next, see what work we need to get the addresses to where the
@@ -3612,7 +3658,8 @@ namespace Realm {
                                        0 /*no serdez*/, 0 /*redop_id*/, path);
           assert(ok);
           decoded_addr_edges[i] =
-              add_copy_path(xd_nodes, ib_edges, decoded_addr_edges[i], path);
+              add_copy_path(xd_nodes, ib_edges, decoded_addr_edges[i], path,
+                            Config::ib_size_bytes, address_min_size, address_granularity);
         }
       }
 
@@ -3649,8 +3696,9 @@ namespace Realm {
             ib_edges.resize(ib_idx + 1);
             data_edges[i] = TransferGraph::XDTemplate::mk_edge(ib_idx);
             xdn.outputs[i] = data_edges[i];
-            ib_edges[ib_idx].memory = path_infos[path_idx[i]].path[1];
-            ib_edges[ib_idx].size = 65536; // TODO: pick size?
+            init_ib_edge(ib_edges[ib_idx], path_infos[path_idx[i]].path[1],
+                         std::max<size_t>(65536, data_min_size), data_min_size,
+                         data_granularity);
           }
         }
       }
@@ -3682,8 +3730,9 @@ namespace Realm {
                             : TransferGraph::XDTemplate::mk_edge(ib_base + j - 1));
               xdn.outputs.resize(1);
               xdn.outputs[0] = TransferGraph::XDTemplate::mk_edge(ib_base + j);
-              ib_edges[ib_base + j].memory = mpi.path[j + 2];
-              ib_edges[ib_base + j].size = 65536; // TODO: pick size?
+              init_ib_edge(ib_edges[ib_base + j], mpi.path[j + 2],
+                           std::max<size_t>(65536, data_min_size), data_min_size,
+                           data_granularity);
             } else {
               // last hop uses the address stream
               xdn.inputs.resize(2);
@@ -3939,30 +3988,155 @@ namespace Realm {
     }
   }
 
-  static size_t compute_ib_size(size_t combined_field_size, size_t domain_size,
-                                CustomSerdezID serdez_id)
+  static size_t ib_align_down(size_t n, size_t mult)
+  {
+    if(mult == 0) {
+      return n;
+    }
+    return n - (n % mult);
+  }
+
+  static bool ib_align_up_overflow(size_t n, size_t mult, size_t &result)
+  {
+    if(mult == 0) {
+      result = n;
+      return false;
+    }
+
+    size_t leftover = n % mult;
+    if(leftover == 0) {
+      result = n;
+      return false;
+    }
+
+    size_t extra = mult - leftover;
+    if(n > (std::numeric_limits<size_t>::max() - extra)) {
+      result = std::numeric_limits<size_t>::max();
+      return true;
+    }
+    result = n + extra;
+    return false;
+  }
+
+  static bool ib_add_overflow(size_t a, size_t b, size_t &result)
+  {
+    if(a > (std::numeric_limits<size_t>::max() - b)) {
+      result = std::numeric_limits<size_t>::max();
+      return true;
+    }
+    result = a + b;
+    return false;
+  }
+
+  static size_t ib_saturating_add(size_t a, size_t b)
+  {
+    size_t result;
+    ib_add_overflow(a, b, result);
+    return result;
+  }
+
+  static size_t ib_saturating_mul(size_t a, size_t b)
+  {
+    if((a != 0) && (b > (std::numeric_limits<size_t>::max() / a))) {
+      return std::numeric_limits<size_t>::max();
+    }
+    return a * b;
+  }
+
+  static size_t ib_saturating_mul_add(size_t a, size_t b, size_t c)
+  {
+    return ib_saturating_add(ib_saturating_mul(a, b), c);
+  }
+
+  static bool ib_checked_lcm(size_t a, size_t b, size_t &result)
+  {
+    if((a == 0) || (b == 0)) {
+      result = 0;
+      return true;
+    }
+
+    size_t div = a / std::gcd(a, b);
+    if(div > (std::numeric_limits<size_t>::max() / b)) {
+      return false;
+    }
+    result = div * b;
+    return true;
+  }
+
+  // floor(a * b / c) without overflowing a 64-bit intermediate for realistic IB
+  // sizes; uses 128-bit arithmetic where the compiler provides it (gcc/clang)
+  // and falls back to long double otherwise (e.g. MSVC).
+  static size_t ib_mul_div_floor(size_t a, size_t b, size_t c)
+  {
+    if(c == 0) {
+      return 0;
+    }
+#if defined(__SIZEOF_INT128__)
+    return static_cast<size_t>((static_cast<unsigned __int128>(a) * b) / c);
+#else
+    long double v = (static_cast<long double>(a) * static_cast<long double>(b)) /
+                    static_cast<long double>(c);
+    return static_cast<size_t>(v);
+#endif
+  }
+
+  static size_t get_cached_memory_size(std::map<Memory, size_t> &caps, Memory memory)
+  {
+    std::map<Memory, size_t>::const_iterator it = caps.find(memory);
+    if(it != caps.end()) {
+      return it->second;
+    }
+    size_t memory_size = MemoryImpl::get_memory_size(get_runtime(), memory);
+    caps[memory] = memory_size;
+    return memory_size;
+  }
+
+  static size_t get_ib_size_limit(Memory ib_mem, size_t config_limit,
+                                  std::map<Memory, size_t> &caps)
+  {
+    size_t memory_limit = get_cached_memory_size(caps, ib_mem);
+    return std::min(memory_limit, config_limit);
+  }
+
+  static size_t get_serdez_max_serialized_size(CustomSerdezID serdez_id)
+  {
+    const CustomSerdezUntyped *serdez_op =
+        get_runtime()->custom_serdez_table.get(serdez_id, 0);
+    assert(serdez_op != 0);
+    return serdez_op->max_serialized_size;
+  }
+
+  static size_t compute_ib_granularity(size_t combined_field_size,
+                                       CustomSerdezID serdez_id)
+  {
+    return (serdez_id != 0) ? 1 : std::max<size_t>(combined_field_size, 1);
+  }
+
+  size_t compute_ib_natural_size(size_t combined_field_size, size_t domain_size,
+                                 CustomSerdezID serdez_id)
   {
     size_t element_size;
     size_t serdez_pad = 0;
-    size_t min_granularity = 1;
     if(serdez_id != 0) {
-      const CustomSerdezUntyped *serdez_op =
-          get_runtime()->custom_serdez_table.get(serdez_id, 0);
-      assert(serdez_op != 0);
-      element_size = serdez_op->max_serialized_size;
-      serdez_pad = serdez_op->max_serialized_size;
+      element_size = get_serdez_max_serialized_size(serdez_id);
+      serdez_pad = element_size;
     } else {
       element_size = combined_field_size;
+    }
+
+    return ib_saturating_mul_add(domain_size, element_size, serdez_pad);
+  }
+
+  static size_t compute_ib_size(size_t combined_field_size, size_t domain_size,
+                                CustomSerdezID serdez_id, size_t max_ib_size)
+  {
+    size_t min_granularity = 1;
+    if(serdez_id == 0) {
       min_granularity = combined_field_size;
     }
 
-    size_t max_ib_size = 0;
-    RealmStatus status =
-        get_runtime()->get_module_config("core")->get_property("ib_regmem", max_ib_size);
-    assert(status == REALM_SUCCESS);
-
-    size_t ib_size = domain_size * element_size + serdez_pad;
-    const size_t IB_MAX_SIZE = max_ib_size; // 16 << 20; // 16MB
+    size_t ib_size = compute_ib_natural_size(combined_field_size, domain_size, serdez_id);
+    const size_t IB_MAX_SIZE = max_ib_size;
     if(ib_size > IB_MAX_SIZE) {
       // take up to IB_MAX_SIZE, respecting the min granularity
       if(min_granularity > 1) {
@@ -3980,6 +4154,238 @@ namespace Realm {
     }
 
     return ib_size;
+  }
+
+  // Smallest IB (logical ring) size that still lets a transfer make forward
+  // progress.  The engine moves at most ib_size>>1 bytes per step (channel.cc)
+  // and stalls if the ring can't hold a whole element, so the pipeline floor is
+  // 2 elements (plus one serdez pad, matching compute_ib_size's layout).  A
+  // transfer whose entire data is smaller than that floor is served by a buffer
+  // holding all of it, so 'max_needed' caps the floor at the total data size.
+  // The result is the logical ring floor and is intentionally NOT 256-aligned:
+  // ibe.size need not be aligned (only its allocation is), and aligning the
+  // floor up here would spuriously reject sub-256-byte transfers.
+  size_t compute_ib_min_size(size_t combined_field_size, CustomSerdezID serdez_id,
+                             size_t max_needed)
+  {
+    size_t element_size;
+    size_t serdez_pad = 0;
+    if(serdez_id != 0) {
+      element_size = get_serdez_max_serialized_size(serdez_id);
+      serdez_pad = element_size;
+    } else {
+      element_size = combined_field_size;
+    }
+    return std::min(ib_saturating_add(serdez_pad, ib_saturating_mul(2, element_size)),
+                    max_needed);
+  }
+
+  static void init_ib_edge(TransferGraph::IBInfo &ibe, Memory memory, size_t size,
+                           size_t min_size, size_t size_granularity)
+  {
+    ibe.memory = memory;
+    ibe.size = size;
+    ibe.min_size = min_size;
+    ibe.size_granularity = std::max<size_t>(size_granularity, 1);
+  }
+
+  static void init_transfer_ib_edge(TransferGraph::IBInfo &ibe, Memory memory,
+                                    size_t combined_field_size, size_t domain_size,
+                                    CustomSerdezID serdez_id, size_t ib_limit)
+  {
+    size_t size = compute_ib_size(combined_field_size, domain_size, serdez_id, ib_limit);
+    // the progress floor never needs to exceed the transfer's natural (uncapped)
+    //  size: a domain smaller than the 2-element floor is fully served by a
+    //  buffer holding all of its data
+    size_t natural_size =
+        compute_ib_natural_size(combined_field_size, domain_size, serdez_id);
+    init_ib_edge(ibe, memory, size,
+                 compute_ib_min_size(combined_field_size, serdez_id, natural_size),
+                 compute_ib_granularity(combined_field_size, serdez_id));
+  }
+
+  static size_t effective_ib_min_size(const TransferGraph::IBInfo &edge)
+  {
+    return (edge.min_size != 0) ? edge.min_size : IB_ALLOC_ALIGNMENT;
+  }
+
+  void redistribute_ib_sizes_impl(std::vector<TransferGraph::IBInfo> &ib_edges,
+                                  const std::map<Memory, size_t> &caps)
+  {
+    // group edge indices by target memory
+    std::map<Memory, std::vector<size_t>> groups;
+    for(size_t i = 0; i < ib_edges.size(); i++) {
+      groups[ib_edges[i].memory].push_back(i);
+    }
+
+    for(const std::pair<const Memory, std::vector<size_t>> &kv : groups) {
+      Memory mem = kv.first;
+      const std::vector<size_t> &idxs = kv.second;
+      size_t cap = caps.at(mem);
+      size_t budget_bytes = ib_align_down(cap, IB_ALLOC_ALIGNMENT);
+
+      // aggregate as the allocator will actually consume it (256-byte rounded)
+      size_t rounded_sum = 0;
+      bool rounded_sum_overflow = false;
+      for(size_t e : idxs) {
+        size_t min_size = effective_ib_min_size(ib_edges[e]);
+        if(ib_edges[e].size < min_size) {
+          log_new_dma.fatal() << "FATAL: impossible IB allocation planned: index=" << e
+                              << " mem=" << ib_edges[e].memory
+                              << " requested=" << ib_edges[e].size
+                              << " min-needed=" << min_size;
+          abort();
+        }
+        size_t rounded_size = 0;
+        rounded_sum_overflow |=
+            ib_align_up_overflow(ib_edges[e].size, IB_ALLOC_ALIGNMENT, rounded_size);
+        rounded_sum_overflow |= ib_add_overflow(rounded_sum, rounded_size, rounded_sum);
+      }
+      if(!rounded_sum_overflow && (rounded_sum <= cap)) {
+        continue; // fits already, leave untouched
+      }
+
+      // Per-edge floor and requested size, both rounded to a unit that is valid
+      // for the allocator and the transfer's element granularity.
+      std::vector<size_t> unit_bytes(idxs.size());
+      std::vector<size_t> floor_bytes(idxs.size());
+      std::vector<size_t> req_bytes(idxs.size());
+      std::vector<size_t> want_bytes(idxs.size());
+      size_t floor_bytes_total = 0;
+      size_t want_bytes_total = 0;
+      bool floor_bytes_overflow = false;
+      for(size_t k = 0; k < idxs.size(); k++) {
+        size_t e = idxs[k];
+        // final sizes must be a multiple of both the allocator alignment and the
+        //  transfer's element granularity
+        if(!ib_checked_lcm(IB_ALLOC_ALIGNMENT,
+                           std::max<size_t>(ib_edges[e].size_granularity, 1),
+                           unit_bytes[k])) {
+          log_new_dma.fatal() << "FATAL: impossible IB allocation planned: index=" << e
+                              << " mem=" << ib_edges[e].memory
+                              << " granularity=" << ib_edges[e].size_granularity
+                              << " alignment=" << IB_ALLOC_ALIGNMENT
+                              << " has unrepresentable lcm";
+          abort();
+        }
+        size_t floor_sz = 0;
+        if(ib_align_up_overflow(effective_ib_min_size(ib_edges[e]), unit_bytes[k],
+                                floor_sz)) {
+          log_new_dma.fatal() << "FATAL: impossible IB allocation planned: index=" << e
+                              << " mem=" << ib_edges[e].memory
+                              << " min-needed=" << effective_ib_min_size(ib_edges[e])
+                              << " unit=" << unit_bytes[k]
+                              << " has unrepresentable aligned floor";
+          abort();
+        }
+        size_t req_sz = ib_align_down(ib_edges[e].size, unit_bytes[k]);
+        if(req_sz < floor_sz) {
+          log_new_dma.fatal() << "FATAL: impossible IB allocation planned: index=" << e
+                              << " mem=" << ib_edges[e].memory
+                              << " requested=" << ib_edges[e].size
+                              << " min-needed=" << floor_sz << " unit=" << unit_bytes[k];
+          abort();
+        }
+        floor_bytes[k] = floor_sz;
+        req_bytes[k] = req_sz;
+        want_bytes[k] = req_bytes[k] - floor_bytes[k];
+        floor_bytes_overflow |=
+            ib_add_overflow(floor_bytes_total, floor_bytes[k], floor_bytes_total);
+        want_bytes_total = ib_saturating_add(want_bytes_total, want_bytes[k]);
+      }
+
+      if(floor_bytes_overflow || (floor_bytes_total > budget_bytes)) {
+        // genuinely impossible: can't fit even one element per edge at once
+        log_new_dma.fatal() << "FATAL: impossible IB allocation batch: mem=" << mem
+                            << " min-needed=" << floor_bytes_total << " avail=" << cap
+                            << " edges=" << idxs.size();
+        abort();
+      }
+      size_t extra_bytes = budget_bytes - floor_bytes_total;
+
+      // give each edge its floor plus a proportional share of the spare
+      // capacity, weighted by how much it wanted above its floor.  A running
+      // remainder bounds each grant so the total handed out never exceeds the
+      // spare budget - this keeps the aggregate <= cap and avoids any size_t
+      // underflow regardless of how the (floored) proportional share is rounded.
+      size_t remaining_extra = extra_bytes;
+      for(size_t k = 0; k < idxs.size(); k++) {
+        size_t give = 0;
+        if(want_bytes_total != 0) {
+          size_t share = ib_mul_div_floor(want_bytes[k], extra_bytes, want_bytes_total);
+          give = ib_align_down(std::min(share, remaining_extra), unit_bytes[k]);
+        }
+        ib_edges[idxs[k]].size = floor_bytes[k] + give;
+        remaining_extra -= give;
+      }
+
+      // Rounding can leave whole units unused; hand them to edges still below
+      // their requested size when a whole valid unit fits.
+      for(size_t k = 0; (remaining_extra > 0) && (k < idxs.size()); k++) {
+        size_t cur = ib_edges[idxs[k]].size;
+        if(cur < req_bytes[k]) {
+          size_t add =
+              ib_align_down(std::min(remaining_extra, req_bytes[k] - cur), unit_bytes[k]);
+          if(add > 0) {
+            ib_edges[idxs[k]].size += add;
+            remaining_extra -= add;
+          }
+        }
+      }
+    }
+  }
+
+  static void verify_ib_alloc_sizes(const std::vector<TransferGraph::IBInfo> &ib_edges,
+                                    const std::map<Memory, size_t> &caps)
+  {
+    std::map<Memory, size_t> bytes_by_memory;
+    for(size_t i = 0; i < ib_edges.size(); i++) {
+      size_t memory_size = caps.at(ib_edges[i].memory);
+      size_t min_size = effective_ib_min_size(ib_edges[i]);
+      if(ib_edges[i].size < min_size) {
+        log_new_dma.fatal() << "FATAL: impossible IB allocation planned: index=" << i
+                            << " mem=" << ib_edges[i].memory
+                            << " requested=" << ib_edges[i].size
+                            << " min-needed=" << min_size;
+        abort();
+      }
+
+      // the allocator rounds each request up to IB_ALLOC_ALIGNMENT, so compare
+      // against the rounded size to stay consistent with what it consumes
+      size_t rounded_size = 0;
+      if(ib_align_up_overflow(ib_edges[i].size, IB_ALLOC_ALIGNMENT, rounded_size)) {
+        log_new_dma.fatal() << "FATAL: impossible IB allocation planned: index=" << i
+                            << " mem=" << ib_edges[i].memory
+                            << " requested=" << ib_edges[i].size
+                            << " has unrepresentable aligned size";
+        abort();
+      }
+      if(rounded_size > memory_size) {
+        log_new_dma.fatal() << "FATAL: impossible IB allocation planned: index=" << i
+                            << " mem=" << ib_edges[i].memory << " needed=" << rounded_size
+                            << " avail=" << memory_size;
+        abort();
+      }
+
+      size_t &bytes_for_memory = bytes_by_memory[ib_edges[i].memory];
+      if(ib_add_overflow(bytes_for_memory, rounded_size, bytes_for_memory)) {
+        log_new_dma.fatal() << "FATAL: impossible IB allocation batch planned: mem="
+                            << ib_edges[i].memory << " needed exceeds size_t"
+                            << " avail=" << memory_size;
+        abort();
+      }
+    }
+
+    for(const std::pair<const Memory, size_t> &kv : bytes_by_memory) {
+      Memory memory = kv.first;
+      size_t memory_size = caps.at(memory);
+      if(kv.second > memory_size) {
+        log_new_dma.fatal() << "FATAL: impossible IB allocation batch planned: mem="
+                            << memory << " needed=" << kv.second
+                            << " avail=" << memory_size;
+        abort();
+      }
+    }
   }
 
   struct IBAllocOrderSorter {
@@ -4064,6 +4470,11 @@ namespace Realm {
     }
 
     size_t domain_size = analysis_domain_size;
+    size_t ib_regmem_limit = 0;
+    RealmStatus ib_regmem_status = get_runtime()->get_module_config("core")->get_property(
+        "ib_regmem", ib_regmem_limit);
+    assert(ib_regmem_status == REALM_SUCCESS);
+    std::map<Memory, size_t> ib_caps;
 
     // TODO: look at layouts and decide if fields should be grouped into
     //  a smaller number of copies
@@ -4143,11 +4554,9 @@ namespace Realm {
         size_t pathlen = path_info.xd_channels.size();
         size_t xd_idx = graph.xd_nodes.size();
         size_t ib_idx = graph.ib_edges.size();
-        size_t ib_alloc_size = 0;
         graph.xd_nodes.resize(xd_idx + pathlen);
         if(pathlen > 1) {
           graph.ib_edges.resize(ib_idx + pathlen - 1);
-          ib_alloc_size = compute_ib_size(combined_field_size, domain_size, serdez_id);
         }
         for(size_t j = 0; j < pathlen; j++) {
           TransferGraph::XDTemplate &xdn = graph.xd_nodes[xd_idx++];
@@ -4175,8 +4584,10 @@ namespace Realm {
           // xdn.outputs[0].indirect_inst = RegionInstance::NO_INST;
           if(j < (pathlen - 1)) {
             TransferGraph::IBInfo &ibe = graph.ib_edges[ib_idx++];
-            ibe.memory = path_info.path[j + 1];
-            ibe.size = ib_alloc_size;
+            Memory ib_memory = path_info.path[j + 1];
+            size_t ib_limit = get_ib_size_limit(ib_memory, ib_regmem_limit, ib_caps);
+            init_transfer_ib_edge(ibe, ib_memory, combined_field_size, domain_size,
+                                  serdez_id, ib_limit);
           }
         }
 
@@ -4218,11 +4629,9 @@ namespace Realm {
         size_t pathlen = path_info.xd_channels.size();
         size_t xd_idx = graph.xd_nodes.size();
         size_t ib_idx = graph.ib_edges.size();
-        size_t ib_alloc_size = 0;
         graph.xd_nodes.resize(xd_idx + pathlen);
         if(pathlen > 1) {
           graph.ib_edges.resize(ib_idx + pathlen - 1);
-          ib_alloc_size = compute_ib_size(combined_field_size, domain_size, serdez_id);
         }
         for(size_t j = 0; j < pathlen; j++) {
           TransferGraph::XDTemplate &xdn = graph.xd_nodes[xd_idx++];
@@ -4247,8 +4656,10 @@ namespace Realm {
                    : TransferGraph::XDTemplate::mk_edge(ib_idx));
           if(j < (pathlen - 1)) {
             TransferGraph::IBInfo &ibe = graph.ib_edges[ib_idx++];
-            ibe.memory = path_info.path[j + 1];
-            ibe.size = ib_alloc_size;
+            Memory ib_memory = path_info.path[j + 1];
+            size_t ib_limit = get_ib_size_limit(ib_memory, ib_regmem_limit, ib_caps);
+            init_transfer_ib_edge(ibe, ib_memory, combined_field_size, domain_size,
+                                  serdez_id, ib_limit);
           }
         }
 
@@ -4361,12 +4772,9 @@ namespace Realm {
             size_t pathlen = path_info.xd_channels.size();
             size_t xd_idx = graph.xd_nodes.size();
             size_t ib_idx = graph.ib_edges.size();
-            size_t ib_alloc_size = 0;
             graph.xd_nodes.resize(xd_idx + pathlen);
             if(pathlen > 1) {
               graph.ib_edges.resize(ib_idx + pathlen - 1);
-              ib_alloc_size =
-                  compute_ib_size(combined_field_size, domain_size, serdez_id);
             }
             for(size_t j = 0; j < pathlen; j++) {
               TransferGraph::XDTemplate &xdn = graph.xd_nodes[xd_idx++];
@@ -4401,8 +4809,10 @@ namespace Realm {
               // xdn.outputs[0].indirect_inst = RegionInstance::NO_INST;
               if(j < (pathlen - 1)) {
                 TransferGraph::IBInfo &ibe = graph.ib_edges[ib_idx++];
-                ibe.memory = path_info.path[j + 1];
-                ibe.size = ib_alloc_size;
+                Memory ib_memory = path_info.path[j + 1];
+                size_t ib_limit = get_ib_size_limit(ib_memory, ib_regmem_limit, ib_caps);
+                init_transfer_ib_edge(ibe, ib_memory, combined_field_size, domain_size,
+                                      serdez_id, ib_limit);
               }
             }
 
@@ -4493,8 +4903,15 @@ namespace Realm {
 
             int ib_idx = graph.ib_edges.size();
             graph.ib_edges.resize(ib_idx + 1);
-            graph.ib_edges[ib_idx].memory = ib_mem;
-            graph.ib_edges[ib_idx].size = 1 << 20; // HACK
+            size_t data_natural_size = compute_ib_natural_size(
+                addrsplit_bytes_per_element, domain_size, serdez_id);
+            size_t data_min_size = compute_ib_min_size(addrsplit_bytes_per_element,
+                                                       serdez_id, data_natural_size);
+            size_t data_granularity =
+                compute_ib_granularity(addrsplit_bytes_per_element, serdez_id);
+            init_ib_edge(graph.ib_edges[ib_idx], ib_mem,
+                         std::max<size_t>(size_t(1) << 20, data_min_size), data_min_size,
+                         data_granularity);
 
             IndirectionInfo *gather_info = indirects[srcs[i].indirect_index];
             gather_info->generate_gather_paths(
@@ -4550,6 +4967,15 @@ namespace Realm {
     //  then having the allocation code do all ibs for the same memory for a single
     //  transfer op atomically) does the trick
     if(!graph.ib_edges.empty()) {
+      // shrink any set of same-memory IB edges whose aggregate exceeds the
+      //  memory's capacity so the plan is feasible (must run before the sort
+      //  below, which tiebreaks on the final edge sizes)
+      for(const TransferGraph::IBInfo &e : graph.ib_edges) {
+        get_cached_memory_size(ib_caps, e.memory);
+      }
+      redistribute_ib_sizes_impl(graph.ib_edges, ib_caps);
+      verify_ib_alloc_sizes(graph.ib_edges, ib_caps);
+
       graph.ib_alloc_order.resize(graph.ib_edges.size());
       for(size_t i = 0; i < graph.ib_edges.size(); i++) {
         graph.ib_alloc_order[i] = i;

--- a/src/realm/transfer/transfer.h
+++ b/src/realm/transfer/transfer.h
@@ -440,6 +440,12 @@ namespace Realm {
     struct IBInfo {
       Memory memory;
       size_t size;
+      // smallest size that still lets the transfer make forward progress;
+      // 0 means "no explicit floor, use the global IB_ALLOC_ALIGNMENT default"
+      size_t min_size = 0;
+      // final sizes chosen by redistribution must remain multiples of this
+      // transfer granularity, in addition to the allocator's alignment
+      size_t size_granularity = 1;
     };
     std::vector<XDTemplate> xd_nodes;
     std::vector<IBInfo> ib_edges;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -101,6 +101,7 @@ list(
   event_test.cc
   path_cache_test.cc
   transfer_utils_test.cc
+  ib_redistribute_test.cc
   address_list_test.cc
   cmdline_parser_test.cc
   sequence_assembler_test.cc

--- a/tests/unit_tests/ib_redistribute_test.cc
+++ b/tests/unit_tests/ib_redistribute_test.cc
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2025 Stanford University, NVIDIA Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "realm/transfer/transfer.h"
+#include "realm/transfer/ib_memory.h"
+#include <gtest/gtest.h>
+#include <limits>
+#include <map>
+
+using namespace Realm;
+
+namespace Realm {
+  void redistribute_ib_sizes_impl(std::vector<TransferGraph::IBInfo> &ib_edges,
+                                  const std::map<Memory, size_t> &caps);
+  size_t compute_ib_min_size(size_t combined_field_size, CustomSerdezID serdez_id,
+                             size_t max_needed);
+  size_t compute_ib_natural_size(size_t combined_field_size, size_t domain_size,
+                                 CustomSerdezID serdez_id);
+} // namespace Realm
+
+namespace {
+
+  constexpr size_t A = IB_ALLOC_ALIGNMENT; // 256
+
+  TransferGraph::IBInfo mk(Memory memory, size_t size, size_t min_size,
+                           size_t size_granularity = 1)
+  {
+    TransferGraph::IBInfo e;
+    e.memory = memory;
+    e.size = size;
+    e.min_size = min_size;
+    e.size_granularity = size_granularity;
+    return e;
+  }
+
+  // total bytes the allocator would consume for all edges targeting mem
+  size_t rounded_total(const std::vector<TransferGraph::IBInfo> &edges, Memory mem)
+  {
+    size_t sum = 0;
+    for(const auto &e : edges) {
+      if(e.memory == mem) {
+        sum += ib_align_up(e.size);
+      }
+    }
+    return sum;
+  }
+
+} // namespace
+
+// Edges that already fit are left untouched.
+TEST(IBRedistributeTest, LeavesFittingPlanUntouched)
+{
+  const Memory M(0x1000);
+  std::vector<TransferGraph::IBInfo> edges = {
+      mk(M, 100 * A, 4 * A),
+      mk(M, 100 * A, 4 * A),
+  };
+  std::map<Memory, size_t> caps = {{M, 1024 * A}};
+
+  redistribute_ib_sizes_impl(edges, caps);
+
+  EXPECT_EQ(edges[0].size, 100u * A);
+  EXPECT_EQ(edges[1].size, 100u * A);
+}
+
+// Oversubscribed same-memory edges are shrunk so the rounded aggregate fits,
+// each stays 256-aligned and >= its floor, and the larger requester keeps the
+// larger share.
+TEST(IBRedistributeTest, ShrinksProportionallyToFit)
+{
+  const Memory M(0x2000);
+  const size_t cap = 1024 * A;
+  std::vector<TransferGraph::IBInfo> edges = {
+      mk(M, 300 * A, 10 * A), // small requester
+      mk(M, 900 * A, 10 * A), // large requester
+  };
+  std::map<Memory, size_t> caps = {{M, cap}};
+
+  redistribute_ib_sizes_impl(edges, caps);
+
+  EXPECT_LE(rounded_total(edges, M), cap);
+  for(const auto &e : edges) {
+    EXPECT_EQ(e.size % A, 0u) << "size must stay 256-aligned";
+    EXPECT_GE(e.size, 10u * A) << "size must not drop below its floor";
+    EXPECT_LE(e.size, ib_align_up(e.size)) << "sanity";
+  }
+  // the edge that asked for more keeps more
+  EXPECT_GT(edges[1].size, edges[0].size);
+  // and neither is grown beyond what it requested
+  EXPECT_LE(edges[0].size, 300u * A);
+  EXPECT_LE(edges[1].size, 900u * A);
+}
+
+// A single edge larger than its memory is shrunk to fit rather than aborting.
+TEST(IBRedistributeTest, ShrinksSingleOversizedEdge)
+{
+  const Memory M(0x3000);
+  const size_t cap = 512 * A;
+  std::vector<TransferGraph::IBInfo> edges = {mk(M, 4096 * A, 8 * A)};
+  std::map<Memory, size_t> caps = {{M, cap}};
+
+  redistribute_ib_sizes_impl(edges, caps);
+
+  EXPECT_LE(ib_align_up(edges[0].size), cap);
+  EXPECT_GE(edges[0].size, 8u * A);
+  EXPECT_EQ(edges[0].size % A, 0u);
+}
+
+// Metadata edges with no explicit floor (min_size == 0) are never shrunk below
+// the 256-byte alignment.
+TEST(IBRedistributeTest, RespectsDefaultFloorForMetadataEdges)
+{
+  const Memory M(0x4000);
+  const size_t cap = 300 * A;
+  std::vector<TransferGraph::IBInfo> edges = {
+      mk(M, 256 * A, 0),      // metadata edge, no explicit floor
+      mk(M, 256 * A, 32 * A), // real edge
+  };
+  std::map<Memory, size_t> caps = {{M, cap}};
+
+  redistribute_ib_sizes_impl(edges, caps);
+
+  EXPECT_LE(rounded_total(edges, M), cap);
+  EXPECT_GE(edges[0].size, A) << "metadata edge must not drop below 256";
+  EXPECT_GE(edges[1].size, 32u * A) << "real edge must keep its floor";
+}
+
+// Different memories are handled independently.
+TEST(IBRedistributeTest, HandlesMultipleMemoriesIndependently)
+{
+  const Memory M1(0x5000), M2(0x6000);
+  std::vector<TransferGraph::IBInfo> edges = {
+      mk(M1, 900 * A, 8 * A), // M1 oversubscribed with the next edge
+      mk(M2, 10 * A, 2 * A),  // M2 fits comfortably, must be untouched
+      mk(M1, 900 * A, 8 * A),
+  };
+  std::map<Memory, size_t> caps = {{M1, 1024 * A}, {M2, 1024 * A}};
+
+  redistribute_ib_sizes_impl(edges, caps);
+
+  EXPECT_LE(rounded_total(edges, M1), 1024u * A);
+  EXPECT_EQ(edges[1].size, 10u * A) << "fitting memory must be left untouched";
+}
+
+// Shrunk payload edges keep their transfer granularity, not just allocator
+// alignment.
+TEST(IBRedistributeTest, PreservesEdgeGranularityWhenShrinking)
+{
+  const Memory M(0x6500);
+  const size_t G = 3 * A; // valid transfer unit larger than allocator alignment
+  const size_t cap = 9 * G;
+  std::vector<TransferGraph::IBInfo> edges = {
+      mk(M, 6 * G, A, G),
+      mk(M, 6 * G, A, G),
+  };
+  std::map<Memory, size_t> caps = {{M, cap}};
+
+  redistribute_ib_sizes_impl(edges, caps);
+
+  EXPECT_LE(rounded_total(edges, M), cap);
+  for(const auto &e : edges) {
+    EXPECT_EQ(e.size % G, 0u);
+    EXPECT_GE(e.size, G);
+    EXPECT_LE(e.size, 6u * G);
+  }
+}
+
+// The progress floor is the raw 2-element ring size (NOT rounded up to the
+// allocator's 256-byte alignment), and it is capped at the transfer's total
+// data so small transfers are not spuriously rejected.
+TEST(IBMinSizeTest, FloorIsTwoElementsCappedAtDataSize)
+{
+  constexpr size_t no_cap = std::numeric_limits<size_t>::max();
+  // large domain of a small field: floor is 2 elements, not rounded up to 256
+  EXPECT_EQ(compute_ib_min_size(4, 0, no_cap), 8u);
+  // total data below 2 elements: floor is capped at the data size
+  EXPECT_EQ(compute_ib_min_size(4, 0, 4), 4u);
+  // a field whose 2-element floor exceeds the total data is capped at the data
+  EXPECT_LE(compute_ib_min_size(64, 0, 100), 100u);
+  EXPECT_EQ(compute_ib_min_size(64, 0, no_cap), 128u);
+}
+
+TEST(IBMinSizeTest, NaturalSizeSaturatesOnOverflow)
+{
+  constexpr size_t max_size = std::numeric_limits<size_t>::max();
+  const size_t large_element = (max_size / 2) + 1;
+
+  EXPECT_EQ(compute_ib_natural_size(large_element, 3, 0), max_size);
+  EXPECT_EQ(compute_ib_min_size(large_element, 0, max_size), max_size);
+}
+
+TEST(IBMinSizeTest, SmallIndirectFloorsAreCappedAtNaturalSize)
+{
+  const size_t one_address = compute_ib_natural_size(64, 1, 0);
+  const size_t one_payload = compute_ib_natural_size(128, 1, 0);
+
+  EXPECT_EQ(compute_ib_min_size(64, 0, one_address), 64u);
+  EXPECT_EQ(compute_ib_min_size(128, 0, one_payload), 128u);
+  EXPECT_EQ(compute_ib_min_size(sizeof(unsigned), 0, std::numeric_limits<size_t>::max()),
+            2u * sizeof(unsigned));
+}
+
+// Regression: a small multi-hop transfer whose logical ring size is below the
+// allocator's 256-byte alignment but at/above its own progress floor must be
+// preserved, not rejected.  This mirrors init_transfer_ib_edge's output for a
+// 10-element x 4-byte copy: size=40, min_size=min(2*4, 40)=8, granularity=4.
+TEST(IBRedistributeTest, PreservesSmallSubAlignmentEdge)
+{
+  const Memory M(0x8000);
+  std::vector<TransferGraph::IBInfo> edges = {mk(M, 40, 8, 4)};
+  std::map<Memory, size_t> caps = {{M, 128ull * 1024 * 1024}};
+  redistribute_ib_sizes_impl(edges, caps);
+  EXPECT_EQ(edges[0].size, 40u) << "small transfer must not be rejected or shrunk";
+}
+
+// A hard progress floor is enforced even when the aggregate allocation would
+// fit in the target memory.
+TEST(IBRedistributeDeathTest, AbortsWhenEdgeBelowHardFloor)
+{
+  const Memory M(0x6800);
+  std::vector<TransferGraph::IBInfo> edges = {mk(M, 2 * A, 4 * A)};
+  std::map<Memory, size_t> caps = {{M, 1024 * A}};
+
+  EXPECT_DEATH(redistribute_ib_sizes_impl(edges, caps), ".*");
+}
+
+TEST(IBRedistributeDeathTest, AbortsWhenGranularityLcmOverflows)
+{
+  const Memory M(0x7800);
+  const size_t huge_odd_granularity = std::numeric_limits<size_t>::max() / 2;
+  std::vector<TransferGraph::IBInfo> edges = {
+      mk(M, 2 * 1024 * A, A, huge_odd_granularity),
+  };
+  std::map<Memory, size_t> caps = {{M, 1024 * A}};
+
+  EXPECT_DEATH(redistribute_ib_sizes_impl(edges, caps), ".*");
+}
+
+TEST(IBRedistributeDeathTest, AbortsWhenAlignedFloorOverflows)
+{
+  const Memory M(0x7900);
+  const size_t max_size = std::numeric_limits<size_t>::max();
+  std::vector<TransferGraph::IBInfo> edges = {
+      mk(M, max_size, max_size - 1, A),
+  };
+  std::map<Memory, size_t> caps = {{M, 1024 * A}};
+
+  EXPECT_DEATH(redistribute_ib_sizes_impl(edges, caps), ".*");
+}
+
+// When not even one element per edge fits, the plan is genuinely impossible.
+TEST(IBRedistributeDeathTest, AbortsWhenFloorsCannotFit)
+{
+  const Memory M(0x7000);
+  const size_t cap = 8 * A; // only 8 units available
+  std::vector<TransferGraph::IBInfo> edges = {
+      mk(M, 100 * A, 8 * A), // floor 8 units
+      mk(M, 100 * A, 8 * A), // floor 8 units -> 16 > 8 avail
+  };
+  std::map<Memory, size_t> caps = {{M, cap}};
+
+  // the fatal log message is routed through Realm's logger, which isn't
+  // initialized in this bare unit test, so just assert the process aborts
+  EXPECT_DEATH(redistribute_ib_sizes_impl(edges, caps), ".*");
+}


### PR DESCRIPTION
Cap and redistribute transfer IB allocations so plans always fit their target memories

Problem

The DMA transfer planner could produce intermediate-buffer (IB) allocation plans that no IB memory could satisfy, crashing at allocation time:

```
ib_alloc: impossible: op=1/0x14079124c260 mem=1a00010000000002 needed=536870904 avail=134217728
```

The planner sized IB edges against the global registered-IB config (core.ib_regmem / -ll:ib_rsize), which is not the actual capacity of the IB memory selected for a given path. For GPU-involved paths this let a planned edge near the 512 MB registered-memory cap target a 128 MB GPU framebuffer IB pool (-ll:ib_fsize) — the exact failure above.

Two deeper issues lurked behind the reported single-edge case:
- Aggregate overflow. A single copy can enumerate many (instance, field) pairs. Fields that don't share both a source and destination instance aren't grouped, so they take independent paths — and those paths can route through the same intermediate memory. The allocator holds all of an op's same-memory IBs simultaneously (allocated as one atomic batch), so N individually-fitting edges can collectively blow the pool.
- Small-transfer over-constraint. A naive per-edge minimum could reject small (sub-256-byte, or single-element) multi-hop transfers that were previously fine.

Fix

Per-edge cap. Each IB edge is sized against min(core.ib_regmem, size_of(that edge's target memory)), so no single edge can exceed the pool it lands in. Edges are sized after their target memory is assigned, so each uses the correct per-memory cap.

Aggregate redistribution. After the full transfer graph is built (all fields/paths), a new pass groups IB edges by memory and, for any memory whose 256-byte-rounded aggregate exceeds capacity, shrinks its edges proportionally to how much each requested above its floor, down to a per-edge minimum. It only aborts when even the minimums can't coexist (genuinely impossible). Shrinking is safe because an IB is a streaming pipeline window, not a whole-transfer buffer — a smaller window just means more, smaller chunks.

Correct progress floor. The per-edge minimum is the raw 2-element ring size (what the engine needs to avoid stalling on the ib_size >> 1 step), capped at the transfer's total data so small domains aren't over-floored, and not rounded up to 256 (the logical ring size needn't be allocator-aligned). This applies to direct copies, reductions, fills, and indirect gather/scatter/scatter-gather edges alike.

Allocator-consistent accounting. IBMemory::do_alloc rounds every request up to 256 bytes; the planner's checks and redistribution now use the same rounding, so a plan the planner accepts is always one the allocator can satisfy (closing a boundary case that could otherwise hang rather than abort).

Overflow-safe sizing. All IB size arithmetic on the planner guard path uses saturating multiply/add and a checked LCM (saturating up to SIZE_MAX, which correctly disables the data-size cap rather than under-shrinking the floor). Replaces an unguarded std::lcm (UB on overflow) and unchecked size * element products.

Single memory-size lookup. Memory capacities are cached in one Memory → size map shared by edge sizing, redistribution, and verification, so each IB memory is queried from the runtime once per planning pass instead of per edge.

Files

- transfer/transfer.cc — per-edge cap, redistribute_ib_sizes_impl, alignment-consistent verify_ib_alloc_sizes, saturating size helpers, memory-size cache
- transfer/ib_memory.{h,cc} — shared IB_ALLOC_ALIGNMENT constant + ib_align_up helper (de-duplicates the bare 256 literals)
- transfer/transfer.h — IBInfo gains min_size and size_granularity fields
- tests/unit_tests/ib_redistribute_test.cc (new) + tests/CMakeLists.txt

Testing

- New unit suite (ib_redistribute_test.cc) covering: fitting plans left untouched, proportional shrink, single-oversized-edge shrink, per-edge granularity preserved, small sub-256-byte transfers preserved, floor capped at data size, overflow saturation, indirect floors capped at natural size, and the impossible-plan / overflow abort paths (death tests).
- Full suites pass: realm_unit_tests (555) and realm_c_unit_tests (148), no regressions.

Notes for reviewers

- No new user-facing flags — IB sizing remains automatic.
- The end-to-end multi-hop/indirect paths that exercise redistribution run under the GPU/multi-node integration tests (CPU-only same-node copies don't stage through an IB); the unit tests lock in the sizing/redistribution math directly.
- clang-format should be run before merge (formatting was deferred during review).