### PR TITLE
Move-Only Logger Message Semantics

### DIFF
--- a/src/realm/logging.h
+++ b/src/realm/logging.h
@@ -142,7 +142,12 @@ namespace Realm {
     LoggerMessage(Logger *_logger, bool _active, Logger::LoggingLevel _level);
 
   public:
-    LoggerMessage(const LoggerMessage &to_copy);
+    LoggerMessage(const LoggerMessage &to_copy) = delete;
+    LoggerMessage &operator=(const LoggerMessage &to_copy) = delete;
+
+    LoggerMessage(LoggerMessage &&to_move);
+    LoggerMessage &operator=(LoggerMessage &&to_move) = delete;
+
     ~LoggerMessage(void);
 
     template <typename T>

--- a/src/realm/logging.inl
+++ b/src/realm/logging.inl
@@ -367,13 +367,21 @@ namespace Realm {
       stream.construct(buffer.construct());
   }
 
-  inline LoggerMessage::LoggerMessage(const LoggerMessage &to_copy)
-    : logger(to_copy.logger)
-    , active(to_copy.active)
-    , level(to_copy.level)
+  inline LoggerMessage::LoggerMessage(LoggerMessage &&to_move)
+    : logger(to_move.logger)
+    , active(to_move.active)
+    , level(to_move.level)
   {
-    if(active)
+    if(active) {
       stream.construct(buffer.construct());
+      stream->write(to_move.buffer->data(), to_move.buffer->size());
+      stream->copyfmt(*to_move.stream);
+      stream->clear(to_move.stream->rdstate());
+
+      to_move.logger = 0;
+      to_move.active = false;
+      to_move.level = Logger::LEVEL_NONE;
+    }
   }
 
   inline LoggerMessage::~LoggerMessage(void)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -124,6 +124,7 @@ list(
   hpp_event_test.cc
   key_value_store_test.cc
   deferred_alloc_test.cc
+  logging_test.cc
 )
 list(TRANSFORM REALM_UNIT_TESTS PREPEND "${REALM_TEST_DIR}/unit_tests/")
 add_executable(realm_unit_tests ${REALM_UNIT_TESTS})

--- a/tests/unit_tests/logging_test.cc
+++ b/tests/unit_tests/logging_test.cc
@@ -54,6 +54,17 @@ namespace Realm {
       }
     };
 
