### PR TITLE
Add rsrv logger for machine topology

### DIFF
--- a/src/realm/runtime_impl.cc
+++ b/src/realm/runtime_impl.cc
@@ -154,6 +154,7 @@ namespace Realm {
 
   Logger log_runtime("realm");
   Logger log_collective("collective");
+  Logger log_rsrv("rsrv");
   extern Logger log_task;    // defined in proc_impl.cc
   extern Logger log_taskreg; // defined in proc_impl.cc
   extern Logger log_machine; // defined in machine_impl.cc
@@ -2241,9 +2242,20 @@ namespace Realm {
     //  threads that have already been requested
     bool ok = core_reservations->satisfy_reservations(config->dummy_reservation_ok);
     if(ok) {
+      // The topology/reservation dump can go to stdout (-ll:show_rsrv) and/or to
+      //  the "rsrv" logger (-level rsrv=2); both are independent.  Funnel each
+      //  active sink through the same ostream-based formatting so it isn't
+      //  duplicated - operator<<(HardwareTopology) and report_reservations()
+      //  already take a generic std::ostream&.
+      auto report_topology = [&](std::ostream &os) {
+        os << host_topology << std::endl;
+        core_reservations->report_reservations(os);
+      };
       if(config->show_reservations) {
-        std::cout << host_topology << std::endl;
-        core_reservations->report_reservations(std::cout);
+        report_topology(std::cout);
+      }
+      if(LoggerMessage msg = log_rsrv.info(); msg.is_active()) {
+        report_topology(msg.get_stream());
       }
     } else {
       printf("HELP!  Could not satisfy all core reservations!\n");


### PR DESCRIPTION
Fixes #458.

Adds a new `-level rsrv=2` logger that replaces `-ll:show_rsrv`. Right now the old code paths are still in place, and this new code path works independently of the old flag. Use `-level rsrv=2` OR `-ll:show_rsrv`, not both.

Alternatives/design decisions:

 * We could remove `-ll:show_rsrv` in favor of the new logger, possibly with an error message to users who attempt to use it, directing to the new syntax.
 * The logger currently prefixes only the first line, because we reuse the existing infrastructure for printing to a stream. If we wanted *every* line to be prefixed, we'd need to make deeper changes.

Output looks like:

```console
$ ./examples/saxpy/saxpy -level rsrv=2
[0 - 1fb2b5e80]    0.000126 {2}{rsrv}: Topology {
  domain 0, memory size:68719476736 {
    core 0 { ids=<0> }
    core 1 { ids=<1> }
    core 2 { ids=<2> }
    core 3 { ids=<3> }
    core 4 { ids=<4> }
    core 5 { ids=<5> }
    core 6 { ids=<6> }
    core 7 { ids=<7> }
    core 8 { ids=<8> }
    core 9 { ids=<9> }
    core 10 { ids=<10> }
    core 11 { ids=<11> }
    core 12 { ids=<12> }
    core 13 { ids=<13> }
    core 14 { ids=<14> }
    core 15 { ids=<15> }
    core 16 { ids=<16> }
    core 17 { ids=<17> }
  }
}
CPU proc 1d00000000000001: allocated <0>
dedicated worker (generic) #1: allocated <1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17>
dedicated worker (generic) #2: allocated <1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17>
utility proc 1d00000000000000: allocated <1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17>
```