+    class TestLoggerMessage : public LoggerMessage {
+    public:
+      TestLoggerMessage(Logger &logger, bool active)
+        : LoggerMessage(&logger, active, Logger::LEVEL_INFO)
+      {}
+
+      TestLoggerMessage(TestLoggerMessage &&to_move)
+        : LoggerMessage(std::move(to_move))
+      {}
+    };
+
     static_assert(!std::is_copy_constructible<LoggerMessage>::value,
                   "LoggerMessage must not be copy constructible");
     static_assert(!std::is_copy_assignable<LoggerMessage>::value,
@@ -70,10 +81,10 @@ namespace Realm {
       const std::string message(256, 'x');
 
       {
-        LoggerMessage source = logger.info();
+        TestLoggerMessage source(logger, true);
         source << message;
 
-        LoggerMessage destination(std::move(source));
+        TestLoggerMessage destination(std::move(source));
 
         EXPECT_FALSE(source.is_active());
         EXPECT_TRUE(destination.is_active());
@@ -89,10 +100,10 @@ namespace Realm {
       TestLogger logger("move_stream_formatting", &output);
 
       {
-        LoggerMessage source = logger.info();
+        TestLoggerMessage source(logger, true);
         source << "value=" << std::hex << std::showbase;
 
-        LoggerMessage destination(std::move(source));
+        TestLoggerMessage destination(std::move(source));
         destination << 42;
       }
 
@@ -106,11 +117,11 @@ namespace Realm {
       TestLogger logger("move_inactive_message", &output);
 
       {
-        LoggerMessage source = logger.info();
+        TestLoggerMessage source(logger, true);
         source << "deactivated";
         source.deactivate();
 
-        LoggerMessage destination(std::move(source));
+        TestLoggerMessage destination(std::move(source));
 
         EXPECT_FALSE(source.is_active());
         EXPECT_FALSE(destination.is_active());

--- a/tests/unit_tests/logging_test.cc
+++ b/tests/unit_tests/logging_test.cc
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 Stanford University, NVIDIA Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "realm/logging.h"
+
+#include <gtest/gtest.h>
+
+#include <iomanip>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace Realm {
+
+  namespace {
+
+    class CapturingLoggerOutput : public LoggerOutputStream {
+    public:
+      virtual void log_msg(Logger::LoggingLevel level, const char *name,
+                           const char *msgdata, size_t msglen)
+      {
+        messages.push_back(std::string(msgdata, msglen));
+      }
+
+      virtual void flush(void) {}
+
+      std::vector<std::string> messages;
+    };
+
+    class TestLogger : public Logger {
+    public:
+      TestLogger(const std::string &name, LoggerOutputStream *output)
+        : Logger(name)
+      {
+        configured = true;
+        log_level = LEVEL_SPEW;
+        add_stream(output, LEVEL_SPEW, false /*delete_when_done*/,
+                   false /*flush_each_write*/);
+      }
+    };
+
+    static_assert(!std::is_copy_constructible<LoggerMessage>::value,
+                  "LoggerMessage must not be copy constructible");
+    static_assert(!std::is_copy_assignable<LoggerMessage>::value,
+                  "LoggerMessage must not be copy assignable");
+    static_assert(std::is_move_constructible<LoggerMessage>::value,
+                  "LoggerMessage must be move constructible");
+    static_assert(!std::is_move_assignable<LoggerMessage>::value,
+                  "LoggerMessage must not be move assignable");
+
+    TEST(LoggerMessageTest, MoveTransfersBufferedMessage)
+    {
+      CapturingLoggerOutput output;
+      TestLogger logger("move_buffered_message", &output);
+      const std::string message(256, 'x');
+
+      {
+        LoggerMessage source = logger.info();
+        source << message;
+
+        LoggerMessage destination(std::move(source));
+
+        EXPECT_FALSE(source.is_active());
+        EXPECT_TRUE(destination.is_active());
+      }
+
+      ASSERT_EQ(output.messages.size(), 1U);
+      EXPECT_EQ(output.messages.front(), message);
+    }
+
+    TEST(LoggerMessageTest, MovePreservesStreamFormatting)
+    {
+      CapturingLoggerOutput output;
+      TestLogger logger("move_stream_formatting", &output);
+
+      {
+        LoggerMessage source = logger.info();
+        source << "value=" << std::hex << std::showbase;
+
+        LoggerMessage destination(std::move(source));
+        destination << 42;
+      }
+
+      ASSERT_EQ(output.messages.size(), 1U);
+      EXPECT_EQ(output.messages.front(), "value=0x2a");
+    }
+
+    TEST(LoggerMessageTest, MovePreservesInactiveState)
+    {
+      CapturingLoggerOutput output;
+      TestLogger logger("move_inactive_message", &output);
+
+      {
+        LoggerMessage source = logger.info();
+        source << "deactivated";
+        source.deactivate();
+
+        LoggerMessage destination(std::move(source));
+
+        EXPECT_FALSE(source.is_active());
+        EXPECT_FALSE(destination.is_active());
+      }
+
+      EXPECT_TRUE(output.messages.empty());
+    }
+
+  }; // anonymous namespace
+
+}; // namespace Realm


### PR DESCRIPTION
LoggerMessage previously allowed copying, but its copy constructor created an empty buffer while leaving both objects
  active. This could silently lose the copied message content and cause the original object to emit unexpectedly.

  This change makes LoggerMessage a single-owner, move-only type:

  - Deletes copy construction and copy assignment.
  - Adds a move constructor that transfers:
      - The accumulated message content.
      - Stream formatting state.
      - Logger and logging level.
      - Responsibility for emitting the message.

  - Deactivates the moved-from object so it cannot emit during destruction.
  - Deletes move assignment because replacing an existing active message has ambiguous emission semantics.

  This preserves ordinary return-by-value usage under C++17 while turning accidental copies into compile-time errors.
  Existing Legion logger usage remains compatible.