### PR TITLE
Scalable Barriers (Again)

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -94,6 +94,8 @@ add_benchmark(lock_chains "${REALM_BENCH_DIR}/lock_chains/lock_chains.cc")
 add_benchmark(lock_contention "${REALM_BENCH_DIR}/lock_contention/lock_contention.cc")
 set(reducetest_ARGS -batches 1) # Run short version
 add_benchmark(reducetest "${REALM_BENCH_DIR}/reducetest/reducetest.cc")
+set(barrier_bench_ARGS -sgens 32 -pgens 128 -reps 1 -adopt 8) # Run short version
+add_benchmark(barrier_bench "${REALM_BENCH_DIR}/barrier_bench/barrier_bench.cc")
 
 add_benchmark(
   task_throughput "${REALM_BENCH_DIR}/task_throughput/task_throughput.cc"

--- a/benchmarks/barrier_bench/barrier_bench.cc
+++ b/benchmarks/barrier_bench/barrier_bench.cc
@@ -91,7 +91,8 @@ namespace TestConfig {
   int reps = 3;     // repetitions (fresh barrier each) per mode+pattern
   int adopt = 32;   // adoption-curve generations printed from serial rep 0
   int pattern = -1; // -1 = both, else a single Pattern
-};
+  int dummy_to_prevent_bad_formatting = 0;
+}; // namespace TestConfig
 
 struct WorkerArgs {
   Barrier barrier;

--- a/benchmarks/barrier_bench/barrier_bench.cc
+++ b/benchmarks/barrier_bench/barrier_bench.cc
@@ -91,7 +91,7 @@ namespace TestConfig {
   int reps = 3;     // repetitions (fresh barrier each) per mode+pattern
   int adopt = 32;   // adoption-curve generations printed from serial rep 0
   int pattern = -1; // -1 = both, else a single Pattern
-}; // namespace TestConfig
+};                  // namespace TestConfig
 
 struct WorkerArgs {
   Barrier barrier;

--- a/benchmarks/barrier_bench/barrier_bench.cc
+++ b/benchmarks/barrier_bench/barrier_bench.cc
@@ -91,7 +91,7 @@ namespace TestConfig {
   int reps = 3;     // repetitions (fresh barrier each) per mode+pattern
   int adopt = 32;   // adoption-curve generations printed from serial rep 0
   int pattern = -1; // -1 = both, else a single Pattern
-};                  // namespace TestConfig
+}; // namespace TestConfig
 
 struct WorkerArgs {
   Barrier barrier;

--- a/benchmarks/barrier_bench/barrier_bench.cc
+++ b/benchmarks/barrier_bench/barrier_bench.cc
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2026 Stanford University, NVIDIA Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Barrier performance benchmark (tla/barrier/SCALE_TEST_PLAN.md section 4, the
+// T4 A/B comparison).  Uses ONLY the public Barrier API so the identical
+// source compiles against both this branch and main - A/B is by build, never
+// by runtime toggle.  Results go to stdout via printf: the compile-time log
+// floor defaults to WARNING, and a benchmark's output must not depend on the
+// logging configuration.
+//
+// Two timing modes per repetition, each on a fresh barrier:
+//
+//   serial - arrive -> wait -> advance, fully synchronous.  The per-generation
+//     time is one complete arrive/trigger/notify/wake round, measured locally
+//     on rank 0, so it needs no cross-rank clock.  The first generations of
+//     rep 0 are printed individually (the ADOPTION CURVE): on the scalable
+//     path the eager->planned transition is visible as a step down, and its
+//     absence means a plan silently failed to install.
+//
+//   pipe - arrivals run ahead of waits by a fixed window.  Once the plan has
+//     converged every generation is pure tree aggregation, so this is the
+//     repeated-pattern fast path under test.  Reported as generations/second
+//     over the post-warmup span.
+//
+// Two arrival patterns, fixed across generations (a REPEATED pattern is the
+// point - the plan must be learned once and then only aggregated):
+//
+//   uniform - every rank arrives once per generation.
+//   half    - the lower half of the ranks arrive twice, the upper half only
+//     wait.  This puts real quotas in the plan and disjoint arriver/waiter
+//     sets in the notification tree.
+//
+// Wall-clock numbers say whether it is fast; the fast-path PROOF is the
+// counter cross-check (new build only): rerun with '-level barrier=2' and
+// check reports_received at the owner is ~plan_radix per generation - flat in
+// N - with plan_rebuilds=1 and flush_episodes confined to startup.
+
+#include <assert.h>
+#include <stdio.h>
+
+#include <algorithm>
+#include <vector>
+
+#include "realm.h"
+#include "realm/cmdline.h"
+
+using namespace Realm;
+
+Logger log_app("app");
+
+enum
+{
+  MAIN_TASK = Processor::TASK_ID_FIRST_AVAILABLE + 0,
+  WORKER_TASK,
+};
+
+enum Mode
+{
+  M_SERIAL = 0,
+  M_PIPE,
+};
+
+enum Pattern
+{
+  PAT_UNIFORM = 0,
+  PAT_HALF,
+  PAT_NUM
+};
+
+static const char *pattern_names[PAT_NUM] = {"uniform", "half"};
+
+namespace TestConfig {
+  int sgens = 256;  // generations per serial rep
+  int pgens = 1024; // generations per pipe rep
+  int window = 32;  // run-ahead window for pipe mode
+  int warmup = 16;  // generations excluded from steady-state stats
+  int reps = 3;     // repetitions (fresh barrier each) per mode+pattern
+  int adopt = 32;   // adoption-curve generations printed from serial rep 0
+  int pattern = -1; // -1 = both, else a single Pattern
+}; // namespace TestConfig
+
+struct WorkerArgs {
+  Barrier barrier;
+  int mode;
+  int pattern;
+  int gens;
+  int rep;
+  int rank;
+  int nranks;
+};
+
+// arrivals rank r owes each generation; the sum over r is ALWAYS nranks
+static int count_for(int pattern, int nranks, int r)
+{
+  if((pattern == PAT_UNIFORM) || (nranks < 2)) {
+    return 1;
+  }
+  // PAT_HALF: lower half carries doubled arrivals, upper half only waits
+  if(r < (nranks / 2)) {
+    return 2;
+  }
+  if(((nranks % 2) != 0) && (r == (nranks - 1))) {
+    return 1; // odd rank count: the last rank tops the total up to nranks
+  }
+  return 0;
+}
+
+static double percentile(std::vector<double> &v, double p)
+{
+  if(v.empty()) {
+    return 0.0;
+  }
+  std::sort(v.begin(), v.end());
+  size_t idx = (size_t)(p * (v.size() - 1));
+  return v[idx];
+}
+
+static void worker_task(const void *args, size_t arglen, const void *userdata,
+                        size_t userlen, Processor p)
+{
+  const WorkerArgs wa = *(const WorkerArgs *)args;
+  const int N = wa.nranks, G = wa.gens, R = wa.rank;
+  const int count = count_for(wa.pattern, N, R);
+  const bool timer = (R == 0); // per-gen rounds are local, any rank would do
+
+  Barrier b = wa.barrier;
+
+  if(wa.mode == M_SERIAL) {
+    std::vector<double> gen_us;
+    if(timer) {
+      gen_us.reserve(G);
+    }
+    for(int g = 0; g < G; g++) {
+      long long t0 = timer ? Clock::current_time_in_nanoseconds() : 0;
+      if(count > 0) {
+        b.arrive(count);
+      }
+      b.wait();
+      if(timer) {
+        long long t1 = Clock::current_time_in_nanoseconds();
+        gen_us.push_back((double)(t1 - t0) * 1e-3);
+      }
+      b = b.advance_barrier();
+      assert(b.exists());
+    }
+    if(timer) {
+      if((wa.rep == 0) && (TestConfig::adopt > 0)) {
+        printf("adoption_us: pattern=%s", pattern_names[wa.pattern]);
+        for(int g = 0; (g < TestConfig::adopt) && (g < G); g++) {
+          printf(" %.1f", gen_us[g]);
+        }
+        printf("\n");
+      }
+      std::vector<double> steady(gen_us.begin() + std::min(TestConfig::warmup, G - 1),
+                                 gen_us.end());
+      std::vector<double> tmp(steady);
+      printf("serial: pattern=%s rep=%d gens=%d median_us=%.2f p95_us=%.2f min_us=%.2f\n",
+             pattern_names[wa.pattern], wa.rep, G, percentile(steady, 0.5),
+             percentile(tmp, 0.95), *std::min_element(steady.begin(), steady.end()));
+      fflush(stdout);
+    }
+    return;
+  }
+
+  // M_PIPE.  Generation 1 is the start-sync: every rank arrives AND waits on
+  //  it, so the measured span begins with all ranks released together.
+  std::vector<Barrier> handles;
+  handles.reserve(G);
+  long long t_start = 0, t_warm = 0, t_end = 0;
+  const int W = TestConfig::window;
+  const int warm = std::min(TestConfig::warmup, G - 1);
+  for(int g = 0; g < G; g++) {
+    handles.push_back(b);
+    if(g == 0) {
+      if(count > 0) {
+        b.arrive(count);
+      }
+      b.wait();
+      t_start = Clock::current_time_in_nanoseconds();
+    } else {
+      if(count > 0) {
+        b.arrive(count);
+      }
+      if(g >= W) {
+        handles[g - W].wait();
+        if((g - W) == warm) {
+          t_warm = Clock::current_time_in_nanoseconds();
+        }
+      }
+    }
+    b = b.advance_barrier();
+    assert(b.exists());
+  }
+  // drain the windowed waits
+  for(int wg = std::max(1, G - W); wg < G; wg++) {
+    handles[wg].wait();
+    if(wg == warm) {
+      t_warm = Clock::current_time_in_nanoseconds();
+    }
+  }
+  t_end = Clock::current_time_in_nanoseconds();
+
+  if(timer) {
+    // gens 1..G-1 complete inside [t_start, t_end]; gens warm+1..G-1 inside
+    //  [t_warm, t_end]
+    double total = (double)(G - 1) / ((double)(t_end - t_start) * 1e-9);
+    double steady = (double)(G - 1 - warm) / ((double)(t_end - t_warm) * 1e-9);
+    printf("pipe: pattern=%s rep=%d gens=%d window=%d gens_per_sec=%.0f "
+           "total_gens_per_sec=%.0f\n",
+           pattern_names[wa.pattern], wa.rep, G, W, steady, total);
+    fflush(stdout);
+  }
+}
+
+static void main_task(const void *args, size_t arglen, const void *userdata,
+                      size_t userlen, Processor p)
+{
+  // one worker processor per address space
+  std::map<AddressSpace, Processor> per_space;
+  Machine::ProcessorQuery pq =
+      Machine::ProcessorQuery(Machine::get_machine()).only_kind(Processor::LOC_PROC);
+  for(Machine::ProcessorQuery::iterator it = pq.begin(); it != pq.end(); ++it) {
+    AddressSpace s = (*it).address_space();
+    if(per_space.find(s) == per_space.end()) {
+      per_space[s] = *it;
+    }
+  }
+  const int N = (int)per_space.size();
+  printf("barrier_bench: ranks=%d sgens=%d pgens=%d window=%d warmup=%d reps=%d\n", N,
+         TestConfig::sgens, TestConfig::pgens, TestConfig::window, TestConfig::warmup,
+         TestConfig::reps);
+  fflush(stdout);
+
+  for(int pat = 0; pat < PAT_NUM; pat++) {
+    if((TestConfig::pattern >= 0) && (pat != TestConfig::pattern)) {
+      continue;
+    }
+    for(int mode = 0; mode <= M_PIPE; mode++) {
+      for(int rep = 0; rep < TestConfig::reps; rep++) {
+        Barrier bar = Barrier::create_barrier(N);
+        std::vector<Event> done;
+        int rank = 0;
+        for(std::map<AddressSpace, Processor>::iterator it = per_space.begin();
+            it != per_space.end(); ++it, ++rank) {
+          WorkerArgs wa;
+          wa.barrier = bar;
+          wa.mode = mode;
+          wa.pattern = pat;
+          wa.gens = (mode == M_SERIAL) ? TestConfig::sgens : TestConfig::pgens;
+          wa.rep = rep;
+          wa.rank = rank;
+          wa.nranks = N;
+          done.push_back(it->second.spawn(WORKER_TASK, &wa, sizeof(wa)));
+        }
+        Event::merge_events(done).wait();
+        bar.destroy_barrier();
+      }
+    }
+  }
+  printf("barrier_bench: DONE\n");
+  fflush(stdout);
+}
+
+int main(int argc, char **argv)
+{
+  Runtime rt;
+  rt.init(&argc, (char ***)&argv);
+
+  CommandLineParser cp;
+  cp.add_option_int("-sgens", TestConfig::sgens);
+  cp.add_option_int("-pgens", TestConfig::pgens);
+  cp.add_option_int("-window", TestConfig::window);
+  cp.add_option_int("-warmup", TestConfig::warmup);
+  cp.add_option_int("-reps", TestConfig::reps);
+  cp.add_option_int("-adopt", TestConfig::adopt);
+  cp.add_option_int("-pattern", TestConfig::pattern);
+  bool ok = cp.parse_command_line(argc, const_cast<const char **>(argv));
+  assert(ok);
+  // the pipe-mode warm timestamp is recorded at the wait of generation
+  //  'warmup', which the windowed loop only reaches if this holds
+  assert(TestConfig::pgens > (TestConfig::window + TestConfig::warmup));
+
+  Processor p = Machine::ProcessorQuery(Machine::get_machine())
+                    .only_kind(Processor::LOC_PROC)
+                    .first();
+  assert(p.exists());
+
+  Processor::register_task_by_kind(Processor::LOC_PROC, false /*!global*/, MAIN_TASK,
+                                   CodeDescriptor(main_task), ProfilingRequestSet())
+      .external_wait();
+  Processor::register_task_by_kind(Processor::LOC_PROC, false /*!global*/, WORKER_TASK,
+                                   CodeDescriptor(worker_task), ProfilingRequestSet())
+      .external_wait();
+
+  Event e = rt.collective_spawn(p, MAIN_TASK, 0, 0);
+  rt.shutdown(e);
+  return rt.wait_for_shutdown();
+}

--- a/benchmarks/barrier_bench/barrier_bench.cc
+++ b/benchmarks/barrier_bench/barrier_bench.cc
@@ -119,16 +119,6 @@ static int count_for(int pattern, int nranks, int r)
   return 0;
 }
 
-static double percentile(std::vector<double> &v, double p)
-{
-  if(v.empty()) {
-    return 0.0;
-  }
-  std::sort(v.begin(), v.end());
-  size_t idx = (size_t)(p * (v.size() - 1));
-  return v[idx];
-}
-
 static void worker_task(const void *args, size_t arglen, const void *userdata,
                         size_t userlen, Processor p)
 {
@@ -167,10 +157,15 @@ static void worker_task(const void *args, size_t arglen, const void *userdata,
       }
       std::vector<double> steady(gen_us.begin() + std::min(TestConfig::warmup, G - 1),
                                  gen_us.end());
-      std::vector<double> tmp(steady);
-      printf("serial: pattern=%s rep=%d gens=%d median_us=%.2f p95_us=%.2f min_us=%.2f\n",
-             pattern_names[wa.pattern], wa.rep, G, percentile(steady, 0.5),
-             percentile(tmp, 0.95), *std::min_element(steady.begin(), steady.end()));
+      std::sort(steady.begin(), steady.end());
+      const size_t n = steady.size();
+      // the p99/max tail matters as much as the median: a rare multi-ms stall
+      //  barely moves p95 but eats hundreds of generations of pipe throughput
+      printf("serial: pattern=%s rep=%d gens=%d median_us=%.2f p95_us=%.2f "
+             "p99_us=%.2f max_us=%.2f min_us=%.2f\n",
+             pattern_names[wa.pattern], wa.rep, G, steady[n / 2],
+             steady[(size_t)(0.95 * (n - 1))], steady[(size_t)(0.99 * (n - 1))],
+             steady[n - 1], steady[0]);
       fflush(stdout);
     }
     return;

--- a/benchmarks/barrier_bench/barrier_bench.cc
+++ b/benchmarks/barrier_bench/barrier_bench.cc
@@ -91,7 +91,7 @@ namespace TestConfig {
   int reps = 3;     // repetitions (fresh barrier each) per mode+pattern
   int adopt = 32;   // adoption-curve generations printed from serial rep 0
   int pattern = -1; // -1 = both, else a single Pattern
-}; // namespace TestConfig
+};
 
 struct WorkerArgs {
   Barrier barrier;

--- a/src/realm/barrier_impl.cc
+++ b/src/realm/barrier_impl.cc
@@ -816,14 +816,16 @@ namespace Realm {
             plan_rebuilds_declined | gathering_declared | identical_plans_skipped |
             plans_parked | parked_plans_applied | dead_plans_discarded |
             retro_flushes_sent | stale_edge_forwards | report_edges_pinned |
-            pin_conflicts_avoided | gap_pulls) != 0;
+            pin_conflicts_avoided | gap_pulls | reports_received | notifies_received) !=
+           0;
   }
 
   // IMPLEMENTATION_PLAN section 5 - the counters' way out.  Everything in
   //  BarrierCounters is written under 'mutex' beside the state it describes and
   //  nothing branches on any of it, so without this it would be write-only.
-  //  One line, at 'info' level, only for a barrier that actually exercised the
-  //  deviation or hysteresis paths - a barrier that behaved is silent.
+  //  One line, at 'info' level, for any barrier with remote traffic (the
+  //  reports/notifies fast-path counters make every remotely-used barrier
+  //  report); a purely local barrier is silent.
   void BarrierImpl::dump_counters(const char *why) const
   {
     if(!counters.any()) {
@@ -855,7 +857,9 @@ namespace Realm {
                        << " stale_edge_forwards=" << counters.stale_edge_forwards
                        << " report_edges_pinned=" << counters.report_edges_pinned
                        << " pin_conflicts_avoided=" << counters.pin_conflicts_avoided
-                       << " gap_pulls=" << counters.gap_pulls;
+                       << " gap_pulls=" << counters.gap_pulls
+                       << " reports_received=" << counters.reports_received
+                       << " notifies_received=" << counters.notifies_received;
   }
 
 #ifdef DEBUG_REALM
@@ -3803,6 +3807,7 @@ namespace Realm {
 
     do {
       AutoLock<> a(mutex);
+      counters.reports_received++;
 
       // step 1: a report for a generation that has already triggered is dropped
       //  SILENTLY.  This is exactly what makes freeing a triggered generation's
@@ -4884,6 +4889,7 @@ namespace Realm {
 
     {
       AutoLock<> a(mutex);
+      counters.notifies_received++;
 
       // STEP 0 - RULE 8's advisory byte.  Not version gated and not ordered
       //  against anything: it is a hint, the worst a stale one can do is waste

--- a/src/realm/barrier_impl.cc
+++ b/src/realm/barrier_impl.cc
@@ -816,8 +816,8 @@ namespace Realm {
             plan_rebuilds_declined | gathering_declared | identical_plans_skipped |
             plans_parked | parked_plans_applied | dead_plans_discarded |
             retro_flushes_sent | stale_edge_forwards | report_edges_pinned |
-            pin_conflicts_avoided | gap_pulls | reports_received | notifies_received) !=
-           0;
+            pin_conflicts_avoided | gap_pulls | reports_received | notifies_received |
+            reports_gated | owner_valve_flushes) != 0;
   }
 
   // IMPLEMENTATION_PLAN section 5 - the counters' way out.  Everything in
@@ -859,7 +859,9 @@ namespace Realm {
                        << " pin_conflicts_avoided=" << counters.pin_conflicts_avoided
                        << " gap_pulls=" << counters.gap_pulls
                        << " reports_received=" << counters.reports_received
-                       << " notifies_received=" << counters.notifies_received;
+                       << " notifies_received=" << counters.notifies_received
+                       << " reports_gated=" << counters.reports_gated
+                       << " owner_valve_flushes=" << counters.owner_valve_flushes;
   }
 
 #ifdef DEBUG_REALM
@@ -1165,38 +1167,8 @@ namespace Realm {
     return g;
   }
 
-  // ARRIVAL_PROTOCOL rule 1 - the steady state, and BOTH of its halves are
-  //  required.  A node forwards its cumulative subtree total only when its
-  //  local arrival count equals the quota its plan predicts AND every child the
-  //  plan predicts has reported at least once.
-  //
-  // The child-wait is a CORRECTNESS requirement, not an optimisation.  Early
-  //  forwarding does NOT self-correct just because reports are cumulative: at
-  //  depth >= 3, where a relay sits below another relay, dropping the child-wait
-  //  is a mutation TLC catches.  Do not simplify it away.
-  bool BarrierImpl::plan_satisfied_locked(const Generation &g) const
-  {
-    REALM_BARRIER_ASSERT_LOCKED();
-    // MEMBERSHIP: a node with no plan has no completion condition at all
-    if(!cur_plan.inplan) {
-      return false;
-    }
-    if(g.local_total != static_cast<int64_t>(cur_plan.quota)) {
-      return false;
-    }
-    // NO CHILD-WAIT (ARRIVAL_PROTOCOL rule 1).  A relay does NOT additionally
-    //  wait for every predicted child.  Reports are cumulative and REPLACE, so
-    //  a forward that omits an absent child is superseded when that child
-    //  reports, and a generation only triggers on exact equality with the
-    //  expected count, so a low total cannot fire early.
-    //
-    //  This is load-bearing for rule 5: the child-wait is the only reason a
-    //  relay cares WHICH child reports to it, and therefore the only reason a
-    //  re-parented generation can strand on a child that already reported by
-    //  the retiring tree.  Removing it is what lets flush stop being sticky.
-    //  Do not reintroduce it.
-    return true;
-  }
+  // (rule 1's steady-state test now lives inline in should_report_locked() -
+  //  see QUOTA-GATED FORWARDING below)
 
   // ARRIVAL_PROTOCOL section 8.1: the parent is STORED in the plan record, not
   //  derived by searching for whoever lists us as a child.  A node outside the
@@ -1320,8 +1292,19 @@ namespace Realm {
     if(flush_mode_locked(gen, g)) {
       return true;
     }
-    // rule 1 - both halves
-    return plan_satisfied_locked(g);
+    // rule 1 / ARRIVAL_PROTOCOL section 13 - QUOTA-GATED FORWARDING.  In
+    //  planned mode a node speaks exactly ONCE per steady generation: when its
+    //  cumulative subtree total reaches the plan's subtree quota.  The gate is
+    //  >= and never = (MCGateJump: a cumulative REPLACE can jump PAST the
+    //  quota in one accepted report).  An earlier design gated on the LOCAL
+    //  quota only, which made the owner's fan-in ~N-1 messages per generation
+    //  under synchronized arrivals (SCALE_TEST_PLAN.md section 7); gating on
+    //  the subtree is safe ONLY because of the valves - the owner's receipt
+    //  tests and switch audit, the install re-fan, and the stale-edge signal -
+    //  each certified by a scenario that deadlocks without it (the gate
+    //  battery suite).  Do not strengthen or weaken this test without re-running
+    //  battery.py.
+    return cur_plan.inplan && (g.subtree_known() >= cur_plan.subtree_quota);
   }
 
   ////////////////////////////////////////////////////////////////////////
@@ -2008,6 +1991,29 @@ namespace Realm {
       return (off == datalen);
     }
 
+    // Total predicted arrivals in a plan payload - the SUBTREE QUOTA of the
+    //  node the payload is addressed to (ARRIVAL_PROTOCOL section 13).  Same
+    //  wire format as decode_plan_subtree, summed recursively; -1 on a
+    //  malformed slice.  Each node receives its ENTIRE subtree, so this is
+    //  computable at install with nothing new on the wire.
+    int64_t plan_subtree_total(const void *data, size_t datalen)
+    {
+      PlanSubtree sub;
+      if(!decode_plan_subtree(data, datalen, sub)) {
+        return -1;
+      }
+      int64_t total = sub.quota;
+      for(size_t i = 0; i < sub.kids.size(); i++) {
+        const int64_t k =
+            plan_subtree_total(sub.kid_payload[i].first, sub.kid_payload[i].second);
+        if(k < 0) {
+          return -1;
+        }
+        total += k;
+      }
+      return total;
+    }
+
     // Fan-out of a constructed plan.  This is a shape choice, not a protocol
     //  rule - the model verifies that ANY plan is safe to adopt - and 8 keeps a
     //  few-thousand-node barrier at depth 4.
@@ -2131,6 +2137,21 @@ namespace Realm {
     cur_plan.inplan = true;
     cur_plan.parent = parent;
     cur_plan.kids = sub.kids;
+    // section 13 - the gate's threshold and (owner-read) per-child subtree
+    //  totals, from the payload slices already in hand
+    cur_plan.kid_subq.clear();
+    cur_plan.subtree_quota = sub.quota;
+    for(size_t i = 0; i < sub.kids.size(); i++) {
+      const int64_t k =
+          plan_subtree_total(sub.kid_payload[i].first, sub.kid_payload[i].second);
+      if(k < 0) {
+        log_barrier.fatal() << "malformed barrier plan kid slice: " << me
+                            << " epoch=" << epoch << " kid=" << sub.kids[i];
+        abort();
+      }
+      cur_plan.kid_subq.push_back(k);
+      cur_plan.subtree_quota += k;
+    }
     my_epoch = epoch;
 
     // A PLAN INSTALL NEVER CLEARS FLUSH (BarrierArrive, a caught mutation on
@@ -2432,8 +2453,73 @@ namespace Realm {
     for(size_t k = 1; (k <= barrier_plan_radix()) && (k < tv.size()); k++) {
       cur_plan.kids.push_back(tv[k]);
     }
+    // section 13 - subtree quotas from the heap layout: the parent of index i
+    //  is (i-1)/radix, so one reverse pass folds every node's quota into its
+    //  ancestors.  The owner's own subtree quota is the whole tree.
+    {
+      const size_t radix = barrier_plan_radix();
+      std::vector<int64_t> sub_q(quota.begin(), quota.end());
+      for(size_t i = sub_q.size(); i-- > 1;) {
+        sub_q[(i - 1) / radix] += sub_q[i];
+      }
+      cur_plan.subtree_quota = sub_q[0];
+      cur_plan.kid_subq.clear();
+      for(size_t k = 1; (k <= radix) && (k < sub_q.size()); k++) {
+        cur_plan.kid_subq.push_back(sub_q[k]);
+      }
+    }
     my_epoch = new_epoch;
     inval_epoch = new_epoch - 1;
+
+    // section 13 - THE SWITCH-TIME AUDIT (MCGateMove, MCGateDemote) and the
+    //  owner-side flush re-fan (the non-owner half lives in apply_plan_locked
+    //  step 4).  The receipt valve judges a report against the plan CURRENT at
+    //  delivery, but installing this plan can make an already-accepted value
+    //  deviant retroactively: a total that was exactly what the old plan
+    //  predicted (a stowaway count inside a legitimate chain), or a sender the
+    //  new plan no longer lists under the owner at all.  No further report
+    //  ever arrives to re-run the receipt test, so the owner re-judges its
+    //  accepted values HERE, and flushes the generations that no longer add
+    //  up.  Already-flushed generations are re-announced to the new child
+    //  list for the same reason apply_plan_locked re-fans: a flush fan is a
+    //  snapshot of the fanning node's kid list.
+    {
+      const gen_t watermark = generation.load();
+      for(std::map<gen_t, Generation *>::const_iterator git = generations.begin();
+          git != generations.end(); ++git) {
+        if(git->first <= watermark) {
+          continue;
+        }
+        Generation *ng = git->second;
+        if(ng->flushing) {
+          if(!cur_plan.kids.empty()) {
+            sends.flushes.push_back(PendingFlush());
+            PendingFlush &pf = sends.flushes.back();
+            pf.gen = git->first;
+            pf.to.insert(pf.to.end(), cur_plan.kids.begin(), cur_plan.kids.end());
+          }
+          continue;
+        }
+        bool deviant = false;
+        for(std::map<NodeID, Generation::ChildReport>::const_iterator cit =
+                ng->child_acc.begin();
+            !deviant && (cit != ng->child_acc.end()); ++cit) {
+          if(cit->second.total <= 0) {
+            continue;
+          }
+          size_t ki = 0;
+          while((ki < cur_plan.kids.size()) && (cur_plan.kids[ki] != cit->first)) {
+            ki++;
+          }
+          deviant =
+              (ki == cur_plan.kids.size()) || (cit->second.total > cur_plan.kid_subq[ki]);
+        }
+        if(deviant) {
+          counters.owner_valve_flushes++;
+          enter_flush_locked(*ng, git->first, sends);
+        }
+      }
+    }
 
     // (4) DISTRIBUTION (section 11.4): each child is sent ITS OWN SUBTREE, not
     //     just an epoch number - its quota, its child list, and recursively
@@ -3902,7 +3988,30 @@ namespace Realm {
         //  '*g'.  Fanning a flush for a generation that then triggers in the
         //  same section is harmless - the recipients' own reports come back
         //  for an already-triggered generation and action R step 1 drops them.
-        if(is_direct && (redop_id == 0)) {
+        // section 13 - THE RECEIPT HALF OF THE OWNER VALVE (MCGateAhead,
+        //  MCGateOver).  With relays gated on subtree quotas, counts that
+        //  route AROUND a gated relay strand it unless the owner notices and
+        //  flushes.  Two owner-visible symptoms cover every such routing: a
+        //  sender the current plan does not list as an owner child (a retired
+        //  relay's invalidation-time forward - 'is_direct' covers the
+        //  sender-aware cases, this covers the rest), or a child whose
+        //  cumulative total EXCEEDS its predicted subtree quota (an
+        //  over-arrival straddling a gated relay elsewhere).  The response is
+        //  the same as for a 'direct': flush the generation down the current
+        //  tree, which un-gates every holder.
+        bool valve = is_direct;
+        if(!valve && cur_plan.inplan && !g->flushing && (redop_id == 0)) {
+          size_t ki = 0;
+          while((ki < cur_plan.kids.size()) && (cur_plan.kids[ki] != from)) {
+            ki++;
+          }
+          valve =
+              (ki == cur_plan.kids.size()) || (it->second.total > cur_plan.kid_subq[ki]);
+          if(valve) {
+            counters.owner_valve_flushes++;
+          }
+        }
+        if(valve && (redop_id == 0)) {
           enter_flush_locked(*g, report_gen, sends);
         }
 
@@ -3943,9 +4052,25 @@ namespace Realm {
         //  completes this relay
         if(stale_edge) {
           counters.stale_edge_forwards++;
+          // section 13 - THE STALE-EDGE SIGNAL (MCGatePark).  This relay is
+          //  the one witness that counts are routing over an edge the current
+          //  plan disowns; the forward below keeps them flowing, but a gated
+          //  holder ANYWHERE can be starving on exactly these counts, hidden
+          //  value-legal inside a legitimate chain where the owner's receipt
+          //  tests see nothing.  A count-free flush to the owner lets its fan
+          //  reach every holder.  Idempotent there, so duplicates cost one
+          //  message each and nothing else.
+          sends.flushes.push_back(PendingFlush());
+          PendingFlush &pf = sends.flushes.back();
+          pf.gen = report_gen;
+          pf.to.push_back(owner);
         }
         if(stale_edge || should_report_locked(report_gen, *g)) {
           record_report_locked(*g, report_gen, sends);
+        } else if(g->holding() && cur_plan.inplan && !flush_mode_locked(report_gen, *g)) {
+          // the gate held a forward the local-quota design would have sent -
+          //  the message-count saving, made visible (section 13)
+          counters.reports_gated++;
         }
       }
     } while(0);

--- a/src/realm/barrier_impl.cc
+++ b/src/realm/barrier_impl.cc
@@ -909,6 +909,7 @@ namespace Realm {
     //  this one.
     last_consult_wm = 0;
     last_depart_wm = 0;
+    rejoin_judge_pending = false;
     depart_K = DEPART_K_INITIAL;
     depart_outstanding = false;
     shrink_hint = true;
@@ -2803,8 +2804,11 @@ namespace Realm {
     if(member != MEMBER_NO) {
       return;
     }
-    // rule 8 - coming back after having asked to leave is the churn signal
-    note_rejoin_locked();
+    // rule 8 - coming back after having asked to leave is a rejoin, but its
+    //  churn judgment waits for the reply: this node's own watermark froze
+    //  when it departed, so only the owner's clock can say how long it was
+    //  really gone
+    note_rejoin_deferred_locked();
     member = MEMBER_PENDING;
     pull_outstanding = true;
     pull_deferred = false;
@@ -2884,6 +2888,35 @@ namespace Realm {
   //
   // 'last_depart_wm' is the guard, so a node that has never asked to leave -
   //  including one subscribing for the very first time - is never counted.
+  //
+  // THE CLOCK MATTERS.  A departed node receives no notifications, so its own
+  //  watermark froze at the depart point; judging a voluntary-consult rejoin
+  //  against generation.load() reads a delta of ~1 no matter how long the node
+  //  was really gone, calls every return churn, and ratchets K to DEPART_K_MAX
+  //  in a handful of episodes - after which a legitimately idle-then-returning
+  //  node never departs again.  So the judgment is split from the bookkeeping:
+  //  the rule-6 sites judge immediately (their clock IS current - the removal
+  //  notification they just processed carried it), while action C defers to
+  //  the subscribe reply's watermark via 'rejoin_judge_pending'.
+  void BarrierImpl::judge_rejoin_locked(gen_t now_wm)
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    if(last_depart_wm == 0) {
+      return;
+    }
+    if((now_wm - last_depart_wm) <= DEPART_CHURN_WINDOW) {
+      counters.churn_backoffs++;
+      if(depart_K < DEPART_K_MAX) {
+        depart_K = ((depart_K * 2) < DEPART_K_MAX) ? (depart_K * 2) : DEPART_K_MAX;
+      }
+      log_barrier.info() << "barrier departure churn: " << me << " wm=" << now_wm
+                         << " asked_to_leave_at=" << last_depart_wm
+                         << " new_K=" << depart_K;
+    }
+    last_depart_wm = 0;
+    rejoin_judge_pending = false;
+  }
+
   void BarrierImpl::note_rejoin_locked(void)
   {
     REALM_BARRIER_ASSERT_LOCKED();
@@ -2893,19 +2926,26 @@ namespace Realm {
     if(last_depart_wm == 0) {
       return;
     }
-
-    const gen_t wm = generation.load();
-    counters.leave_rejoin_cycles++;
-    if((wm - last_depart_wm) <= DEPART_CHURN_WINDOW) {
-      counters.churn_backoffs++;
-      if(depart_K < DEPART_K_MAX) {
-        depart_K = ((depart_K * 2) < DEPART_K_MAX) ? (depart_K * 2) : DEPART_K_MAX;
-      }
-      log_barrier.info() << "barrier departure churn: " << me << " wm=" << wm
-                         << " asked_to_leave_at=" << last_depart_wm
-                         << " new_K=" << depart_K;
+    // a deferred judgment reaches here only if this node was removed AGAIN
+    //  while its subscribe was in flight; the episode was already counted at
+    //  the consult, so only the judgment runs
+    if(!rejoin_judge_pending) {
+      counters.leave_rejoin_cycles++;
     }
-    last_depart_wm = 0;
+    judge_rejoin_locked(generation.load());
+  }
+
+  void BarrierImpl::note_rejoin_deferred_locked(void)
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    if(last_depart_wm == 0) {
+      return;
+    }
+    if(rejoin_judge_pending) {
+      return; // one episode, one count - the reply will judge it
+    }
+    counters.leave_rejoin_cycles++;
+    rejoin_judge_pending = true;
   }
 
   // Action N step 6 / action RP - the eligibility test.  It lives where the
@@ -4971,6 +5011,17 @@ namespace Realm {
       // STEP 4 - if the reply is not fresh, do not merge.  Safe because this
       //  node's poison knowledge is already exactly the truth up to its own
       //  (higher) watermark.
+
+      // STEP 4.5 - the DEFERRED rule-8 judgment (see note_rejoin_locked): the
+      //  reply's watermark is the first honest reading of how far the barrier
+      //  moved while this node was out, so the churn test for a
+      //  voluntary-consult rejoin runs here rather than at the consult.  The
+      //  max() guards the rare case of a stale reply arriving after newer
+      //  knowledge: judging with the LARGER clock only ever errs toward clean.
+      if(rejoin_judge_pending) {
+        const gen_t local_wm = generation.load();
+        judge_rejoin_locked((wm > local_wm) ? wm : local_wm);
+      }
 
       // STEP 5 - re-issue whatever rule 7 suppressed while this pull was
       //  outstanding.  The model only suppresses while a SUBSCRIBE is in

--- a/src/realm/barrier_impl.cc
+++ b/src/realm/barrier_impl.cc
@@ -20,16 +20,12 @@
 #include "realm/runtime_impl.h"
 #include "realm/logging.h"
 
+#include <algorithm>
 #include <cstring>
 #include "realm/runtime_impl.h"
 #include "realm/logging.h"
 #include "realm/activemsg.h"
-
-#define DISABLE_BARRIER_MIGRATION
-
-// TODO(apryakhin@): Enable that back when related bug is fixed
-// https://github.com/StanfordLegion/legion/issues/1809
-// #define BARRIER_ENABLE_BROADCAST
+#include "realm/multicast.h"
 
 namespace Realm {
 
@@ -88,11 +84,18 @@ namespace Realm {
 
   Barrier Barrier::alter_arrival_count(int delta) const
   {
-    timestamp_t timestamp = BarrierImpl::barrier_adjustment_timestamp.fetch_add(1);
+    // a no-op alteration changes nothing and opens no causal branch, so it
+    //  keeps whatever branch this handle was already on
+    if(delta == 0) {
+      return *this;
+    }
+
     BarrierImpl *impl = get_runtime()->get_barrier_impl(*this);
-    impl->adjust_arrival(ID(id).barrier_generation(), delta, timestamp, Event::NO_EVENT,
-                         Network::my_node_id, false /*!forwarded*/, 0, 0,
-                         TimeLimit::responsive());
+    // ARRIVAL_PROTOCOL rules 8 and 9, action AL.  The causal timestamp is
+    //  minted INSIDE the one critical section that also installs the arrival
+    //  floor, enters eager flush and records the message (section 12); it comes
+    //  back out so it can go on the returned handle.
+    timestamp_t timestamp = impl->alter_arrival_count(ID(id).barrier_generation(), delta);
 
     Barrier with_ts;
     with_ts.id = id;
@@ -121,8 +124,8 @@ namespace Realm {
     // arrival uses the timestamp stored in this barrier object
     BarrierImpl *impl = get_runtime()->get_barrier_impl(*this);
     impl->adjust_arrival(ID(id).barrier_generation(), -int(count), timestamp, wait_on,
-                         Network::my_node_id, false /*!forwarded*/, reduce_value,
-                         reduce_value_size, TimeLimit::responsive());
+                         Network::my_node_id, reduce_value, reduce_value_size,
+                         TimeLimit::responsive());
   }
 
   bool Barrier::get_result(void *value, size_t value_size) const
@@ -150,7 +153,10 @@ namespace Realm {
       impl->initial_value = 0;
       impl->value_capacity = 0;
       impl->final_values.clear();
+      impl->legacy.reset();
     } else {
+      // reduction barriers stay on the legacy (non-scalable) path
+      impl->legacy.reset(new BarrierImpl::LegacyReductionState);
       impl->redop_id = redopid; // keep the ID too so we can share it
       impl->redop = get_runtime()->reduce_op_table.get(redopid, 0);
       if(impl->redop == 0) {
@@ -181,11 +187,22 @@ namespace Realm {
   // active messages
 
   namespace {
+    // NOTIFICATION_PROTOCOL rule 5 - THE PULL.  One message type, two reply
+    //  shapes forked at the OWNER (BarrierSubscribeReplyMessage on the scalable
+    //  path, BarrierTriggerMessage on the legacy one), which is exactly why a
+    //  remote node never has to know in advance whether this is a reduction
+    //  barrier (tla/STATE_AND_LOCKING.md D2).
     struct BarrierSubscribeMessage {
       NodeID subscriber;
       ID::IDType barrier_id;
+      // what the subscriber NEEDS - used only by the legacy path's one-shot
+      //  'remote_subscribe_gens'
       EventImpl::gen_t subscribe_gen;
-      bool forwarded;
+      // 'lk' - what the subscriber ALREADY KNOWS.  The reply's poison list is
+      //  the delta above this, which is what a point-to-point answer can do and
+      //  a multicast notification cannot, and it is what replaces the owner's
+      //  per-node 'remote_trigger_gens' lookup on the pull path.
+      EventImpl::gen_t last_known;
 
       static void handle_message(NodeID sender, const BarrierSubscribeMessage &args,
                                  const void *data, size_t datalen)
@@ -195,72 +212,25 @@ namespace Realm {
         Barrier b = id.convert<Barrier>();
         BarrierImpl *impl = get_runtime()->get_barrier_impl(b);
 
-        impl->handle_remote_subscription(sender, args.subscribe_gen, args.forwarded, data,
-                                         datalen);
+        impl->handle_remote_subscription(args.subscriber, args.subscribe_gen,
+                                         args.last_known, data, datalen);
       }
 
       static void send_request(NodeID target, ID::IDType barrier_id,
-                               EventImpl::gen_t subscribe_gen, NodeID subscriber,
-                               bool forwarded)
+                               EventImpl::gen_t subscribe_gen,
+                               EventImpl::gen_t last_known, NodeID subscriber)
       {
         ActiveMessage<BarrierSubscribeMessage> amsg(target);
         amsg->subscriber = subscriber;
-        amsg->forwarded = forwarded;
         amsg->barrier_id = barrier_id;
         amsg->subscribe_gen = subscribe_gen;
+        amsg->last_known = last_known;
         amsg.commit();
       }
     };
-
-#ifdef BARRIER_ENABLE_BROADCAST
-    struct BarrierTriggerMessage {
-      ID::IDType barrier_id;
-
-      static void handle_message(NodeID sender, const BarrierTriggerMessage &args,
-                                 const void *data, size_t datalen, TimeLimit work_until)
-      {
-        Serialization::FixedBufferDeserializer fbd(data, datalen);
-        BarrierTriggerMessageArgs trigger_args;
-        bool ok = fbd & trigger_args;
-        assert(ok);
-
-        data = (char *)data + (datalen - fbd.bytes_left());
-        datalen = fbd.bytes_left();
-
-        EventImpl::gen_t trigger_gen = trigger_args.internal.trigger_gen;
-
-        ID id(args.barrier_id);
-        id.barrier_generation() = trigger_gen;
-        Barrier b = id.convert<Barrier>();
-        BarrierImpl *impl = get_runtime()->get_barrier_impl(b);
-
-        if(datalen > 0 && (trigger_args.internal.redop_id != 0)) {
-          impl->redop_id = trigger_args.internal.redop_id;
-          impl->redop =
-              get_runtime()->reduce_op_table.get(trigger_args.internal.redop_id, 0);
-        }
-
-        impl->handle_remote_trigger(
-            sender, args.barrier_id, trigger_gen, trigger_args.internal.previous_gen,
-            trigger_args.internal.first_generation, trigger_args.internal.redop_id,
-            trigger_args.internal.migration_target, trigger_args.internal.broadcast_index,
-            trigger_args.internal.base_arrival_count, data, datalen, work_until);
-      }
-
-      static void send_request(NodeID target, ID::IDType barrier_id, const void *data,
-                               size_t datalen, size_t max_payload_size)
-      {
-        ActiveMessageAuto<BarrierTriggerMessage> amsg(target, max_payload_size);
-        amsg->barrier_id = barrier_id;
-        amsg.add_payload(data, datalen);
-        amsg.commit();
-      }
-    };
-#endif
 
     struct BarrierAdjustMessage {
       NodeID sender;
-      int forwarded;
       int delta;
       Barrier barrier;
       Event wait_on;
@@ -274,57 +244,197 @@ namespace Realm {
         BarrierImpl *impl = get_runtime()->get_barrier_impl(args.barrier);
         EventImpl::gen_t gen = ID(args.barrier).barrier_generation();
         impl->adjust_arrival(gen, args.delta, args.barrier.timestamp, args.wait_on,
-                             args.sender, args.forwarded, datalen ? data : 0, datalen,
-                             work_until);
+                             args.sender, datalen ? data : 0, datalen, work_until);
       }
 
       static void send_request(NodeID target, Barrier barrier, int delta, Event wait_on,
-                               NodeID sender, bool forwarded, const void *data,
-                               size_t datalen)
+                               NodeID sender, const void *data, size_t datalen)
       {
         ActiveMessage<BarrierAdjustMessage> amsg(target, datalen);
         amsg->barrier = barrier;
         amsg->delta = delta;
         amsg->wait_on = wait_on;
         amsg->sender = sender;
-        amsg->forwarded = forwarded;
         amsg.add_payload(data, datalen);
-        amsg.commit();
-      }
-    };
-
-    struct BarrierMigrationMessage {
-      Barrier barrier;
-      NodeID current_owner;
-
-      static void handle_message(NodeID sender, const BarrierMigrationMessage &args,
-                                 const void *data, size_t datalen)
-      {
-        log_barrier.info() << "received barrier migration: barrier=" << args.barrier
-                           << " owner=" << args.current_owner;
-        BarrierImpl *impl = get_runtime()->get_barrier_impl(args.barrier);
-        {
-          AutoLock<> a(impl->mutex);
-          impl->owner = args.current_owner;
-        }
-      }
-
-      static void send_request(NodeID target, Barrier barrier, NodeID owner)
-      {
-        ActiveMessage<BarrierMigrationMessage> amsg(target);
-        amsg->barrier = barrier;
-        amsg->current_owner = owner;
         amsg.commit();
       }
     };
   } // namespace
 
-#ifndef BARRIER_ENABLE_BROADCAST
+  // NOTE: no handle_inline - every barrier action takes 'mutex' and touches
+  //  maps, and the inline contract forbids both (tla/STATE_AND_LOCKING.md D10).
+  /*static*/ void BarrierReportMessage::handle_message(NodeID sender,
+                                                       const BarrierReportMessage &args,
+                                                       const void *data, size_t datalen,
+                                                       TimeLimit work_until)
+  {
+    ID id(args.barrier_id);
+    id.barrier_generation() = args.gen;
+    Barrier b = id.convert<Barrier>();
+    BarrierImpl *impl = get_runtime()->get_barrier_impl(b);
+
+    impl->handle_remote_report(args.from, args.gen, args.val, args.is_direct,
+                               args.poisoned, data, datalen, work_until);
+  }
+
+  /*static*/ void BarrierReportMessage::send_request(NodeID target, ID::IDType barrier_id,
+                                                     EventImpl::gen_t gen, int64_t val,
+                                                     NodeID from, bool is_direct,
+                                                     bool poisoned, const void *data,
+                                                     size_t datalen)
+  {
+    // Q6: no hand-rolled chunking - an eager-flush map is O(subtree) and the
+    //  active message layer fragments it for us.
+    ActiveMessage<BarrierReportMessage> amsg(target, datalen);
+    amsg->barrier_id = barrier_id;
+    amsg->gen = gen;
+    amsg->val = val;
+    amsg->from = from;
+    amsg->is_direct = is_direct;
+    amsg->poisoned = poisoned;
+    amsg.add_payload(data, datalen);
+    amsg.commit();
+  }
+
+  // NOTE: no handle_inline, for the same reason as the report handler above -
+  //  this one takes 'mutex' and may create a generation record (D10).
+  /*static*/ void BarrierFlushMessage::handle_message(NodeID sender,
+                                                      const BarrierFlushMessage &args,
+                                                      const void *data, size_t datalen)
+  {
+    ID id(args.barrier_id);
+    id.barrier_generation() = args.gen;
+    Barrier b = id.convert<Barrier>();
+    BarrierImpl *impl = get_runtime()->get_barrier_impl(b);
+
+    impl->handle_remote_flush(args.gen);
+  }
+
+  /*static*/ void BarrierFlushMessage::send_request(NodeID target, ID::IDType barrier_id,
+                                                    EventImpl::gen_t gen)
+  {
+    ActiveMessage<BarrierFlushMessage> amsg(target);
+    amsg->barrier_id = barrier_id;
+    amsg->gen = gen;
+    amsg.commit();
+  }
+
+  // NOTE: no handle_inline (D10) - this one takes 'mutex', walks every open
+  //  generation and may install a parked plan.  It needs no TimeLimit: an
+  //  invalidation moves no counts, so it can neither complete a generation nor
+  //  wake a waiter.
+  /*static*/ void
+  BarrierInvalidateMessage::handle_message(NodeID sender,
+                                           const BarrierInvalidateMessage &args,
+                                           const void *data, size_t datalen)
+  {
+    ID id(args.barrier_id);
+    Barrier b = id.convert<Barrier>();
+    BarrierImpl *impl = get_runtime()->get_barrier_impl(b);
+
+    impl->handle_remote_invalidate(args.epoch);
+  }
+
+  /*static*/ void BarrierInvalidateMessage::send_request(NodeID target,
+                                                         ID::IDType barrier_id,
+                                                         uint32_t epoch)
+  {
+    ActiveMessage<BarrierInvalidateMessage> amsg(target);
+    amsg->barrier_id = barrier_id;
+    amsg->epoch = epoch;
+    amsg.commit();
+  }
+
+  // NOTE: no handle_inline (D10) - takes 'mutex' and copies the payload.  Like
+  //  the invalidation it moves no counts, so it needs no TimeLimit.
+  /*static*/ void BarrierNewPlanMessage::handle_message(NodeID sender,
+                                                        const BarrierNewPlanMessage &args,
+                                                        const void *data, size_t datalen)
+  {
+    ID id(args.barrier_id);
+    Barrier b = id.convert<Barrier>();
+    BarrierImpl *impl = get_runtime()->get_barrier_impl(b);
+
+    // the node that sent us our plan record IS our parent in the new tree
+    //  (ARRIVAL_PROTOCOL section 8.1 - the parent is stored, not derived)
+    impl->handle_remote_new_plan(sender, args.epoch, data, datalen);
+  }
+
+  /*static*/ void BarrierNewPlanMessage::send_request(NodeID target,
+                                                      ID::IDType barrier_id,
+                                                      uint32_t epoch, const void *data,
+                                                      size_t datalen)
+  {
+    ActiveMessage<BarrierNewPlanMessage> amsg(target, datalen);
+    amsg->barrier_id = barrier_id;
+    amsg->epoch = epoch;
+    amsg.add_payload(data, datalen);
+    amsg.commit();
+  }
+
+  // NOTE: no handle_inline (D10) - this takes 'mutex', walks the open
+  //  generations and may complete one, so it needs a TimeLimit.
+  /*static*/ void BarrierAlterMessage::handle_message(NodeID sender,
+                                                      const BarrierAlterMessage &args,
+                                                      const void *data, size_t datalen,
+                                                      TimeLimit work_until)
+  {
+    ID id(args.barrier_id);
+    id.barrier_generation() = args.gen;
+    Barrier b = id.convert<Barrier>();
+    BarrierImpl *impl = get_runtime()->get_barrier_impl(b);
+
+    impl->handle_remote_alter(sender, args.gen, args.delta, args.ts, args.prev_ts,
+                              work_until);
+  }
+
+  /*static*/ void BarrierAlterMessage::send_request(NodeID target, ID::IDType barrier_id,
+                                                    EventImpl::gen_t gen, int delta,
+                                                    Barrier::timestamp_t ts,
+                                                    Barrier::timestamp_t prev_ts)
+  {
+    ActiveMessage<BarrierAlterMessage> amsg(target);
+    amsg->barrier_id = barrier_id;
+    amsg->gen = gen;
+    amsg->delta = delta;
+    amsg->ts = ts;
+    amsg->prev_ts = prev_ts;
+    amsg.commit();
+  }
+
+  // NOTE: no handle_inline (D10) - this takes 'mutex' and can complete a
+  //  generation, so it needs a TimeLimit.
+  /*static*/ void BarrierTsArrivalMessage::handle_message(
+      NodeID sender, const BarrierTsArrivalMessage &args, const void *data,
+      size_t datalen, TimeLimit work_until)
+  {
+    ID id(args.barrier_id);
+    id.barrier_generation() = args.gen;
+    Barrier b = id.convert<Barrier>();
+    BarrierImpl *impl = get_runtime()->get_barrier_impl(b);
+
+    impl->handle_remote_ts_arrival(sender, args.gen, args.val, args.ts, args.local_ts,
+                                   args.poisoned, work_until);
+  }
+
+  /*static*/ void BarrierTsArrivalMessage::send_request(
+      NodeID target, ID::IDType barrier_id, EventImpl::gen_t gen, int64_t val,
+      Barrier::timestamp_t ts, Barrier::timestamp_t local_ts, bool poisoned)
+  {
+    ActiveMessage<BarrierTsArrivalMessage> amsg(target);
+    amsg->barrier_id = barrier_id;
+    amsg->gen = gen;
+    amsg->val = val;
+    amsg->ts = ts;
+    amsg->local_ts = local_ts;
+    amsg->poisoned = poisoned;
+    amsg.commit();
+  }
+
   /*static*/ void BarrierTriggerMessage::send_request(
       NodeID target, ID::IDType barrier_id, EventImpl::gen_t trigger_gen,
       EventImpl::gen_t previous_gen, EventImpl::gen_t first_generation,
-      ReductionOpID redop_id, NodeID migration_target, unsigned base_arrival_count,
-      const void *data, size_t datalen)
+      ReductionOpID redop_id, const void *data, size_t datalen)
   {
     ActiveMessage<BarrierTriggerMessage> amsg(target, datalen);
     amsg->barrier_id = barrier_id;
@@ -332,8 +442,6 @@ namespace Realm {
     amsg->previous_gen = previous_gen;
     amsg->first_generation = first_generation;
     amsg->redop_id = redop_id;
-    amsg->migration_target = migration_target;
-    amsg->base_arrival_count = base_arrival_count;
     amsg.add_payload(data, datalen);
     amsg.commit();
   }
@@ -352,45 +460,54 @@ namespace Realm {
     Barrier b = id.convert<Barrier>();
     BarrierImpl *impl = get_runtime()->get_barrier_impl(b);
 
+    // LEGACY / REDUCTION PATH ONLY.  The owner sends this message only when
+    //  'redop_id != 0' - the scalable path's notification is
+    //  BarrierNotifyMessage - so receiving one is itself the proof that this is
+    //  a reduction barrier (D2).  The discriminator has to be the message's
+    //  redop_id and not impl->redop_id, because this may be the very first
+    //  thing this node ever hears about the barrier.
+    const bool is_reduction = (args.redop_id != 0);
+
     // we'll probably end up with a list of local waiters to notify
     EventWaiter::EventWaiterList local_notifications;
+    // this message doubles as the LEGACY path's subscribe reply, so it may have
+    //  to re-subscribe (see below); that send is recorded here and emitted
+    //  after the unlock (S2)
+    BarrierImpl::PendingSends sends;
     {
       AutoLock<> a(impl->mutex);
 
       bool generation_updated = false;
 
-      // handle migration of the barrier ownership (possibly to us)
-      if(args.migration_target != (NodeID)-1) {
-        log_barrier.info() << "barrier " << b << " has migrated to "
-                           << args.migration_target;
-        impl->owner = args.migration_target;
-        impl->base_arrival_count = args.base_arrival_count;
-      }
-
       // it's theoretically possible for multiple trigger messages to arrive out
-      //  of order, so check if this message triggers the oldest possible range
-      // NOTE: it's ok for previous_gen to be earlier than our current generation - this
-      //  occurs with barrier migration because the new owner may not know which
-      //  notifications have already been performed
+      //  of order, so check if this message triggers the oldest possible range.
       if(args.previous_gen <= impl->generation.load()) {
-        // see if we can pick up any of the held triggers too
-        while(!impl->held_triggers.empty()) {
-          std::map<EventImpl::gen_t, EventImpl::gen_t>::iterator it =
-              impl->held_triggers.begin();
-          // if it's not contiguous, we're done
-          if(it->first != trigger_gen)
-            break;
-          // it is contiguous, so absorb it into this message and remove the held
-          // trigger
-          log_barrier.info("collapsing future trigger: " IDFMT "/%d -> %d -> %d",
-                           args.barrier_id, args.previous_gen, trigger_gen, it->second);
-          trigger_gen = it->second;
-          impl->held_triggers.erase(it);
+        if(is_reduction) {
+          // LEGACY ONLY: see if we can pick up any of the held triggers too
+          BarrierImpl::LegacyReductionState &ls = impl->legacy_state();
+          while(!ls.held_triggers.empty()) {
+            std::map<EventImpl::gen_t, EventImpl::gen_t>::iterator it =
+                ls.held_triggers.begin();
+            // if it's not contiguous, we're done
+            if(it->first != trigger_gen)
+              break;
+            // it is contiguous, so absorb it into this message and remove the held
+            // trigger
+            log_barrier.info("collapsing future trigger: " IDFMT "/%d -> %d -> %d",
+                             args.barrier_id, args.previous_gen, trigger_gen, it->second);
+            trigger_gen = it->second;
+            ls.held_triggers.erase(it);
+          }
         }
 
         if(trigger_gen > impl->generation.load()) {
           impl->generation.store_release(trigger_gen);
           generation_updated = true;
+          // ARRIVAL_PROTOCOL section 8.8 - a non-owner reclaims its own
+          //  alteration state here, for the same reason the owner reclaims its
+          //  in check_triggers_locked: an arrival can only ever name a
+          //  breakpoint above the watermark
+          impl->prune_alter_state_locked(trigger_gen);
         }
 
         // now iterate through any generations up to and including the latest triggered
@@ -405,12 +522,21 @@ namespace Realm {
           delete it->second;
           impl->generations.erase(it);
         }
-      } else {
-        // hold this trigger until we get messages for the earlier generation(s)
+      } else if(is_reduction) {
+        // LEGACY ONLY: hold this trigger until we get messages for the earlier
+        //  generation(s)
         log_barrier.info("holding future trigger: " IDFMT "/%d (%d -> %d)",
                          args.barrier_id, impl->generation.load(), args.previous_gen,
                          trigger_gen);
-        impl->held_triggers[args.previous_gen] = trigger_gen;
+        impl->legacy_state().held_triggers[args.previous_gen] = trigger_gen;
+      } else {
+        // A trigger message for a NON-reduction barrier should not exist: the
+        //  scalable path notifies with BarrierNotifyMessage.  Discard rather
+        //  than buffer, which is what NOTIFICATION_PROTOCOL rule 4 would do
+        //  anyway.
+        log_barrier.info("discarding out-of-order trigger: " IDFMT "/%d (%d -> %d)",
+                         args.barrier_id, impl->generation.load(), args.previous_gen,
+                         trigger_gen);
       }
 
       // is there any data we need to store?
@@ -445,6 +571,22 @@ namespace Realm {
                data, datalen);
       }
 
+      // THE LEGACY PATH'S SUBSCRIBE REPLY.  This message is what the owner
+      //  sends back to a subscribe on a reduction barrier, so it closes the
+      //  rule-7 pull window.  A legacy subscription is ONE SHOT - the owner
+      //  erases 'remote_subscribe_gens[node]' as soon as it is fulfilled - so
+      //  membership goes back to NO, and a node that still holds a waiter has
+      //  to ask again.  That is the same recovery NOTIFICATION_PROTOCOL rule 6
+      //  makes on the scalable path, and it is needed here for the same reason:
+      //  a consultation for a HIGHER generation, made while this pull was in
+      //  flight, was suppressed and left no other trace.
+      impl->pull_outstanding = false;
+      impl->pull_deferred = false;
+      impl->member = BarrierImpl::MEMBER_NO;
+      if(impl->has_waiters_locked()) {
+        impl->consult_subscribe_locked(sends);
+      }
+
       // external waiters need to be signalled inside the lock
       if(generation_updated && impl->has_external_waiters) {
         impl->has_external_waiters = false;
@@ -454,48 +596,198 @@ namespace Realm {
       }
     }
 
-    // with lock released, perform any local notifications
+    impl->emit_pending_sends(sends);
+
+    // with lock released, perform any local notifications.  The legacy path
+    //  does not carry poison (Q4 is implemented on the scalable path only), so
+    //  POISON_FIXME stays here.  The only other survivors are external_wait and
+    //  external_timedwait, which decision Q9 puts out of scope entirely.
     if(!local_notifications.empty())
       get_runtime()->event_triggerer.trigger_event_waiters(local_notifications,
                                                            POISON_FIXME, work_until);
   }
-#endif
 
   ////////////////////////////////////////////////////////////////////////
   //
-  // class BarrierCommunicator
+  // NOTIFICATION_PROTOCOL rules 1, 2, 4 and 5 - the notify and reply messages.
+  //
+  // Both carry their poison list as a plain ascending array of generations in
+  //  the payload.  Neither list can grow without bound: a notification's is
+  //  confined to the range it announces, and a reply's to what the subscriber
+  //  says it is missing, both capped by POISONED_GENERATION_LIMIT.
   //
 
-  void BarrierCommunicator::adjust(NodeID target, Barrier barrier, int delta,
-                                   Event wait_on, NodeID sender, bool forwarded,
-                                   const void *data, size_t datalen)
+  namespace {
+    // Shared payload validation for both messages: 'num_poisoned' generations
+    //  followed by 'trailing' bytes of something else (the departing set, or
+    //  nothing).  The length is checked here rather than trusted, so a
+    //  corrupt header can never make the reader walk off the buffer.
+    //
+    // NOTE the empty case is a NULL payload pointer, not an error: the common
+    //  notification carries no poison and no membership at all.  That is why
+    //  this returns a status and the pointer separately.
+    bool poison_payload_ok(size_t datalen, uint32_t num_poisoned, size_t trailing)
+    {
+      return datalen == ((num_poisoned * sizeof(EventImpl::gen_t)) + trailing);
+    }
+  } // namespace
+
+  // NOTE: no handle_inline (D10) - this takes 'mutex', frees generation records
+  //  and wakes waiters, so it needs a TimeLimit.
+  /*static*/ void BarrierNotifyMessage::handle_message(NodeID sender,
+                                                       const BarrierNotifyMessage &args,
+                                                       const void *data, size_t datalen,
+                                                       TimeLimit work_until)
   {
-    BarrierAdjustMessage::send_request(target, barrier, delta, wait_on, sender, forwarded,
-                                       data, datalen);
+    log_barrier.info("received barrier notify: " IDFMT "/%d -> %d sv=%llu",
+                     args.barrier_id, args.prev, args.wm,
+                     (unsigned long long)args.set_ver);
+
+    ID id(args.barrier_id);
+    id.barrier_generation() = args.wm;
+    Barrier b = id.convert<Barrier>();
+    BarrierImpl *impl = get_runtime()->get_barrier_impl(b);
+
+    if(!poison_payload_ok(datalen, args.num_poisoned, args.departing_bytes)) {
+      log_barrier.fatal() << "malformed barrier notification payload: " << b
+                          << " bytes=" << datalen << " npois=" << args.num_poisoned
+                          << " dep=" << args.departing_bytes;
+      std::abort();
+    }
+    const EventImpl::gen_t *poison =
+        (args.num_poisoned > 0) ? static_cast<const EventImpl::gen_t *>(data) : nullptr;
+
+    // RULE 1, the wire detail.  A per-recipient membership flag cannot survive
+    //  a multicast, so the message names the DEPARTING SET and each recipient
+    //  computes its own membership.  This is EXACT because the notification
+    //  goes only to the PRE-SHRINK set: every recipient is in it, so "still a
+    //  member" is precisely "not in R".
+    //
+    // Decoded OUTSIDE the critical section - it is a pure byte codec, and a
+    //  payload has no business lengthening an action (ARRIVAL_PROTOCOL 12).
+    bool inset = true;
+    if(args.departing_bytes > 0) {
+      MulticastTargetSet departing;
+      const unsigned char *dep = static_cast<const unsigned char *>(data) +
+                                 (args.num_poisoned * sizeof(EventImpl::gen_t));
+      if(EncodedMulticastTargets::decode(dep, args.departing_bytes,
+                                         Network::max_node_id + 1,
+                                         departing) != MulticastDecodeStatus::OK) {
+        log_barrier.fatal() << "malformed barrier notification departing set: " << b
+                            << " bytes=" << args.departing_bytes;
+        std::abort();
+      }
+      inset = !departing.contains(Network::my_node_id);
+    }
+
+    impl->handle_remote_notify(args.wm, args.prev, args.set_ver, poison,
+                               args.num_poisoned, inset, (args.shrink_hint != 0),
+                               work_until);
   }
 
-  void BarrierCommunicator::trigger(NodeID target, ID::IDType barrier_id,
-                                    const void *data, size_t datalen,
-                                    size_t max_payload_size)
+  /*static*/ void BarrierNotifyMessage::send_request(
+      const MulticastTargetSet &targets, ID::IDType barrier_id, EventImpl::gen_t wm,
+      EventImpl::gen_t prev, uint64_t set_ver, bool shrink_hint,
+      const std::vector<EventImpl::gen_t> &poison,
+      const std::vector<unsigned char> &departing)
   {
-#ifdef BARRIER_ENABLE_BROADCAST
-    BarrierTriggerMessage::send_request(target, barrier_id, data, datalen,
-                                        max_payload_size);
-#endif
+    if(targets.empty()) {
+      return;
+    }
+
+    std::vector<unsigned char> payload;
+    payload.resize((poison.size() * sizeof(EventImpl::gen_t)) + departing.size());
+    if(!poison.empty()) {
+      memcpy(payload.data(), poison.data(), poison.size() * sizeof(EventImpl::gen_t));
+    }
+    if(!departing.empty()) {
+      memcpy(payload.data() + (poison.size() * sizeof(EventImpl::gen_t)),
+             departing.data(), departing.size());
+    }
+
+    BarrierNotifyMessage hdr;
+    hdr.barrier_id = barrier_id;
+    hdr.wm = wm;
+    hdr.prev = prev;
+    hdr.set_ver = set_ver;
+    hdr.num_poisoned = static_cast<uint32_t>(poison.size());
+    hdr.departing_bytes = static_cast<uint32_t>(departing.size());
+    // rule 8's advisory byte.  It rides the notification that was going out
+    //  anyway, so publishing it costs nothing on the wire.
+    hdr.shrink_hint = (shrink_hint ? 1 : 0);
+
+    // The forwarding tree is planned FRESH from the encoded set on every send
+    //  (NOTIFICATION_PROTOCOL section 1), which is why this protocol needs none
+    //  of the tree-invalidation machinery the arrival one does.
+    multicast_message<BarrierNotifyMessage>(
+        targets, hdr, payload.empty() ? nullptr : payload.data(), payload.size());
   }
 
-  void BarrierCommunicator::subscribe(NodeID target, ID::IDType barrier_id,
-                                      EventImpl::gen_t subscribe_gen, NodeID subscriber,
-                                      bool forwarded)
+  // NOTE: no handle_inline (D10) - takes 'mutex' and wakes waiters.
+  /*static*/ void BarrierSubscribeReplyMessage::handle_message(
+      NodeID sender, const BarrierSubscribeReplyMessage &args, const void *data,
+      size_t datalen, TimeLimit work_until)
   {
-    BarrierSubscribeMessage::send_request(target, barrier_id, subscribe_gen, subscriber,
-                                          forwarded);
+    log_barrier.info("received barrier subscribe reply: " IDFMT " wm=%d sv=%llu",
+                     args.barrier_id, args.wm, (unsigned long long)args.set_ver);
+
+    ID id(args.barrier_id);
+    id.barrier_generation() = args.wm;
+    Barrier b = id.convert<Barrier>();
+    BarrierImpl *impl = get_runtime()->get_barrier_impl(b);
+
+    if(!poison_payload_ok(datalen, args.num_poisoned, /*trailing=*/0)) {
+      log_barrier.fatal() << "malformed barrier subscribe reply payload: " << b
+                          << " bytes=" << datalen << " npois=" << args.num_poisoned;
+      std::abort();
+    }
+    const EventImpl::gen_t *poison =
+        (args.num_poisoned > 0) ? static_cast<const EventImpl::gen_t *>(data) : nullptr;
+
+    impl->handle_remote_subscribe_reply(args.wm, args.set_ver, poison, args.num_poisoned,
+                                        work_until);
   }
 
-  size_t BarrierCommunicator::recommend_max_payload(NodeID node, size_t size,
-                                                    bool with_congestion)
+  /*static*/ void
+  BarrierSubscribeReplyMessage::send_request(NodeID target, ID::IDType barrier_id,
+                                             EventImpl::gen_t wm, uint64_t set_ver,
+                                             const std::vector<EventImpl::gen_t> &poison)
   {
-    return Network::recommended_max_payload(node, with_congestion, size);
+    const size_t bytes = poison.size() * sizeof(EventImpl::gen_t);
+    ActiveMessage<BarrierSubscribeReplyMessage> amsg(target, bytes);
+    amsg->barrier_id = barrier_id;
+    amsg->wm = wm;
+    amsg->set_ver = set_ver;
+    amsg->num_poisoned = static_cast<uint32_t>(poison.size());
+    if(bytes > 0) {
+      amsg.add_payload(poison.data(), bytes);
+    }
+    amsg.commit();
+  }
+
+  // NOTE: no handle_inline (D10) - this takes 'mutex'.  It needs no TimeLimit:
+  //  a departure intent moves no counts and no watermark, so it can neither
+  //  complete a generation nor wake a waiter.  It cannot even change what the
+  //  owner will publish next, because the shrink is not decided here - it is
+  //  decided by the cost test at the next trigger.
+  /*static*/ void BarrierDepartMessage::handle_message(NodeID sender,
+                                                       const BarrierDepartMessage &args,
+                                                       const void *data, size_t datalen)
+  {
+    ID id(args.barrier_id);
+    Barrier b = id.convert<Barrier>();
+    BarrierImpl *impl = get_runtime()->get_barrier_impl(b);
+
+    impl->handle_remote_depart(args.departing);
+  }
+
+  /*static*/ void BarrierDepartMessage::send_request(NodeID target, ID::IDType barrier_id,
+                                                     NodeID departing)
+  {
+    ActiveMessage<BarrierDepartMessage> amsg(target);
+    amsg->barrier_id = barrier_id;
+    amsg->departing = departing;
+    amsg.commit();
   }
 
   ////////////////////////////////////////////////////////////////////////
@@ -504,41 +796,156 @@ namespace Realm {
   //
 
   BarrierImpl::BarrierImpl(void)
-    : barrier_comm(std::make_unique<BarrierCommunicator>())
-    , external_waiter_condvar(external_waiter_mutex)
+    : external_waiter_condvar(external_waiter_mutex)
   {
     remote_subscribe_gens.clear();
-    remote_trigger_gens.clear();
-    assert(get_runtime()->get_module_config("core")->get_property(
-               "barrier_broadcast_radix", broadcast_radix) == REALM_SUCCESS);
   }
 
-  BarrierImpl::BarrierImpl(BarrierCommunicator *_barrier_comm, int _broadcast_radix)
-    : barrier_comm(_barrier_comm)
-    , external_waiter_condvar(external_waiter_mutex)
-    , broadcast_radix(_broadcast_radix)
+  BarrierImpl::~BarrierImpl(void)
   {
-    remote_subscribe_gens.clear();
-    remote_trigger_gens.clear();
+    dump_counters("destroyed");
+    delete[] poisoned_generations;
   }
 
-  BarrierImpl::~BarrierImpl(void) {}
+  bool BarrierImpl::BarrierCounters::any(void) const
+  {
+    return (departs_sent | departs_suppressed | leave_rejoin_cycles | churn_backoffs |
+            subscribe_fan_in | departs_received | shrinks_applied | shrinks_declined |
+            nodes_removed | flush_episodes | flush_report_bytes | plan_rebuilds |
+            plans_parked | parked_plans_applied | dead_plans_discarded |
+            retro_flushes_sent | stale_edge_forwards | report_edges_pinned |
+            pin_conflicts_avoided | gap_pulls) != 0;
+  }
+
+  // IMPLEMENTATION_PLAN section 5 - the counters' way out.  Everything in
+  //  BarrierCounters is written under 'mutex' beside the state it describes and
+  //  nothing branches on any of it, so without this it would be write-only.
+  //  One line, at 'info' level, only for a barrier that actually exercised the
+  //  deviation or hysteresis paths - a barrier that behaved is silent.
+  void BarrierImpl::dump_counters(const char *why) const
+  {
+    if(!counters.any()) {
+      return;
+    }
+    log_barrier.info() << "barrier counters (" << why << "): " << me
+                       << " departs_sent=" << counters.departs_sent
+                       << " departs_suppressed=" << counters.departs_suppressed
+                       << " leave_rejoin=" << counters.leave_rejoin_cycles
+                       << " churn_backoffs=" << counters.churn_backoffs
+                       << " depart_K=" << depart_K
+                       << " subscribe_fan_in=" << counters.subscribe_fan_in
+                       << " departs_received=" << counters.departs_received
+                       << " shrinks_applied=" << counters.shrinks_applied
+                       << " shrinks_declined=" << counters.shrinks_declined
+                       << " nodes_removed=" << counters.nodes_removed
+                       << " flush_episodes=" << counters.flush_episodes
+                       << " flush_report_bytes=" << counters.flush_report_bytes
+                       << " flush_report_bytes_max=" << counters.flush_report_bytes_max
+                       << " plan_rebuilds=" << counters.plan_rebuilds
+                       << " agg_peak_entries=" << counters.agg_peak_entries
+                       << " plans_parked=" << counters.plans_parked
+                       << " parked_plans_applied=" << counters.parked_plans_applied
+                       << " dead_plans_discarded=" << counters.dead_plans_discarded
+                       << " retro_flushes_sent=" << counters.retro_flushes_sent
+                       << " stale_edge_forwards=" << counters.stale_edge_forwards
+                       << " report_edges_pinned=" << counters.report_edges_pinned
+                       << " pin_conflicts_avoided=" << counters.pin_conflicts_avoided
+                       << " gap_pulls=" << counters.gap_pulls;
+  }
+
+#ifdef DEBUG_REALM
+  // DEBUG ONLY.  See the declaration: taking 'mutex' here proves NOBODY held
+  //  it, and therefore that this caller did not.  Failing to take it proves
+  //  nothing (another thread may hold it), so this never fires falsely.
+  void BarrierImpl::assert_locked(const char *who) const
+  {
+    Mutex &m = const_cast<Mutex &>(mutex);
+    if(m.trylock()) {
+      m.unlock();
+      log_barrier.fatal() << "barrier " << me << ": " << who
+                          << "() called without holding 'mutex'";
+      abort();
+    }
+  }
+#endif
 
   void BarrierImpl::init(ID _me, unsigned _init_owner)
   {
+    // the previous life of this slot is over - say what it did before the
+    //  counters are cleared below
+    dump_counters("recycled");
     me = _me;
     owner = _init_owner;
     gen_subscribed.store(0);
     first_generation = /*free_generation =*/0;
+    // decision Q3 - the poison array is per-lifetime.  A stale entry would make
+    //  has_triggered() report the NEW barrier's generation poisoned.
+    delete[] poisoned_generations;
+    poisoned_generations = nullptr;
+    num_poisoned_generations.store(0);
+    // NOTIFICATION_PROTOCOL: the node's belief about its own membership, and
+    //  (on the owner) the published set itself.  Both are per-lifetime: a
+    //  surviving 'member == MEMBER_YES' would stop the new barrier ever
+    //  subscribing, and a surviving 'sub_set' would multicast the new
+    //  barrier's notifications to nodes that never asked.
+    member = MEMBER_NO;
+    my_set_ver = 0;
+    pull_outstanding = false;
+    pull_deferred = false;
+    sub_set.clear();
+    set_ver = 0;
+    want_out.clear();
+    // rule 8 - the hysteresis state is per-lifetime too.  A surviving idle
+    //  counter would make the new barrier's first notification look like K
+    //  generations of silence and retire a node that has never been asked for
+    //  anything, and a surviving 'depart_outstanding' would suppress the one
+    //  request the new barrier is entitled to.  K itself restarts at its
+    //  initial value: the churn the previous life observed says nothing about
+    //  this one.
+    last_consult_wm = 0;
+    last_depart_wm = 0;
+    depart_K = DEPART_K_INITIAL;
+    depart_outstanding = false;
+    shrink_hint = true;
+    shrink_pays = true;
+    counters = BarrierCounters();
     next_free = 0;
     remote_subscribe_gens.clear();
-    remote_trigger_gens.clear();
-    needs_ordering = true;
     base_arrival_count = 0;
     redop = 0;
     initial_value = 0;
     value_capacity = 0;
     final_values.clear();
+    // drops the legacy per-node trigger map and any held triggers left over
+    //  from a previous life of this slot
+    legacy.reset();
+    // the plan record and the epochs are per-lifetime state: a stale parked
+    //  plan surviving into the next life of this slot would be installed by the
+    //  first invalidation the new barrier ever saw
+    cur_plan = ArrivalPlan();
+    my_epoch = 0;
+    inval_epoch = 0;
+    defer_epoch = 0;
+    defer_parent = -1;
+    std::vector<unsigned char>().swap(deferred_plan_payload);
+    // epochs must restart at 1 for the new life of this slot: a node still
+    //  holding a plan record from the previous one would otherwise compare the
+    //  new epochs against a stale, higher 'my_epoch' and drop them all
+    next_epoch = 1;
+    plan_rebuild_pending = false;
+    // the alteration state is per-lifetime too: a stale arrival floor would
+    //  make the new barrier's arrivals bypass the tree waiting on an
+    //  alteration that belonged to the previous one, and a stale applied-set
+    //  would open a gate that has not actually been opened
+    ts_floor.clear();
+    last_alter_ts = 0;
+    alter_floor = 0;
+    alter_steps.clear();
+    applied_ts.clear();
+    held_alters.clear();
+    // a node that altered the PREVIOUS life of this slot has no arrival floor
+    //  for this one, so it is a legitimate plan member again
+    ts_bypass_nodes.clear();
     generation.store_release(0);
   }
 
@@ -556,12 +963,11 @@ namespace Realm {
 
   class DeferredBarrierArrival : public EventWaiter {
   public:
-    DeferredBarrierArrival(Barrier _barrier, int _delta, NodeID _sender, bool _forwarded,
+    DeferredBarrierArrival(Barrier _barrier, int _delta, NodeID _sender,
                            const void *_data, size_t _datalen)
       : barrier(_barrier)
       , delta(_delta)
       , sender(_sender)
-      , forwarded(_forwarded)
       , data(bytedup(_data, _datalen))
       , datalen(_datalen)
     {}
@@ -575,13 +981,16 @@ namespace Realm {
 
     virtual void event_triggered(bool poisoned, TimeLimit work_until)
     {
-      // TODO: handle poison
-      assert(poisoned == POISON_FIXME);
+      // DECISION Q4 - A POISONED PRECONDITION POISONS THE GENERATION.  The
+      //  arrival still happens: withholding it would hang the barrier instead
+      //  of poisoning it, and every waiter would then be told nothing at all
+      //  rather than told the truth.
       log_barrier.info() << "deferred barrier arrival: " << barrier << " ("
-                         << barrier.timestamp << "), delta=" << delta;
+                         << barrier.timestamp << "), delta=" << delta
+                         << ", poisoned=" << poisoned;
       BarrierImpl *impl = get_runtime()->get_barrier_impl(barrier);
       impl->adjust_arrival(ID(barrier).barrier_generation(), delta, barrier.timestamp,
-                           Event::NO_EVENT, sender, forwarded, data, datalen, work_until);
+                           Event::NO_EVENT, sender, data, datalen, work_until, poisoned);
       // not attached to anything, so delete ourselves when we're done
       delete this;
     }
@@ -598,140 +1007,2285 @@ namespace Realm {
     Barrier barrier;
     int delta;
     NodeID sender;
-    bool forwarded;
     void *data;
     size_t datalen;
   };
 
-  BarrierImpl::Generation::Generation(void)
-    : unguarded_delta(0)
-  {}
-  BarrierImpl::Generation::~Generation(void)
+  // NOTE: the per-node timestamp-ordering machinery that used to live here
+  //  (PerNodeUpdates, with its 'ts <= pn->last_ts' test and its own
+  //  "TODO: really need two timestamps to properly order increments") is gone.
+  //  It is replaced by the exact-set gate of ARRIVAL_PROTOCOL rule 8: an
+  //  arrival names the alteration(s) it depends on, and the owner counts it
+  //  only when every one of them IS IN 'applied_ts'.  A "<= the highest
+  //  timestamp seen from that node" comparison admits an arrival whose own
+  //  alteration has not been applied yet, which is a barrier that triggers too
+  //  early - the one failure mode this rule exists to prevent.
+
+  ////////////////////////////////////////////////////////////////////////
+  //
+  // ARRIVAL_PROTOCOL section 11.1 - the eager-flush report's (node,count) map
+  //
+  // These are pure byte-level codecs: they touch no barrier state, take no
+  //  lock, and are deliberately callable OUTSIDE the critical section so that
+  //  decoding an inbound payload does not lengthen an action (section 12).
+  //
+
+  namespace {
+    // The number of nodes both sides of the multicast codec must agree on.
+    NodeID plan_node_count(void) { return Network::max_node_id + 1; }
+
+    // See BarrierReportMessage for the format.  Produces nothing at all for an
+    //  empty map: datalen == 0 is what tells the receiver "this report carries
+    //  no map", which is NOT the same as "this report says the map is empty".
+    //  The distinction matters because maps merge cumulatively and must never
+    //  be seen to shrink.
+    void encode_flush_map(const std::map<NodeID, int64_t> &counts,
+                          std::vector<unsigned char> &out)
+    {
+      out.clear();
+
+      // D8 / plan section 7.2: the node SET goes through the multicast codec,
+      //  which picks the smallest of its eight representations - a contiguous
+      //  block of nodes costs one run, not one entry per node.
+      MulticastTargetSet nodes;
+      for(std::map<NodeID, int64_t>::const_iterator it = counts.begin();
+          it != counts.end(); ++it) {
+        if(it->second <= 0) {
+          continue;
+        }
+        // std::map iterates in ascending key order, which is exactly the
+        //  strictly-increasing order this wants
+        if(!nodes.append_increasing_node(it->first)) {
+          return;
+        }
+      }
+      if(nodes.empty()) {
+        return;
+      }
+
+      EncodedMulticastTargets enc =
+          EncodedMulticastTargets::encode(nodes, plan_node_count());
+
+      MulticastWire::append_varint(out, enc.bytes());
+      const unsigned char *encp = static_cast<const unsigned char *>(enc.data());
+      out.insert(out.end(), encp, encp + enc.bytes());
+
+      // the counts, in the set's own (sorted) iteration order - no node id is
+      //  repeated on the wire
+      for(std::map<NodeID, int64_t>::const_iterator it = counts.begin();
+          it != counts.end(); ++it) {
+        if(it->second <= 0) {
+          continue;
+        }
+        MulticastWire::append_varint(out, static_cast<uint64_t>(it->second));
+      }
+    }
+
+    // Rejects anything malformed rather than aborting, and never sizes an
+    //  allocation from an unvalidated length: the cardinality comes from the
+    //  DECODED set, not from a transmitted count.
+    bool decode_flush_map(const void *data, size_t datalen,
+                          std::map<NodeID, int64_t> &out)
+    {
+      out.clear();
+      const unsigned char *p = static_cast<const unsigned char *>(data);
+      if((p == 0) || (datalen == 0)) {
+        return false;
+      }
+
+      size_t pos = 0;
+      uint64_t set_bytes = 0;
+      if(MulticastWire::read_varint(p, datalen, pos, set_bytes) !=
+         MulticastDecodeStatus::OK) {
+        return false;
+      }
+      if(set_bytes > (datalen - pos)) {
+        return false;
+      }
+
+      MulticastTargetSet nodes;
+      if(EncodedMulticastTargets::decode(p + pos, static_cast<size_t>(set_bytes),
+                                         plan_node_count(),
+                                         nodes) != MulticastDecodeStatus::OK) {
+        return false;
+      }
+      pos += static_cast<size_t>(set_bytes);
+
+      for(MulticastTargetSet::const_iterator it = nodes.begin(); it != nodes.end();
+          ++it) {
+        uint64_t count = 0;
+        if(MulticastWire::read_varint(p, datalen, pos, count) !=
+           MulticastDecodeStatus::OK) {
+          out.clear();
+          return false;
+        }
+        // a count that cannot be a plan quota is a corrupt payload, not a
+        //  merely large one
+        if(count > static_cast<uint64_t>(UINT32_MAX)) {
+          out.clear();
+          return false;
+        }
+        out.insert(out.end(), std::make_pair(*it, static_cast<int64_t>(count)));
+      }
+
+      // trailing bytes are malformed, not merely generous
+      if(pos != datalen) {
+        out.clear();
+        return false;
+      }
+      return true;
+    }
+  } // namespace
+
+  ////////////////////////////////////////////////////////////////////////
+  //
+  // scalable arrival helpers - ALL of these require 'mutex'
+  //
+
+  BarrierImpl::Generation *BarrierImpl::get_generation_locked(gen_t gen)
   {
-    for(std::map<int, PerNodeUpdates *>::iterator it = pernode.begin();
-        it != pernode.end(); it++) {
-      delete(it->second);
+    REALM_BARRIER_ASSERT_LOCKED();
+    std::map<gen_t, Generation *>::iterator it = generations.find(gen);
+    if(it != generations.end()) {
+      return it->second;
+    }
+    Generation *g = new Generation;
+    generations[gen] = g;
+    log_barrier.info() << "added tracker for barrier " << me << ", generation " << gen;
+    return g;
+  }
+
+  // ARRIVAL_PROTOCOL rule 1 - the steady state, and BOTH of its halves are
+  //  required.  A node forwards its cumulative subtree total only when its
+  //  local arrival count equals the quota its plan predicts AND every child the
+  //  plan predicts has reported at least once.
+  //
+  // The child-wait is a CORRECTNESS requirement, not an optimisation.  Early
+  //  forwarding does NOT self-correct just because reports are cumulative: at
+  //  depth >= 3, where a relay sits below another relay, dropping the child-wait
+  //  is a mutation TLC catches.  Do not simplify it away.
+  bool BarrierImpl::plan_satisfied_locked(const Generation &g) const
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    // MEMBERSHIP: a node with no plan has no completion condition at all
+    if(!cur_plan.inplan) {
+      return false;
+    }
+    if(g.local_total != static_cast<int64_t>(cur_plan.quota)) {
+      return false;
+    }
+    // NO CHILD-WAIT (ARRIVAL_PROTOCOL rule 1).  A relay does NOT additionally
+    //  wait for every predicted child.  Reports are cumulative and REPLACE, so
+    //  a forward that omits an absent child is superseded when that child
+    //  reports, and a generation only triggers on exact equality with the
+    //  expected count, so a low total cannot fire early.
+    //
+    //  This is load-bearing for rule 5: the child-wait is the only reason a
+    //  relay cares WHICH child reports to it, and therefore the only reason a
+    //  re-parented generation can strand on a child that already reported by
+    //  the retiring tree.  Removing it is what lets flush stop being sticky.
+    //  Do not reintroduce it.
+    return true;
+  }
+
+  // ARRIVAL_PROTOCOL section 8.1: the parent is STORED in the plan record, not
+  //  derived by searching for whoever lists us as a child.  A node outside the
+  //  plan has no parent, so its reports go straight to the owner (rule 3).
+  NodeID BarrierImpl::report_target_locked(void) const
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    if(cur_plan.inplan && (cur_plan.parent != static_cast<NodeID>(-1))) {
+      return cur_plan.parent;
+    }
+    return owner;
+  }
+
+  // Has the plan this node holds been RETIRED, with no replacement having
+  //  arrived yet?  my_epoch == 0 means "no plan has ever been installed here",
+  //  which cur_plan.inplan already reports, so it is excluded.
+  //
+  // This is the same self-clearing shape as rule 5's deferral guard: applying a
+  //  new plan raises my_epoch above inval_epoch, and nothing else has to
+  //  remember that a switch happened.
+  bool BarrierImpl::plan_retired_locked(void) const
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    return (my_epoch != 0) && (inval_epoch >= my_epoch);
+  }
+
+  // Is this node reporting EAGERLY for 'g' rather than aggregating?  The three
+  //  cases below are the same three that make should_report_locked() true
+  //  without consulting the plan, and they are also exactly the cases in which
+  //  a report carries the (node,count) map of section 11.1: a node that is not
+  //  aggregating is a node whose plan does not describe reality, and the map is
+  //  how the owner learns what reality is.
+  bool BarrierImpl::flush_mode_locked(gen_t gen, const Generation &g) const
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    // eager-flush mode: every arrival reports immediately (rules 2, 3 and 4).
+    //  This is also what carries rule 2 past the moment of over-arrival - once
+    //  the flag is on, this node never goes back to aggregating for this
+    //  generation, which is why there is no 'local_total > quota' test here.
+    //  BarrierArrive's RecvReport guard is exactly 'flushing \/ PlanSatisfied'.
+    if(g.flushing) {
+      return true;
+    }
+    // rule 3 / MEMBERSHIP (section 3): a node outside the plan has no
+    //  completion condition it could ever satisfy, so it is permanently in
+    //  eager-flush mode and speaks at once.  BarrierArrive's RecvReport writes this
+    //  as 'flushing \/ PlanSatisfied' rather than naming it, because in the
+    //  model every un-planned node has already been invalidated and so has
+    //  'flushing' set; here the state is reachable before any plan exists at
+    //  all, and holding would strand the arrival.
+    if(!cur_plan.inplan) {
+      return true;
+    }
+    // A node whose plan has been RETIRED but not yet replaced is in exactly the
+    //  same position as rule 3's outsider: the completion condition its record
+    //  describes belongs to a tree that no longer exists, so waiting on it is
+    //  the silence this protocol exists to prevent.
+    //
+    // BarrierArrive's RecvInvalidate covers this by setting flushing[n][g] for
+    //  every untriggered g the node HAS STATE ON (SubtreeKnown > 0, :452-456)
+    //  and making the node an OUTSIDER (inplan = FALSE, :464-467), so its
+    //  later arrivals fire case 3 natively; nothing clears the flag again
+    //  before the trigger (RecvNewPlan leaves 'flushing' UNCHANGED at
+    //  :510-514).
+    //
+    // Here the outsider transition is DERIVED rather than stored - retiring
+    //  the record would lose the old child list, which step 2 of the
+    //  invalidation still needs - and the deviation signal is kept alive by:
+    //
+    //   * this test, which covers the window between the invalidation and the
+    //     replacement (and IS self-clearing - installing a plan raises
+    //     'my_epoch' above 'inval_epoch');
+    //   * 'saw_direct' below, which makes the deviation signal travel THROUGH a
+    //     below-quota relay rather than being swallowed by it;
+    //   * the retroactive case-3 flush (handle_remote_invalidate step 5),
+    //     which signals the owner for arrivals made BEFORE the invalidation
+    //     that this test can no longer speak for; and
+    //   * the owner's flush of every straddling generation when it installs a
+    //     new plan (build_new_plan_locked step 5), which reaches them across
+    //     the NEW tree.
+    if(plan_retired_locked()) {
+      return true;
+    }
+    // RULE 3, PROPAGATED.  A 'direct' passing through says "the plan does not
+    //  describe reality for this generation", and it says it about the path as
+    //  much as about the node that raised it.  Without this the flag rides on a
+    //  report that a below-quota relay never sends: the signal dies one hop
+    //  above the deviation and the owner never learns it has to flush.  That is
+    //  the silence BarrierArrive avoids by keeping 'flushing' set forever after an
+    //  invalidation, and it is the reason this is a mode and not just a flag to
+    //  be copied onto the next outgoing report.
+    if(g.saw_direct) {
+      return true;
+    }
+    // RULE 8.3 - this node has issued an alteration covering 'gen', so its own
+    //  arrivals BYPASS the tree (rule 8.1) and never reach 'local_total'.  Its
+    //  quota is therefore unreachable, and a relay waiting on an unreachable
+    //  quota goes silent and strands its children - a caught mutation
+    //  (deadlock).  Like plan_retired_locked() above, this is derived rather
+    //  than flagged, because the flag would have to be set on generations this
+    //  node has no record for yet.
+    if(ts_floor_locked(gen) != 0) {
+      return true;
+    }
+    return false;
+  }
+
+  // The forwarding decision of action A step 5 and action R step 6.
+  bool BarrierImpl::should_report_locked(gen_t gen, const Generation &g) const
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    // the owner has no parent - its subtree total is the answer, not a report
+    if(owner == Network::my_node_id) {
+      return false;
+    }
+    // nothing we know that we have not already passed on
+    if(!g.holding()) {
+      return false;
+    }
+    // rules 2, 3, 4, 6 and 8 - not aggregating, so speak at once
+    if(flush_mode_locked(gen, g)) {
+      return true;
+    }
+    // rule 1 - both halves
+    return plan_satisfied_locked(g);
+  }
+
+  ////////////////////////////////////////////////////////////////////////
+  //
+  // ARRIVAL_PROTOCOL rules 8 and 9 - alter_arrival_count.  ALL of these
+  //  require 'mutex'.
+  //
+
+  // The model's myTs[n][g], stored as a step function because alterations are
+  //  PERSISTENT: the entry installed at generation k covers k and everything
+  //  after it, until a later alteration installs a new one.
+  Barrier::timestamp_t BarrierImpl::ts_floor_locked(gen_t gen) const
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    if(ts_floor.empty()) {
+      return 0;
+    }
+    // the greatest entry with key <= gen
+    std::map<gen_t, Barrier::timestamp_t>::const_iterator it = ts_floor.upper_bound(gen);
+    if(it == ts_floor.begin()) {
+      return 0;
+    }
+    --it;
+    return it->second;
+  }
+
+  // OWNER ONLY.  expected(gen) - the arrival count this generation is waiting
+  //  for, with every alteration that applies to it folded in.  PERSISTENCE
+  //  (D5) is exactly the "key <= gen" here: an alteration issued for an earlier
+  //  generation still counts for this one.
+  int64_t BarrierImpl::expected_locked(gen_t gen) const
+  {
+    int64_t total = static_cast<int64_t>(base_arrival_count) + alter_floor;
+    for(std::map<gen_t, int64_t>::const_iterator it = alter_steps.begin();
+        (it != alter_steps.end()) && (it->first <= gen); ++it) {
+      total += it->second;
+    }
+    return total;
+  }
+
+  // OWNER ONLY.  EXACT SET MEMBERSHIP, and deliberately not a comparison
+  //  against the highest timestamp applied for the sending node: alterations
+  //  can be applied out of order, and a "<=" gate would count an arrival whose
+  //  own alteration is still in flight.
+  bool BarrierImpl::ts_gate_open_locked(const Generation::TsKey &gate) const
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    if((gate.ts != 0) && (applied_ts.count(gate.ts) == 0)) {
+      return false;
+    }
+    if((gate.local_ts != 0) && (applied_ts.count(gate.local_ts) == 0)) {
+      return false;
+    }
+    return true;
+  }
+
+  // OWNER ONLY.  'count' arrivals have been accounted for.  On the scalable
+  //  path they count UP into the generation's bypassed-arrival total (D4); on
+  //  the legacy path they count DOWN into 'unguarded_delta', which is that
+  //  path's convention and stays there.
+  void BarrierImpl::credit_arrivals_locked(Generation &g, int64_t count) const
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    if(redop_id != 0) {
+      g.unguarded_delta -= static_cast<int>(count);
+    } else {
+      g.ts_acc += count;
     }
   }
 
-  void BarrierImpl::Generation::handle_adjustment(Barrier::timestamp_t ts, int delta)
+  // OWNER ONLY - action TS.  One bypass stream per (sender, gate), cumulative
+  //  and replace-if-higher exactly like child_acc (rule 7): a value that does
+  //  not strictly exceed what we hold is stale and is dropped.
+  void BarrierImpl::apply_ts_arrival_locked(NodeID from, Generation &g,
+                                            const Generation::TsKey &gate, int64_t val)
   {
-    if(ts == 0) {
-      // simple case - apply delta directly
-      unguarded_delta += delta;
+    REALM_BARRIER_ASSERT_LOCKED();
+    Generation::TsStreamKey key;
+    key.from = from;
+    key.gate = gate;
+
+    Generation::TsStream &st = g.ts_streams[key];
+    if(val <= st.seen) {
+      log_barrier.info() << "dropping stale barrier ts arrival: " << me
+                         << " from=" << from << " val=" << val << " have=" << st.seen;
+      return;
+    }
+    const int64_t added = val - st.seen;
+    st.seen = val;
+
+    if(st.counted) {
+      credit_arrivals_locked(g, added);
+      return;
+    }
+    // THE GATE (rule 8.2): the owner may not count a timestamped arrival until
+    //  every alteration it witnessed has been applied.  Until then the stream
+    //  simply sits here - the model expresses this as RecvTsDirect being
+    //  DISABLED, which is why it needs no message ordering at all.
+    if(!ts_gate_open_locked(gate)) {
+      log_barrier.info() << "parking barrier ts arrival: " << me << " from=" << from
+                         << " val=" << val << " ts=" << gate.ts
+                         << " local_ts=" << gate.local_ts;
+      return;
+    }
+    st.counted = true;
+    credit_arrivals_locked(g, st.seen);
+  }
+
+  // OWNER ONLY.  An alteration has just been applied, so every stream that was
+  //  parked behind it may now be counted.  Fusing this with the application of
+  //  the alteration is a legal refinement: the model expresses it as
+  //  RecvTsDirect becoming ENABLED, and merging an enabling action with the
+  //  action it enables never exposes a state the model does not have.
+  void BarrierImpl::open_ts_gates_locked(Barrier::timestamp_t ts)
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    const gen_t watermark = generation.load();
+    for(std::map<gen_t, Generation *>::iterator it = generations.begin();
+        it != generations.end(); ++it) {
+      if(it->first <= watermark) {
+        continue;
+      }
+      Generation &g = *(it->second);
+      for(std::map<Generation::TsStreamKey, Generation::TsStream>::iterator sit =
+              g.ts_streams.begin();
+          sit != g.ts_streams.end(); ++sit) {
+        if(sit->second.counted) {
+          continue;
+        }
+        // only a stream this timestamp is part of can have been unblocked
+        if((sit->first.gate.ts != ts) && (sit->first.gate.local_ts != ts)) {
+          continue;
+        }
+        if(!ts_gate_open_locked(sit->first.gate)) {
+          continue;
+        }
+        sit->second.counted = true;
+        credit_arrivals_locked(g, sit->second.seen);
+      }
+    }
+  }
+
+  // OWNER ONLY - ARRIVAL_PROTOCOL rule 9, "a negative alteration ... invalidates
+  //  the current arrival plan", applied here to alterations OF EITHER SIGN.
+  //
+  // Rule 9 states the negative case, whose plan defect is an unreachable quota.
+  //  A POSITIVE alteration produces the same defect by a different route, and
+  //  it is the one rule 8.3 is about: the altering node's arrivals now BYPASS
+  //  the tree, so its 'local_total' stops growing and the quota the plan gave
+  //  it can never be met.  Rule 8.3 keeps that node reporting for its own
+  //  children, but nothing in it helps the node's PARENT, which is holding its
+  //  whole subtree back on rule 1's child-wait ("every predicted child has
+  //  reported at least once").  A leaf that alters strands its parent exactly
+  //  as an unreachable quota strands a relay's children.  BarrierArrive does not
+  //  see this because MCAlter's altering node reports to the owner, which never
+  //  waits on a child - so this is a case the model does not cover rather than
+  //  one it rules out.
+  //
+  // Retiring the plan is the protocol's own answer to "the plan is wrong", it
+  //  is rule 6's verified machinery, and it covers the generations this node
+  //  has no record for yet - which a per-generation flush cannot.  The cost is
+  //  that a barrier altered every generation never settles into a plan and
+  //  stays on the eager path; that is today's behaviour for every barrier, and
+  //  it is the safe direction.
+  void BarrierImpl::retire_plan_locked(PendingSends &sends)
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    // nothing has ever been distributed, so there is nothing to retire
+    if(my_epoch == 0) {
+      return;
+    }
+    // already retired and waiting for a replacement
+    if(inval_epoch >= my_epoch) {
       return;
     }
 
-    int node = ts >> BARRIER_TIMESTAMP_NODEID_SHIFT;
-    PerNodeUpdates *pn;
-    std::map<int, PerNodeUpdates *>::iterator it = pernode.find(node);
-    if(it != pernode.end()) {
-      pn = it->second;
-    } else {
-      pn = new PerNodeUpdates;
-      pernode[node] = pn;
+    // RULE 6, FORWARD BEFORE FORGETTING: the targets come from the CURRENT
+    //  child list and are resolved into 'sends' inside this section (S3).
+    sends.fwd_inval_epoch = my_epoch;
+    sends.inval_to.insert(sends.inval_to.end(), cur_plan.kids.begin(),
+                          cur_plan.kids.end());
+    inval_epoch = my_epoch;
+    plan_rebuild_pending = true;
+
+    log_barrier.info() << "retiring barrier plan: " << me << " epoch=" << my_epoch;
+  }
+
+  // OWNER ONLY - action RA, ARRIVAL_PROTOCOL rules 8 and 9.
+  //
+  // The alteration is PERSISTENT: it lands as a STEP in 'alter_steps', so it
+  //  raises (or lowers) expected(g) for the generation it names and for every
+  //  generation after it.  Nothing here is per-generation, which is precisely
+  //  the bug this replaces.
+  void BarrierImpl::apply_alter_locked(gen_t alter_gen, int delta,
+                                       Barrier::timestamp_t ts,
+                                       Barrier::timestamp_t prev_ts, PendingSends &sends)
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    // step 1 - ORDERING.  One node's alterations are applied in the order it
+    //  issued them: an alteration whose predecessor has not landed yet is held
+    //  right here.  That is what makes a single timestamp on an arrival a
+    //  sound gate for the entire chain behind it, and it is checked by exact
+    //  membership rather than by comparing timestamps.
+    if((prev_ts != 0) && (applied_ts.count(prev_ts) == 0)) {
+      HeldAlter ha;
+      ha.gen = alter_gen;
+      ha.delta = delta;
+      ha.ts = ts;
+      held_alters.insert(std::make_pair(prev_ts, ha));
+      log_barrier.info() << "holding barrier alteration: " << me << "/" << alter_gen
+                         << " delta=" << delta << " ts=" << ts << " needs=" << prev_ts;
+      return;
     }
-    if(delta > 0) {
-      // TODO: really need two timestamps to properly order increments
-      unguarded_delta += delta;
-      pn->last_ts = ts;
-      std::map<Barrier::timestamp_t, int>::iterator it2 = pn->pending.begin();
-      while((it2 != pn->pending.end()) && (it2->first <= pn->last_ts)) {
-        log_barrier.info("applying pending delta: %llx/%d", it2->first, it2->second);
-        unguarded_delta += it2->second;
-        pn->pending.erase(it2);
-        it2 = pn->pending.begin();
+
+    // a worklist rather than recursion: applying this one may release others
+    std::vector<HeldAlter> ready;
+    {
+      HeldAlter ha;
+      ha.gen = alter_gen;
+      ha.delta = delta;
+      ha.ts = ts;
+      ready.push_back(ha);
+    }
+
+    while(!ready.empty()) {
+      const HeldAlter cur = ready.back();
+      ready.pop_back();
+
+      // an alteration is applied EXACTLY ONCE.  The transport does not
+      //  duplicate messages, so this is belt and braces - but a delta applied
+      //  twice is a barrier that never triggers, which is expensive to debug.
+      //  A timestamp of 0 is not an identity: it means "this alteration opens
+      //  no causal branch", which several of them can do independently.
+      if((cur.ts != 0) && (applied_ts.count(cur.ts) != 0)) {
+        log_barrier.info() << "ignoring duplicate barrier alteration: " << me << "/"
+                           << cur.gen << " ts=" << cur.ts;
+        continue;
       }
+
+      gen_t apply_gen = cur.gen;
+      const gen_t watermark = generation.load();
+      if(apply_gen <= watermark) {
+        // CONTRACT VIOLATION (event.h:302-306): the generation the application
+        //  named has already triggered, so it triggered without this
+        //  alteration - "a barrier that triggered too early".  It is reported
+        //  rather than fatal because the damage is already done, and the delta
+        //  is still applied persistently from the next open generation on, so
+        //  that every later count stays consistent.
+        log_barrier.fatal() << "barrier alteration for a triggered generation: " << me
+                            << "/" << cur.gen << " delta=" << cur.delta
+                            << " watermark=" << watermark;
+        apply_gen = watermark + 1;
+      }
+
+      alter_steps[apply_gen] += cur.delta;
+      // 0 is the "no causal branch" sentinel and never goes in the applied set:
+      //  ts_gate_open_locked() already reads a zero in a gate as "no dependency
+      //  here", so an entry for it would mean nothing and would collide with
+      //  the next untimestamped alteration.
+      if(cur.ts != 0) {
+        applied_ts[cur.ts] = apply_gen;
+      }
+
+      // RULE 9 - a base arrival count of zero is an error.  It is also what
+      //  makes 0 a safe "not yet known" sentinel elsewhere.  'expected' is a
+      //  step function, so checking it at the first open generation and at
+      //  every breakpoint above the watermark covers every generation.
+      {
+        bool bad = (expected_locked(watermark + 1) <= 0);
+        for(std::map<gen_t, int64_t>::const_iterator it = alter_steps.begin();
+            !bad && (it != alter_steps.end()); ++it) {
+          if(it->first > watermark) {
+            bad = (expected_locked(it->first) <= 0);
+          }
+        }
+        if(bad) {
+          log_barrier.fatal() << "barrier arrival count driven to zero or below: " << me
+                              << "/" << apply_gen << " delta=" << cur.delta;
+          abort();
+        }
+      }
+
+      // step 2 - the gate this timestamp was holding shut is now open
+      if(cur.ts != 0) {
+        open_ts_gates_locked(cur.ts);
+      }
+
+      // step 3 - RULE 9.  The plan is now wrong whichever way the count moved
+      //  (see retire_plan_locked), so it is retired; the next trigger builds a
+      //  replacement out of what the resulting eager reports gather.
+      retire_plan_locked(sends);
+
+      if(cur.delta < 0) {
+        // RULE 9 - a NEGATIVE alteration also behaves as an ARRIVAL: it reduces
+        //  the count still outstanding, which on a count-up accumulator is
+        //  exactly what lowering 'expected' does.  ONE effect, applied once -
+        //  crediting an arrival as well would count it twice.
+        //
+        // Eager flush over the affected open generations is what the state and
+        //  locking document asks for here.  It overlaps the invalidation above,
+        //  which flushes every open generation at each node it reaches, but
+        //  rule 4 is idempotent so the overlap costs nothing.
+        enter_flush_from_locked(apply_gen, sends);
+
+        // THE TERMINAL-NEGATIVE CASE (event.h:293-297): a negative alteration
+        //  that drives the remaining count to exactly zero needs no arrival on
+        //  the returned handle, so it is the one branch of the contract whose
+        //  safety argument does NOT rest on a reserved arrival.  It has no
+        //  formal coverage (ARRIVAL_PROTOCOL section 8.6), so it is gated here
+        //  rather than implemented speculatively.
+        for(std::map<gen_t, Generation *>::iterator it = generations.begin();
+            it != generations.end(); ++it) {
+          if((it->first <= watermark) || (it->first < apply_gen)) {
+            continue;
+          }
+          if(generation_complete_locked(it->first, *(it->second))) {
+            log_barrier.fatal()
+                << "terminal-negative alter_arrival_count is not implemented: " << me
+                << "/" << it->first << " delta=" << cur.delta
+                << " (a negative alteration that completes a generation by itself"
+                << " has no formal coverage - see ARRIVAL_PROTOCOL section 8.6)";
+            abort();
+          }
+        }
+      }
+
+      log_barrier.info() << "applied barrier alteration: " << me << "/" << apply_gen
+                         << " delta=" << cur.delta << " ts=" << cur.ts
+                         << " expected=" << expected_locked(apply_gen);
+
+      // step 3 - release anything that was waiting for THIS alteration
+      std::pair<std::multimap<Barrier::timestamp_t, HeldAlter>::iterator,
+                std::multimap<Barrier::timestamp_t, HeldAlter>::iterator>
+          range = held_alters.equal_range(cur.ts);
+      for(std::multimap<Barrier::timestamp_t, HeldAlter>::iterator it = range.first;
+          it != range.second; ++it) {
+        ready.push_back(it->second);
+      }
+      held_alters.erase(range.first, range.second);
+    }
+  }
+
+  // ARRIVAL_PROTOCOL section 8.8 - retained state must be reclaimable.
+  //
+  // 'alter_steps' entries at or below the watermark can never be un-applied, so
+  //  they fold into the floor.  'ts_floor' answers "the greatest entry with key
+  //  <= gen" and arrivals only ever happen above the watermark, so every
+  //  breakpoint strictly below the greatest one that is <= watermark + 1 is
+  //  unreachable.
+  //
+  // NOT pruned here: 'applied_ts'.  Dropping an entry would make an alteration
+  //  chained behind it (BarrierAlterMessage::prev_ts) wait forever, so it needs
+  //  a companion "already pruned, therefore applied" test to be safe.  What is
+  //  retained is one entry per alteration ever issued on this barrier, which
+  //  tla/STATE_AND_LOCKING.md section 7.3 already calls the residual of this
+  //  design; shrinking it to one entry per altering node is deferred.
+  void BarrierImpl::prune_alter_state_locked(gen_t watermark)
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    while(!alter_steps.empty() && (alter_steps.begin()->first <= watermark)) {
+      alter_floor += alter_steps.begin()->second;
+      alter_steps.erase(alter_steps.begin());
+    }
+
+    if(!ts_floor.empty()) {
+      std::map<gen_t, Barrier::timestamp_t>::iterator it =
+          ts_floor.upper_bound(watermark + 1);
+      if(it != ts_floor.begin()) {
+        --it; // the newest breakpoint an arrival can still name
+        ts_floor.erase(ts_floor.begin(), it);
+      }
+    }
+  }
+
+  // ARRIVAL_PROTOCOL section 11.1 - the (node,count) map this node speaks for.
+  //
+  // Merging is per-node REPLACE-IF-HIGHER and never addition.  Each entry is
+  //  the count of arrivals that happened AT THAT NODE, so the same node showing
+  //  up under two different children - which happens mid-switch, when it has
+  //  reported to its old parent and then to its new one, and both are children
+  //  of ours - must contribute ONCE, at its highest observed value.  Summing
+  //  would inflate the count, and an inflated count becomes an unreachable
+  //  quota, which is the one plan defect that deadlocks (see
+  //  build_new_plan_locked).
+  void BarrierImpl::merge_counts_locked(const Generation &g,
+                                        std::map<NodeID, int64_t> &out) const
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    out.clear();
+    if(g.local_total > 0) {
+      out[Network::my_node_id] = g.local_total;
+    }
+    for(std::map<NodeID, Generation::ChildReport>::const_iterator it =
+            g.child_acc.begin();
+        it != g.child_acc.end(); ++it) {
+      for(std::map<NodeID, int64_t>::const_iterator cit = it->second.counts.begin();
+          cit != it->second.counts.end(); ++cit) {
+        int64_t &slot = out[cit->first];
+        if(cit->second > slot) {
+          slot = cit->second;
+        }
+      }
+    }
+  }
+
+  // A report is CUMULATIVE (rule 7): 'val' is this node's running subtree total
+  //  for the generation, never an increment, so a later report supersedes an
+  //  earlier one at the receiver and duplicate or out-of-order delivery is
+  //  harmless.  'reported_up' is what makes the next Unreported() test exact.
+  void BarrierImpl::record_report_locked(Generation &g, gen_t gen, PendingSends &sends)
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    // build straight into the outbound slot - the map is a vector, and copying
+    //  a PendingReport around would copy it with them
+    PendingReport *r;
+    if(sends.report.to == static_cast<NodeID>(-1)) {
+      // the scalar slot first, so nothing on the steady-state path allocates
+      r = &sends.report;
     } else {
-      // if the timestamp is late enough, we can apply this directly
-      if(ts <= pn->last_ts) {
-        log_barrier.info("adjustment can be applied immediately: %llx/%d (%llx)", ts,
-                         delta, pn->last_ts);
-        unguarded_delta += delta;
+      sends.more_reports.push_back(PendingReport());
+      r = &sends.more_reports.back();
+    }
+
+    r->gen = gen;
+    // RULE 7 AND THE PINNED TARGET (Generation::report_to).  The receiver keys
+    //  its accumulator on the SENDER and REPLACES that sender's previous
+    //  contribution, so this node's contribution to this generation has to
+    //  reach the owner down exactly ONE chain.  The first report fixes which
+    //  one; a plan installed later replaces 'cur_plan.parent' but must not
+    //  re-aim a generation that has already been spoken for, or the same
+    //  arrivals arrive at the common ancestor under two sender keys and are
+    //  summed - with no way to retract the first, since a cumulative total may
+    //  never go down.
+    //
+    // This is the general form of the hazard the note below describes for a
+    //  RETIRED node.  It bites on the FIRST plan too: before any plan exists
+    //  every node reports 'direct' to the owner, and the first plan puts most
+    //  of them under a relay.
+    const NodeID target = report_target_locked();
+    if(g.report_to == static_cast<NodeID>(-1)) {
+      g.report_to = target;
+      counters.report_edges_pinned++;
+    } else if(g.report_to != target) {
+      // the pin is doing its job: the current plan would have re-aimed this
+      //  generation's chain, and rule 10.1 says it must not
+      counters.pin_conflicts_avoided++;
+    }
+    r->to = g.report_to;
+    r->val = g.subtree_known();
+    // decision Q4 - the poison bit is STICKY for the generation and is OR-ed
+    //  into every report this node sends, so it needs no separate message and
+    //  no acknowledgement.  It always rides the same report as the arrival
+    //  COUNT that set it, which the generation cannot complete without, so it
+    //  cannot be lost to the receiver's staleness test.
+    r->poisoned = g.poisoned;
+
+    // rule 3: a node holding no plan record - or one whose plan has been
+    //  retired - has no completion condition the owner's plan predicted, so its
+    //  report is a 'direct': "your plan did not account for me".
+    //
+    // 'saw_direct' propagates that upward.  The target of a report is the
+    //  PINNED one above, never re-aimed mid-generation, because re-aiming would
+    //  let the same arrivals reach the owner down two chains and be counted
+    //  twice.  Keeping the routing fixed means the signal has to travel as a
+    //  flag instead, or the first relay swallows it and the owner never learns
+    //  its plan is wrong.  (Not modelled: BarrierArrive's scenarios never have a
+    //  previously-planned node deviate.  Over-signalling a flush is always safe
+    //  - it only ever causes MORE eager reporting - so this errs in the safe
+    //  direction.)
+    //
+    // Two more cases raise it, and in both a node the plan DID predict is
+    //  telling the owner that the plan is wrong:
+    //
+    //   * an OVER-ARRIVAL (rule 2).  The plan under-predicted this node, and
+    //     only the owner can fix that - but rule 2's own fan-out goes DOWNWARD
+    //     only, so without this the owner never hears about it and any
+    //     below-quota relay between here and there stays silent forever.
+    //     BarrierArrive does not need the signal because an invalidated node is
+    //     flushing for the rest of the run and forwards regardless; this
+    //     implementation lets aggregation resume, so the signal has to be real.
+    //   * a report travelling a STALE EDGE, i.e. one whose pinned target is no
+    //     longer the parent the current plan gives us.  Its receiver may have
+    //     no reason of its own to speak, and everything behind that report
+    //     would then be stuck behind ITS completion condition.
+    r->is_direct =
+        !cur_plan.inplan || plan_retired_locked() || g.saw_direct ||
+        (g.report_to != target) ||
+        (cur_plan.inplan && (g.local_total > static_cast<int64_t>(cur_plan.quota)));
+
+    // section 11.1: only an EAGER-FLUSH report carries the per-node map.  A
+    //  steady-state rule-1 report stays O(1) - which is the entire reason the
+    //  tree exists - so the owner learns the arrival pattern only from the
+    //  deviation path, and only for as long as a deviation is in progress.
+    if(flush_mode_locked(gen, g)) {
+      std::map<NodeID, int64_t> merged;
+      merge_counts_locked(g, merged);
+      encode_flush_map(merged, r->flush_map);
+
+      // IMPLEMENTATION_PLAN section 5 - EAGER-FLUSH REPORT SIZES.  This is the
+      //  only O(subtree) payload the protocol emits, and the peak is what says
+      //  whether Q6's "let active-message fragmentation handle it" is still the
+      //  right answer at scale.
+      counters.flush_report_bytes += r->flush_map.size();
+      if(r->flush_map.size() > counters.flush_report_bytes_max) {
+        counters.flush_report_bytes_max = r->flush_map.size();
+      }
+    }
+
+    g.reported_up = r->val;
+  }
+
+  // BarrierArrive's 'held' set, shared by RecvInvalidate and RecvNewPlan:
+  //
+  //   held == { g \in Gens : ~triggered[g] /\ Unreported(m.to, g) > 0 }
+  //
+  //  Note that this is UNCONDITIONAL - it does not consult 'flushing' or the
+  //  plan-satisfied test.  Both rules report everything the node is sitting on,
+  //  whatever mode it is in, because the tree that work was being aggregated
+  //  for is going away.  The only guard is the model's Send(), which is empty
+  //  at the owner: the owner has no parent, and its subtree total is the answer
+  //  rather than a report.
+  //
+  // The target of each report is resolved HERE, inside the critical section and
+  //  while cur_plan is still the OLD record - which is what BarrierArrive's
+  //  unprimed Send()/ParentOf() means, and what S3 guarantees for free.
+  void BarrierImpl::report_held_locked(PendingSends &sends)
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    if(owner == Network::my_node_id) {
+      return;
+    }
+
+    const gen_t watermark = generation.load();
+    for(std::map<gen_t, Generation *>::iterator it = generations.begin();
+        it != generations.end(); ++it) {
+      // a generation this node already knows has triggered has nothing left to
+      //  collect (the model's ~triggered[g])
+      if(it->first <= watermark) {
+        continue;
+      }
+      if(it->second->holding()) {
+        record_report_locked(*(it->second), it->first, sends);
+      }
+    }
+  }
+
+  // ARRIVAL_PROTOCOL rule 4 - FLUSH IS PER GENERATION AND IDEMPOTENT.
+  //
+  // This is the shared core of rules 2, 3 and 4, which differ only in what
+  //  causes them (an over-arrival here, a 'direct' arriving at the owner, or a
+  //  flush announcement from our parent).  In every case:
+  //
+  //   * a node ALREADY flushing this generation changes nothing and sends
+  //     nothing.  THAT IS WHAT TERMINATES THE FAN-OUT - without the early out
+  //     the announcement would circulate around the tree forever.
+  //   * otherwise the flag goes on for THIS GENERATION ONLY, the announcement
+  //     is re-fanned to this node's children, and anything this node is
+  //     currently HOLDING for the generation is reported at once.  Reporting
+  //     held work on entry is the critical half: a node that has gone quiet
+  //     waiting on a completion condition its stale plan will never meet is
+  //     exactly the silence this protocol exists to break.
+  void BarrierImpl::enter_flush_locked(Generation &g, gen_t gen, PendingSends &sends)
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    if(g.flushing) {
+      return;
+    }
+    g.flushing = true;
+
+    // IMPLEMENTATION_PLAN section 5 - EAGER-FLUSH EPISODES.  One per generation
+    //  this node actually entered flush for; the early out above is what makes
+    //  it an episode count rather than a message count.
+    counters.flush_episodes++;
+
+    // ARRIVAL_PROTOCOL section 11.1 - GATHERING STARTS HERE.  At the owner,
+    //  entering flush is the one and only thing that says "my plan does not
+    //  describe reality": it happens on a 'direct' from a node the plan did not
+    //  predict (rule 3) and on an over-arrival at the owner itself (rule 2),
+    //  and never in steady state.  From this moment every report that reaches
+    //  the owner for this generation carries a (node,count) map, and the next
+    //  trigger turns those maps into the next plan.
+    if(owner == Network::my_node_id) {
+      plan_rebuild_pending = true;
+    }
+
+    // fan out to the children of the plan record AS IT IS NOW.  The targets are
+    //  resolved here, inside the critical section, so nothing that later
+    //  replaces 'cur_plan' can strand this subtree (S3).
+    // One fan PER GENERATION: rule 8's alteration path enters flush for every
+    //  affected open generation in a single action, so these accumulate.
+    if(!cur_plan.kids.empty()) {
+      sends.flushes.push_back(PendingFlush());
+      PendingFlush &pf = sends.flushes.back();
+      pf.gen = gen;
+      pf.to.insert(pf.to.end(), cur_plan.kids.begin(), cur_plan.kids.end());
+    }
+
+    // report whatever we are holding.  With 'flushing' now set, this test is
+    //  exactly the model's "not the owner and Unreported > 0".
+    if(should_report_locked(gen, g)) {
+      record_report_locked(g, gen, sends);
+    }
+  }
+
+  // ARRIVAL_PROTOCOL rule 8.3 - ISSUING AN ALTERATION PUTS THE NODE INTO EAGER
+  //  FLUSH FOR EVERY AFFECTED OPEN GENERATION.  This is the easy one to miss,
+  //  and removing it is a caught mutation (deadlock, not a safety violation):
+  //  a node whose arrivals bypass the tree can never satisfy its own plan
+  //  quota, so as a RELAY it would go silent and strand its children.
+  //
+  // Only generations this node already has a record for can have a flag set
+  //  here.  Later ones are covered by flush_mode_locked() consulting the
+  //  arrival floor, which is the same trick rule 6 uses for the generations it
+  //  cannot flag either.
+  void BarrierImpl::enter_flush_from_locked(gen_t from_gen, PendingSends &sends)
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    const gen_t watermark = generation.load();
+    for(std::map<gen_t, Generation *>::iterator it = generations.begin();
+        it != generations.end(); ++it) {
+      if((it->first < from_gen) || (it->first <= watermark)) {
+        continue;
+      }
+      enter_flush_locked(*(it->second), it->first, sends);
+    }
+  }
+
+  namespace {
+    // The decoded view of one 'newplan' payload - see BarrierNewPlanMessage for
+    //  the wire format.  Each child's record is a contiguous slice of the SAME
+    //  buffer, so forwarding is a copy of those bytes and never a re-encode.
+    struct PlanSubtree {
+      uint32_t quota = 0;
+      std::vector<NodeID> kids;
+      std::vector<std::pair<const unsigned char *, size_t>> kid_payload;
+    };
+
+    bool decode_plan_subtree(const void *data, size_t datalen, PlanSubtree &out)
+    {
+      const unsigned char *p = static_cast<const unsigned char *>(data);
+      if((p == 0) || (datalen < (2 * sizeof(uint32_t)))) {
+        return false;
+      }
+
+      uint32_t quota = 0;
+      uint32_t num_kids = 0;
+      memcpy(&quota, p, sizeof(uint32_t));
+      memcpy(&num_kids, p + sizeof(uint32_t), sizeof(uint32_t));
+      size_t off = 2 * sizeof(uint32_t);
+
+      // each child costs at least its own (node, length) header plus an empty
+      //  record, so a count above that is a truncated or corrupt payload and
+      //  must be rejected BEFORE it is used to size anything
+      if(num_kids > ((datalen - off) / (4 * sizeof(uint32_t)))) {
+        return false;
+      }
+
+      out.quota = quota;
+      out.kids.clear();
+      out.kid_payload.clear();
+      out.kids.reserve(num_kids);
+      out.kid_payload.reserve(num_kids);
+
+      for(uint32_t i = 0; i < num_kids; i++) {
+        if((datalen - off) < (sizeof(int32_t) + sizeof(uint32_t))) {
+          return false;
+        }
+        int32_t kid = 0;
+        uint32_t kid_bytes = 0;
+        memcpy(&kid, p + off, sizeof(int32_t));
+        off += sizeof(int32_t);
+        memcpy(&kid_bytes, p + off, sizeof(uint32_t));
+        off += sizeof(uint32_t);
+        if((datalen - off) < kid_bytes) {
+          return false;
+        }
+        out.kids.push_back(static_cast<NodeID>(kid));
+        out.kid_payload.push_back(
+            std::make_pair(p + off, static_cast<size_t>(kid_bytes)));
+        off += kid_bytes;
+      }
+
+      // a payload with trailing bytes is malformed, not merely generous
+      return (off == datalen);
+    }
+
+    // Fan-out of a constructed plan.  This is a shape choice, not a protocol
+    //  rule - the model verifies that ANY plan is safe to adopt - and 8 keeps a
+    //  few-thousand-node barrier at depth 4.
+    //
+    // It is overridable (-ll:barrier_plan_radix) because the tree DEPTH is what
+    //  makes the rule-10 race windows reachable: below ~radix+2 ranks every
+    //  plan is a flat owner->all tree with no relays, so parks, dead-plan
+    //  discards and stale edges are structurally impossible.  Radix 2 puts
+    //  relay trees at 4 ranks, which is what lets one workstation exercise the
+    //  paths TLC verified (tla/SCALE_TEST_PLAN.md).  Values below 2 are
+    //  clamped: radix 1 would make a chain of every node, and 0 is meaningless.
+    static size_t barrier_plan_radix(void)
+    {
+      static const size_t radix = []() -> size_t {
+        int configured = 0;
+        RuntimeImpl *runtime = get_runtime();
+        if(runtime != nullptr) {
+          ModuleConfig *core = runtime->get_module_config("core");
+          if((core != nullptr) &&
+             (core->get_property("barrier_plan_radix", configured) == REALM_SUCCESS) &&
+             (configured >= 2)) {
+            return static_cast<size_t>(configured);
+          }
+        }
+        return 8;
+      }();
+      return radix;
+    }
+
+    void append_u32(std::vector<unsigned char> &out, uint32_t v)
+    {
+      const unsigned char *p = reinterpret_cast<const unsigned char *>(&v);
+      out.insert(out.end(), p, p + sizeof(uint32_t));
+    }
+
+    // ARRIVAL_PROTOCOL section 11.4 - the other half of decode_plan_subtree.
+    //
+    // The tree is held as a flat array in k-ary heap order: 'tv[0]' is the
+    //  owner and the children of index i are i*radix+1 .. i*radix+radix.  That
+    //  makes "the subtree rooted at i" a pure index computation, so the
+    //  pre-order encoding below needs no auxiliary structure at all.
+    //
+    // Each child's record is written as a CONTIGUOUS, length-prefixed slice, so
+    //  the relay that receives it forwards its own children's slices verbatim -
+    //  it never re-encodes, and never has to understand anything below its own
+    //  depth.  The length is back-patched because it is not known until the
+    //  child's whole subtree has been written.
+    void encode_plan_subtree(size_t idx, const std::vector<NodeID> &tv,
+                             const std::vector<uint32_t> &quota, size_t radix,
+                             std::vector<unsigned char> &out)
+    {
+      const size_t first_kid = (idx * radix) + 1;
+      size_t num_kids = 0;
+      while((num_kids < radix) && ((first_kid + num_kids) < tv.size())) {
+        num_kids++;
+      }
+
+      append_u32(out, quota[idx]);
+      append_u32(out, static_cast<uint32_t>(num_kids));
+
+      for(size_t k = 0; k < num_kids; k++) {
+        const size_t kid_idx = first_kid + k;
+        append_u32(out, static_cast<uint32_t>(static_cast<int32_t>(tv[kid_idx])));
+        const size_t len_pos = out.size();
+        append_u32(out, 0); // back-patched below
+        const size_t start = out.size();
+        encode_plan_subtree(kid_idx, tv, quota, radix, out);
+        const uint32_t kid_bytes = static_cast<uint32_t>(out.size() - start);
+        memcpy(&out[len_pos], &kid_bytes, sizeof(uint32_t));
+      }
+    }
+  } // namespace
+
+  // ARRIVAL_PROTOCOL rule 5 - install a plan record.  Reached from action P
+  //  (the plan arrived and this node was free to take it) and from action I
+  //  step 5 (a plan that was PARKED is applied once the invalidation lands).
+  //
+  // The order inside here is load-bearing:
+  //
+  //   1. the fan-out to the NEW children is recorded from the payload, and each
+  //      child's slice is COPIED, because the active-message buffer is dead the
+  //      moment the handler returns;
+  //   2. held work is reported while cur_plan is still the OLD record.
+  //      BarrierArrive evaluates Send()/ParentOf() in the unprimed state, so those
+  //      reports are owed to the OLD parent - the node that has been collecting
+  //      for this subtree all along and whose childAcc already holds part of
+  //      it.  Re-aiming them at the new parent would let the same arrivals
+  //      reach the owner down two paths at once;
+  //   3. only then is the record replaced.
+  //
+  // 'flushing' is deliberately NOT set (BarrierArrive RecvNewPlan leaves it alone):
+  //  the new plan is authoritative, so the node can go back to aggregating.
+  void BarrierImpl::apply_plan_locked(uint32_t epoch, const void *data, size_t datalen,
+                                      NodeID parent, PendingSends &sends)
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    PlanSubtree sub;
+    if(!decode_plan_subtree(data, datalen, sub)) {
+      log_barrier.fatal() << "malformed barrier plan payload: " << me
+                          << " epoch=" << epoch << " bytes=" << datalen;
+      abort();
+    }
+
+    // (1) record the fan-out to the new children, copying each subtree slice
+    sends.fwd_plan_epoch = epoch;
+    for(size_t i = 0; i < sub.kids.size(); i++) {
+      PendingPlan pp;
+      pp.to = sub.kids[i];
+      pp.payload.assign(sub.kid_payload[i].first,
+                        sub.kid_payload[i].first + sub.kid_payload[i].second);
+      sends.plan_to.push_back(pp);
+    }
+
+    // (2) report held work with the OLD plan still in place
+    report_held_locked(sends);
+
+    // (3) switch
+    cur_plan.quota = sub.quota;
+    // MEMBERSHIP (section 3): only nodes with a non-zero expected contribution
+    //  are in a plan at all, so being sent a record IS membership.
+    cur_plan.inplan = true;
+    cur_plan.parent = parent;
+    cur_plan.kids = sub.kids;
+    my_epoch = epoch;
+
+    // A PLAN INSTALL NEVER CLEARS FLUSH (BarrierArrive, a caught mutation on
+    //  MCStale - installing a plan used to return open generations to planned
+    //  mode right here, and TLC kills it): the owner's deviation flush and the
+    //  newplan RACE, and when the install wins the flush is lost and the
+    //  generation strands behind a quota the new plan cannot meet.  A flushed
+    //  generation stays eager until IT TRIGGERS, which is naturally bounded -
+    //  the flag lives on the Generation record and dies with it.  New
+    //  generations start planned under whatever plan this node holds, so
+    //  nothing is sticky across the barrier's future.
+
+    // (4) RE-FAN THE FLUSH DOWN THE NEW CHILD LIST.  A flush announcement is
+    //  re-fanned by each recipient through the child list IT holds at the
+    //  moment it arrives, so an announcement that overtakes this plan on the
+    //  wire is fanned into the OLD subtree and never reaches the children this
+    //  node has just acquired.  Those children would then go back to
+    //  aggregating for a generation the owner is trying to drain.  The flush is
+    //  idempotent per generation (rule 4), so a child that already has it drops
+    //  this one and the fan-out still terminates.
+    if(!cur_plan.kids.empty()) {
+      const gen_t watermark = generation.load();
+      for(std::map<gen_t, Generation *>::const_iterator it = generations.begin();
+          it != generations.end(); ++it) {
+        if((it->first <= watermark) || !it->second->flushing) {
+          continue;
+        }
+        sends.flushes.push_back(PendingFlush());
+        PendingFlush &pf = sends.flushes.back();
+        pf.gen = it->first;
+        pf.to.insert(pf.to.end(), cur_plan.kids.begin(), cur_plan.kids.end());
+      }
+    }
+
+    log_barrier.info() << "installed barrier plan: " << me << " epoch=" << epoch
+                       << " quota=" << cur_plan.quota << " parent=" << parent
+                       << " kids=" << cur_plan.kids.size();
+  }
+
+  ////////////////////////////////////////////////////////////////////////
+  //
+  // ARRIVAL_PROTOCOL section 11.2 and 11.4 - CONSTRUCTION and DISTRIBUTION.
+  //  OWNER ONLY, called from inside the trigger critical section.
+  //
+  // 'agg' is the merged node -> arrival-count structure of section 11.2, and it
+  //  is a LOCAL of the caller: it was merged out of the generation record that
+  //  is about to be freed and it dies with the stack frame.  Section 11.3 is
+  //  satisfied by there being nowhere for it to persist, which is decision D9 -
+  //  a leak here would not fail loudly, it would just cost O(N) per barrier
+  //  forever, and that is the exact blow-up this design exists to avoid.
+  //
+  // THE ONE INVARIANT PLAN CONSTRUCTION MUST NOT BREAK:
+  //
+  //   sum of quotas <= the arrival count the owner will be waiting for
+  //
+  // Under-estimating a node's quota is SAFE - it over-arrives, rule 2 puts it
+  //  into eager flush, and everything it is holding comes out.  Over-estimating
+  //  is FATAL: a node below its quota is silent by design (that silence is the
+  //  aggregation), and if the plan asks for arrivals that never happen it stays
+  //  silent forever and the generation never triggers.  With the sum bounded,
+  //  total arrivals reaching the expected count forces at least one node either
+  //  over its quota or outside the plan entirely, and both of those are
+  //  deviation signals that break the silence.
+  //
+  // Because every entry in 'agg' is one node's own cumulative local total for a
+  //  generation that has just triggered, their sum is at most that generation's
+  //  arrival count - so the invariant holds by construction.  It is still
+  //  checked, because it is the one place a construction bug turns into a
+  //  hang instead of an assertion.
+  void BarrierImpl::build_new_plan_locked(const std::map<NodeID, int64_t> &agg,
+                                          int64_t tree_arrivals, PendingSends &sends)
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    const NodeID me_node = Network::my_node_id;
+
+    // IMPLEMENTATION_PLAN section 5 - PEAK AGGREGATION SIZE.  'agg' is a LOCAL
+    //  of the trigger path (D9), merged out of the generation record that is
+    //  about to be freed, so O(N) barriers each holding an O(N) participant map
+    //  is structurally impossible rather than merely avoided.  Nothing would
+    //  fail loudly if that ever stopped being true - it would just scale badly
+    //  - so this is the number that would show it.  Recorded before the
+    //  declines below, because a rebuild that is turned down still had to build
+    //  the map.
+    if(agg.size() > counters.agg_peak_entries) {
+      counters.agg_peak_entries = agg.size();
+    }
+
+    // (1) MEMBERSHIP (sections 3 and 11.2): ONLY nodes with a non-zero count
+    //     appear.  A node with no predicted arrivals is not a leaf, not a
+    //     relay, not anything - it is left permanently in eager-flush mode, and
+    //     that is what stops a relay ever waiting on a child that will never
+    //     speak.
+    //
+    //     The owner is the one exception: it is always the root, even with a
+    //     quota of zero, because it has to hold the top-level child list or
+    //     nothing can fan an invalidation or a flush into the tree at all.
+    //     (BarrierArrive's own scenarios do this - MCSeven.tla:52 gives node 0
+    //     'quota |-> 0, inplan |-> TRUE'.)
+    std::vector<NodeID> tv; // tv[0] is the owner; k-ary heap order
+    std::vector<uint32_t> quota;
+    int64_t total = 0;
+    // every arrival the maps ACCOUNT FOR, including the ones belonging to nodes
+    //  deliberately left out below.  This is what the completeness test weighs;
+    //  'total' is what the over-prediction test weighs.
+    int64_t gathered = 0;
+
+    tv.push_back(me_node);
+    quota.push_back(0);
+
+    for(std::map<NodeID, int64_t>::const_iterator it = agg.begin(); it != agg.end();
+        ++it) {
+      if(it->second <= 0) {
+        continue;
+      }
+      gathered += it->second;
+      // RULE 8.1 / MEMBERSHIP.  A node that has altered this barrier bypasses
+      //  the tree from its alteration's generation on, FOREVER (the alteration
+      //  is persistent), so its 'local_total' never moves again and any quota
+      //  this plan gave it would be unreachable.  'agg' is one PAST
+      //  generation's counts, so a node that altered for a LATER generation is
+      //  still in that evidence and would otherwise be re-admitted by every
+      //  rebuild - as a leaf, it strands its parent on rule 1's child-wait
+      //  forever; as a relay, it goes silent and strands its whole subtree.
+      //  Leaving it out costs only that its arrivals stay on the bypass path,
+      //  which is where rule 8.1 puts them anyway.
+      if(ts_bypass_nodes.count(it->first) != 0) {
+        log_barrier.info() << "excluding altered node from barrier plan: " << me
+                           << " node=" << it->first;
+        continue;
+      }
+      if(it->second > static_cast<int64_t>(UINT32_MAX)) {
+        log_barrier.info() << "declining barrier plan rebuild (count overflow): " << me
+                           << " node=" << it->first << " count=" << it->second;
+        return;
+      }
+      total += it->second;
+      if(it->first == me_node) {
+        quota[0] = static_cast<uint32_t>(it->second);
       } else {
-        log_barrier.info("adjustment must be deferred: %llx/%d (%llx)", ts, delta,
-                         pn->last_ts);
-        pn->pending[ts] += delta;
+        // LOAD-BEARING ORDERING: 'agg' is a std::map, so this appends in
+        //  ASCENDING NodeID order, and the heap parent of index i is
+        //  (i-1)/radix < i.  Every non-owner therefore gets a parent that is
+        //  either the owner or a node with a smaller NodeID, in this plan and
+        //  in every other one.  That is what keeps a report edge - including a
+        //  STALE one, left behind by a plan switch (Generation::report_to, and
+        //  a retired node still reporting to its old parent) - strictly
+        //  decreasing, and so what makes a cycle of them impossible.
+        tv.push_back(it->first);
+        quota.push_back(static_cast<uint32_t>(it->second));
       }
+    }
+
+    if(total <= 0) {
+      return;
+    }
+
+    // COMPLETENESS (section 11.2, "from that it has both the participant set
+    //  and the expected count per node, which is exactly a plan").  The merged
+    //  maps are the participant set only when EVERY participant was eager when
+    //  it reported, because only an eager-flush report carries a map (section
+    //  11.1).  A node that met its quota under a valid plan reports a bare
+    //  count and is then no longer holding anything, so the owner's flush
+    //  announcement - which is at least two hops behind a locally satisfied
+    //  quota, and is not even emitted until this critical section unlocks -
+    //  finds nothing left to re-report and that node contributes no (node,
+    //  count) pair at all.
+    //
+    // Building from partial evidence is SAFE (every omitted node is left
+    //  outside the plan and therefore permanently eager) but it is not a plan:
+    //  it invalidates nodes that were behaving correctly, and since those nodes
+    //  then report eagerly - with maps - while the ones just admitted report
+    //  bare counts, the NEXT rebuild gathers the complement and swaps the two
+    //  halves back.  The set can oscillate for the life of the barrier, paying
+    //  an invalidate and a newplan fan-out every generation and never reaching
+    //  the steady state the tree exists to provide.
+    //
+    // So: build only from evidence that accounts for every arrival that went
+    //  through the tree.  Declining costs nothing - the current plan survives
+    //  untouched (nothing has been retired at this point), the deviating node
+    //  stays on the eager path where rule 3 already puts it, and the next
+    //  deviation re-arms the rebuild.  A generation that genuinely cannot
+    //  complete under the stale plan forces a full flush before it triggers,
+    //  and that flush is exactly what makes the gathering complete.
+    if((tree_arrivals > 0) && (gathered != tree_arrivals)) {
+      log_barrier.info() << "declining barrier plan rebuild (partial evidence): " << me
+                         << " gathered=" << gathered << " of " << tree_arrivals;
+      return;
+    }
+
+    // THE INVARIANT, measured against the count this plan's FIRST generation
+    //  will actually be waiting for - not against 'base_arrival_count', which a
+    //  NEGATIVE alteration (rule 9) puts above the truth.  A later positive
+    //  alteration only raises expected(), which is the safe direction; a later
+    //  negative one invalidates the plan outright, which is what rule 9 is for.
+    const gen_t plan_from = generation.load() + 1;
+    const int64_t expected = expected_locked(plan_from);
+    if(total > expected) {
+      log_barrier.info() << "declining barrier plan rebuild (would over-predict): " << me
+                         << " sum=" << total << " expected=" << expected;
+      return;
+    }
+
+    // IMPLEMENTATION_PLAN section 5 - PLAN REBUILD FREQUENCY.  Counted past the
+    //  declines, so it measures plans actually installed: a steady workload
+    //  should build one and then stop.
+    counters.plan_rebuilds++;
+
+    const uint32_t new_epoch = next_epoch++;
+
+    // (2) RULE 6, FORWARD BEFORE FORGETTING.  The invalidation goes down the
+    //     tree BEING RETIRED, so its targets come from the CURRENT child list
+    //     and are resolved into 'sends' here, before step 3 replaces that list.
+    //     'my_epoch' is the epoch being retired, which is what the recipients
+    //     compare against.  With no plan yet there is nothing to retire, and a
+    //     plan an alteration already retired (rule 9) is not retired twice -
+    //     the second invalidation would be dropped as stale anyway.
+    if((my_epoch != 0) && (inval_epoch < my_epoch)) {
+      sends.fwd_inval_epoch = my_epoch;
+      sends.inval_to.insert(sends.inval_to.end(), cur_plan.kids.begin(),
+                            cur_plan.kids.end());
+    }
+
+    // (3) install the owner's own record.  'inval_epoch = new_epoch - 1' is
+    //     what BarrierArrive's Trigger does (:322-324): the owner is never sent its
+    //     own invalidation, so it retires the old epoch itself, which leaves
+    //     plan_retired_locked() false and lets it aggregate under the new plan
+    //     immediately.
+    cur_plan.quota = quota[0];
+    cur_plan.inplan = true;
+    cur_plan.parent = static_cast<NodeID>(-1);
+    cur_plan.kids.clear();
+    for(size_t k = 1; (k <= barrier_plan_radix()) && (k < tv.size()); k++) {
+      cur_plan.kids.push_back(tv[k]);
+    }
+    my_epoch = new_epoch;
+    inval_epoch = new_epoch - 1;
+
+    // (4) DISTRIBUTION (section 11.4): each child is sent ITS OWN SUBTREE, not
+    //     just an epoch number - its quota, its child list, and recursively
+    //     everything below it - because it has to be able to forward its own
+    //     children's records without asking anyone.
+    if(tv.size() > 1) {
+      sends.fwd_plan_epoch = new_epoch;
+      for(size_t k = 1; (k <= barrier_plan_radix()) && (k < tv.size()); k++) {
+        sends.plan_to.push_back(PendingPlan());
+        PendingPlan &pp = sends.plan_to.back();
+        pp.to = tv[k];
+        encode_plan_subtree(k, tv, quota, barrier_plan_radix(), pp.payload);
+      }
+    }
+
+    // (5) FLUSH EVERY GENERATION THAT STRADDLES THE SWITCH.
+    //
+    //     BarrierArrive's RecvInvalidate puts every untriggered generation the
+    //     node HAS STATE ON into eager flush at every node it reaches
+    //     (SubtreeKnown > 0, :452-456), and nothing takes it off again before
+    //     the trigger (RecvNewPlan leaves 'flushing' UNCHANGED, :510-514).
+    //     What that buys is the generations already IN FLIGHT when the tree
+    //     changed:
+    //     their counts were accumulated for the old shape, and the node the new
+    //     shape gives them to may have no record of them, no arrival of its own
+    //     yet, and a child-wait on a child that has already discharged that
+    //     generation to its OLD parent and will never speak again.
+    //
+    //     The invalidation covers that at each node for the generations that
+    //     node has a record for.  This covers it for the generations the OWNER
+    //     has a record for - which is where a subtree total that was forwarded
+    //     BEFORE the switch ends up - and it fans down the NEW child list, so
+    //     it reaches nodes that were nowhere near the old tree.  Together with
+    //     'saw_direct' (which makes a straddling report announce itself all the
+    //     way here rather than dying at a below-quota relay) that is every
+    //     generation any node can be sitting on.
+    //
+    //     This deliberately does NOT go through enter_flush_locked().  That
+    //     function is idempotent per generation - which is what terminates the
+    //     fan-out - so for a generation the owner was ALREADY flushing (the
+    //     usual case, since a 'direct' for it is often what motivated this
+    //     rebuild in the first place) it would do nothing at all, and the
+    //     announcement it did send went to the child list that has just been
+    //     replaced.  The whole point here is to re-announce down the NEW one.
+    //     It also avoids enter_flush_locked's plan_rebuild_pending side effect:
+    //     these flushes are the CONSEQUENCE of a rebuild, not a reason for
+    //     another one.  The owner never reports, so there is nothing else in
+    //     that function this needs.
+    if(!cur_plan.kids.empty()) {
+      const gen_t watermark = generation.load();
+      for(std::map<gen_t, Generation *>::iterator it = generations.begin();
+          it != generations.end(); ++it) {
+        if(it->first <= watermark) {
+          continue;
+        }
+        // ONLY GENERATIONS WITH STATE OR ALREADY IN FLUSH.  The spec's only
+        //  plan-switch flush is per-node at RecvInvalidate, conditioned on
+        //  SubtreeKnown > 0 (BarrierArrive :452-456); a no-activity generation is
+        //  governed by the plan record alone (:448-451), so converting it to
+        //  eager mode here forfeits its aggregation for nothing.  A record CAN
+        //  exist with zero state - add_waiter creates one for any future
+        //  generation a local task waits on - and it is skipped.
+        //
+        // A record that is ALREADY FLUSHING is re-fanned even with no counts
+        //  yet: a count-free flush signal (retroactive case 3) can reach the
+        //  owner before the counts it announces, and this loop is the ONLY
+        //  re-announcement down the NEW child list - enter_flush_locked's
+        //  idempotence means no later signal for this generation will ever
+        //  fan again.
+        if((it->second->subtree_known() <= 0) && !it->second->flushing) {
+          continue;
+        }
+        if(!it->second->flushing) {
+          it->second->flushing = true;
+          counters.flush_episodes++;
+        }
+        sends.flushes.push_back(PendingFlush());
+        PendingFlush &pf = sends.flushes.back();
+        pf.gen = it->first;
+        pf.to.insert(pf.to.end(), cur_plan.kids.begin(), cur_plan.kids.end());
+      }
+    }
+
+    log_barrier.info() << "built barrier plan: " << me << " epoch=" << new_epoch
+                       << " nodes=" << tv.size() << " arrivals=" << total
+                       << " own_quota=" << cur_plan.quota
+                       << " kids=" << cur_plan.kids.size();
+  }
+
+  // 'mutex' must NOT be held (S2).  Reads only its argument and immutable
+  //  members (S3).
+  void BarrierImpl::emit_pending_sends(const PendingSends &sends)
+  {
+    if(sends.report.to != static_cast<NodeID>(-1)) {
+      emit_report(sends.report);
+    }
+    for(std::vector<PendingReport>::const_iterator it = sends.more_reports.begin();
+        it != sends.more_reports.end(); ++it) {
+      emit_report(*it);
+    }
+
+    for(std::vector<PendingFlush>::const_iterator fit = sends.flushes.begin();
+        fit != sends.flushes.end(); ++fit) {
+      for(std::vector<NodeID>::const_iterator it = fit->to.begin(); it != fit->to.end();
+          ++it) {
+        log_barrier.info() << "sending barrier flush: " << me << "/" << fit->gen
+                           << " dest=" << *it;
+        BarrierFlushMessage::send_request(*it, me.id, fit->gen);
+      }
+    }
+
+    // rule 8 - the alteration and the bypassed arrival both go STRAIGHT TO THE
+    //  OWNER.  'owner' is write-once, so reading it here honours S3.
+    if(sends.has_alter) {
+      log_barrier.info() << "sending barrier alter: " << me << "/" << sends.alter.gen
+                         << " delta=" << sends.alter.delta << " ts=" << sends.alter.ts
+                         << " prev_ts=" << sends.alter.prev_ts << " dest=" << owner;
+      BarrierAlterMessage::send_request(owner, me.id, sends.alter.gen, sends.alter.delta,
+                                        sends.alter.ts, sends.alter.prev_ts);
+    }
+
+    if(sends.has_ts_arrival) {
+      log_barrier.info() << "sending barrier ts arrival: " << me << "/"
+                         << sends.ts_arrival.gen << " val=" << sends.ts_arrival.val
+                         << " ts=" << sends.ts_arrival.ts
+                         << " local_ts=" << sends.ts_arrival.local_ts
+                         << " dest=" << owner;
+      BarrierTsArrivalMessage::send_request(
+          owner, me.id, sends.ts_arrival.gen, sends.ts_arrival.val, sends.ts_arrival.ts,
+          sends.ts_arrival.local_ts, sends.ts_arrival.poisoned);
+    }
+
+    if(sends.fwd_inval_epoch != 0) {
+      for(std::vector<NodeID>::const_iterator it = sends.inval_to.begin();
+          it != sends.inval_to.end(); ++it) {
+        log_barrier.info() << "sending barrier invalidate: " << me
+                           << " epoch=" << sends.fwd_inval_epoch << " dest=" << *it;
+        BarrierInvalidateMessage::send_request(*it, me.id, sends.fwd_inval_epoch);
+      }
+    }
+
+    if(sends.fwd_plan_epoch != 0) {
+      for(std::vector<PendingPlan>::const_iterator it = sends.plan_to.begin();
+          it != sends.plan_to.end(); ++it) {
+        log_barrier.info() << "sending barrier newplan: " << me
+                           << " epoch=" << sends.fwd_plan_epoch << " dest=" << it->to
+                           << " bytes=" << it->payload.size();
+        BarrierNewPlanMessage::send_request(it->to, me.id, sends.fwd_plan_epoch,
+                                            it->payload.data(), it->payload.size());
+      }
+    }
+
+    // NOTIFICATION_PROTOCOL action T - the multicast notification.  Every byte
+    //  of it, INCLUDING THE TARGET SET, was materialised inside the critical
+    //  section (S3): the target set is the pre-shrink snapshot, so nothing that
+    //  has happened to 'sub_set' since can strand a departing node.
+    if(sends.notify.valid) {
+      log_barrier.info() << "sending barrier notify: " << me << "/" << sends.notify.prev
+                         << " -> " << sends.notify.wm << " sv=" << sends.notify.set_ver
+                         << " targets=" << sends.notify.targets.size()
+                         << " pois=" << sends.notify.poison.size()
+                         << " dep=" << sends.notify.departing.size();
+      BarrierNotifyMessage::send_request(sends.notify.targets, me.id, sends.notify.wm,
+                                         sends.notify.prev, sends.notify.set_ver,
+                                         sends.notify.shrink_hint, sends.notify.poison,
+                                         sends.notify.departing);
+    }
+
+    // NOTIFICATION_PROTOCOL rule 8 - the departure intent.  UNICAST to the
+    //  owner, deliberately not aggregated up the multicast ack tree (that tree
+    //  carries no payload today, and adding one for a single speculative user
+    //  is out of scope).  'owner' is write-once, so reading it here honours S3.
+    if(sends.has_depart) {
+      log_barrier.info() << "sending barrier depart: " << me << " dest=" << owner;
+      BarrierDepartMessage::send_request(owner, me.id, Network::my_node_id);
+    }
+
+    // NOTIFICATION_PROTOCOL rule 5 - the pull.  'owner' is write-once, so
+    //  reading it here honours S3.
+    if(sends.has_subscribe) {
+      log_barrier.info() << "subscribing to barrier "
+                         << make_barrier(sends.subscribe_need)
+                         << " lk=" << sends.subscribe_lk << " dest=" << owner;
+      BarrierSubscribeMessage::send_request(owner, me.id, sends.subscribe_need,
+                                            sends.subscribe_lk, Network::my_node_id);
     }
   }
 
-  static inline void get_broadcast_targets(NodeID local, int num_peers, int radix,
-                                           std::vector<NodeID> &broadcast_targets)
+  void BarrierImpl::emit_report(const PendingReport &r)
   {
-    assert(broadcast_targets.empty());
-    for(int i = 1; i <= radix; i++) {
-      NodeID target = local * radix + i;
-      if(num_peers <= (target - 1))
+    log_barrier.info() << "sending barrier " << (r.is_direct ? "direct" : "report")
+                       << ": " << me << "/" << r.gen << " val=" << r.val
+                       << " dest=" << r.to << " map=" << r.flush_map.size()
+                       << " poisoned=" << r.poisoned;
+    BarrierReportMessage::send_request(r.to, me.id, r.gen, r.val, Network::my_node_id,
+                                       r.is_direct, r.poisoned, r.flush_map.data(),
+                                       r.flush_map.size());
+  }
+
+  ////////////////////////////////////////////////////////////////////////
+  //
+  // NOTIFICATION_PROTOCOL - poison, the watermark, and the pull.
+  //
+
+  // LOCK FREE (decision Q3/D7), and identical to
+  //  GenEventImpl::is_generation_poisoned.  The acquire load of the count
+  //  synchronises with the release store in add_poison_locked, so every slot
+  //  below the observed count was written before that store; slots are
+  //  append-only and never rewritten, so a concurrent later append can only
+  //  extend the array beyond where this scan stops.
+  bool BarrierImpl::is_generation_poisoned(gen_t gen) const
+  {
+    const int npg_cached = num_poisoned_generations.load_acquire();
+    if(REALM_LIKELY(npg_cached == 0)) {
+      return false;
+    }
+    for(int i = 0; i < npg_cached; i++) {
+      if(poisoned_generations[i] == gen) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // Caller MUST hold 'mutex'.  Idempotent - a notification and a subscribe
+  //  reply can both name the same generation, and rule 5's "merge, never
+  //  substitute" makes duplicates the normal case rather than the exception.
+  void BarrierImpl::add_poison_locked(gen_t gen)
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    if(is_generation_poisoned(gen)) {
+      return;
+    }
+    const int npg = num_poisoned_generations.load();
+    if(npg >= POISONED_GENERATION_LIMIT) {
+      // decision Q3: there is no representation that stays lock-free past the
+      //  cap, and silently forgetting a poisoned generation would wake a waiter
+      //  with the wrong poison status - one of the three failure modes this
+      //  protocol exists to prevent.
+      log_barrier.fatal() << "barrier poisoned more than " << POISONED_GENERATION_LIMIT
+                          << " times: " << me << "/" << gen;
+      std::abort();
+    }
+    if(poisoned_generations == nullptr) {
+      // allocated at full size ONCE and never reallocated, so a lock-free
+      //  reader never sees a dangling array
+      poisoned_generations = new gen_t[POISONED_GENERATION_LIMIT];
+    }
+    // plain store - this slot is not published until the count is
+    poisoned_generations[npg] = gen;
+    num_poisoned_generations.store_release(npg + 1);
+  }
+
+  // Caller MUST hold 'mutex'.  tla/STATE_AND_LOCKING.md section 3.5: the poison
+  //  slots are published BEFORE the watermark, so a lock-free reader that sees
+  //  the new watermark necessarily sees the poison that goes with it.
+  void BarrierImpl::publish_watermark_locked(gen_t wm, const gen_t *poison,
+                                             size_t num_poisoned,
+                                             EventWaiter::EventWaiterList &clean,
+                                             EventWaiter::EventWaiterList &poisoned)
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    for(size_t i = 0; i < num_poisoned; i++) {
+      add_poison_locked(poison[i]);
+    }
+    generation.store_release(wm);
+
+    // ARRIVAL_PROTOCOL section 8.8 - a non-owner reclaims its own alteration
+    //  state here, for the same reason the owner reclaims its in
+    //  check_triggers_locked: an arrival can only ever name a breakpoint above
+    //  the watermark.
+    prune_alter_state_locked(wm);
+
+    while(!generations.empty()) {
+      std::map<gen_t, Generation *>::iterator it = generations.begin();
+      if(it->first > wm) {
         break;
-      broadcast_targets.push_back(target - 1);
+      }
+      if(is_generation_poisoned(it->first)) {
+        poisoned.absorb_append(it->second->local_waiters);
+      } else {
+        clean.absorb_append(it->second->local_waiters);
+      }
+      delete it->second;
+      generations.erase(it);
+    }
+
+    // external waiters are signalled INSIDE the outer section - that is what
+    //  pairs with the hand-over-hand handoff in external_wait
+    if(has_external_waiters) {
+      has_external_waiters = false;
+      AutoLock<KernelMutex> al2(external_waiter_mutex);
+      external_waiter_condvar.broadcast();
     }
   }
 
-  void BarrierImpl::broadcast_trigger(
-      const std::vector<RemoteNotification> &ordered_notifications,
-      const std::vector<NodeID> &broadcast_targets, EventImpl::gen_t oldest_previous,
-      EventImpl::gen_t broadcast_previous, EventImpl::gen_t first_generation,
-      NodeID migration_target, unsigned base_arrival_count, ReductionOpID redopid,
-      const void *data, size_t datalen, bool include_notifications)
+  // the model's 'waiting[n] # {}'
+  //
+  // BarrierNotify evaluates rule 6 over the waiter set AFTER the watermark has
+  //  moved - 'w2 == { g \in waiting[m.to] : g > nk }' (:146) - and 'waiting[n]'
+  //  loses a generation only when 'known[n]' actually REACHES it.  Every test
+  //  below is therefore against the CURRENT watermark, and every consultation
+  //  has to leave a trace that survives one.
+  //
+  // 'gen_subscribed' is that trace, and it is the only one an external waiter
+  //  or a bare Event::subscribe() leaves:
+  //
+  //   * external_wait / external_timedwait push nothing into any
+  //     'local_waiters' list; they set 'has_external_waiters', which is a
+  //     WAKE-UP LATCH that publish_watermark_locked CLEARS when it broadcasts.
+  //     Both rule-6 sites run publish_watermark_locked earlier in the SAME
+  //     critical section, and the woken thread cannot re-arm the latch until
+  //     that section releases 'mutex' - so reading the latch there is a
+  //     guaranteed false negative, and the node is dropped from the subscriber
+  //     set holding a waiter that will never be told (NoStranded, :261).
+  //   * subscribe() records nothing else at all: a node that subscribes and
+  //     then polls has_triggered() - which is the documented use of
+  //     Event::subscribe, and is the lock-free carve-out that deliberately
+  //     records no consultation - would otherwise be invisible here.
+  //
+  // It is an OVER-approximation: remove_waiter does not lower it, so a node can
+  //  stay subscribed longer than it strictly needs to.  That costs bandwidth
+  //  and never correctness, which is the same asymmetry rule 3 rests on.
+  bool BarrierImpl::has_waiters_locked(void) const
   {
-    for(const NodeID target : broadcast_targets) {
-      EventImpl::gen_t trigger_gen = ordered_notifications[target].trigger_gen;
-
-      const char *reduce_data_ptr = static_cast<const char *>(data);
-      size_t remaining_data_size = datalen;
-
-      if(datalen == 0 && redopid != 0) {
-        reduce_data_ptr =
-            (data) ? static_cast<const char *>(data) +
-                         ((broadcast_previous - oldest_previous) * redop->sizeof_lhs)
-                   : nullptr;
-        remaining_data_size = (trigger_gen - broadcast_previous) * redop->sizeof_lhs;
+    REALM_BARRIER_ASSERT_LOCKED();
+    if(has_external_waiters) {
+      return true;
+    }
+    const gen_t watermark = generation.load();
+    if(gen_subscribed.load() > watermark) {
+      return true;
+    }
+    for(std::map<gen_t, Generation *>::const_iterator it = generations.begin();
+        it != generations.end(); ++it) {
+      if(it->first <= watermark) {
+        continue;
       }
-
-      BarrierTriggerMessageArgs trigger_args;
-      trigger_args.internal.trigger_gen = trigger_gen;
-      trigger_args.internal.previous_gen = ordered_notifications[target].previous_gen;
-      trigger_args.internal.first_generation = first_generation;
-      trigger_args.internal.redop_id = redopid;
-      trigger_args.internal.migration_target = migration_target;
-      trigger_args.internal.base_arrival_count = base_arrival_count;
-      trigger_args.internal.broadcast_index = target + 1;
-
-      const size_t header_size =
-          sizeof(BarrierTriggerMessageArgsInternal) + sizeof(size_t);
-
-      BarrierTriggerPayload payload;
-      payload.remotes = ordered_notifications;
-
-      if(remaining_data_size > 0) {
-        payload.reduction.insert(payload.reduction.end(), reduce_data_ptr,
-                                 reduce_data_ptr + remaining_data_size);
+      if(!it->second->local_waiters.empty()) {
+        return true;
       }
+    }
+    return false;
+  }
 
-      Serialization::DynamicBufferSerializer dbs_first(remaining_data_size + header_size);
-      bool ok = dbs_first & trigger_args;
-      assert(ok);
-      ok = dbs_first & payload;
-      assert(ok);
+  BarrierImpl::gen_t BarrierImpl::subscribe_need_locked(void) const
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    const gen_t watermark = generation.load();
+    const gen_t needed = gen_subscribed.load();
+    return (needed > watermark) ? needed : (watermark + 1);
+  }
 
-      size_t max_payload_size = barrier_comm->recommend_max_payload(
-          ordered_notifications[target].node, sizeof(BarrierTriggerMessage));
+  // NOTIFICATION_PROTOCOL action C step 4.  No rule-7 guard: the model's
+  //  Consult (BarrierNotify:122-126) has none, because 'member' moving to
+  //  PENDING is what suppresses the duplicate.  Guarding this on
+  //  'pull_outstanding' instead would let a consultation for a higher
+  //  generation be swallowed by an in-flight pull that does not cover it.
+  void BarrierImpl::consult_subscribe_locked(PendingSends &sends)
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    // RULE 8 step 3 - THE CONSULTATION SIGNAL, recorded BEFORE any early out.
+    //  A consultation that needs no message is still evidence that this node
+    //  cares about the barrier, and the idle counter is the only thing keeping
+    //  it in the owner's set.  This is also the whole of the signal for
+    //  external_wait / external_timedwait, which reach it through subscribe().
+    note_consultation_locked();
 
-      barrier_comm->trigger(ordered_notifications[target].node, me.id,
-                            dbs_first.get_buffer(), dbs_first.bytes_used(),
-                            max_payload_size);
+    if(owner == Network::my_node_id) {
+      return;
+    }
+    if(member != MEMBER_NO) {
+      return;
+    }
+    // rule 8 - coming back after having asked to leave is the churn signal
+    note_rejoin_locked();
+    member = MEMBER_PENDING;
+    pull_outstanding = true;
+    pull_deferred = false;
+    sends.has_subscribe = true;
+    sends.subscribe_lk = generation.load();
+    sends.subscribe_need = subscribe_need_locked();
+  }
+
+  // NOTIFICATION_PROTOCOL action N step 5 - the RECOVERY pull, rule 7 gated.
+  void BarrierImpl::record_pull_locked(PendingSends &sends)
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    if(owner == Network::my_node_id) {
+      return;
+    }
+    if(pull_outstanding) {
+      // RULE 7 - at most one outstanding pull.  The in-flight subscribe carries
+      //  an 'lk' at or below what a new one would, so its reply is a superset
+      //  of what this pull would ask for... but only until the OWNER consumes
+      //  it.  'pull_outstanding' stays set until the reply lands, which is
+      //  longer than the model's window, so the request is remembered and
+      //  re-issued there rather than dropped.
+      pull_deferred = true;
+      return;
+    }
+    pull_outstanding = true;
+    pull_deferred = false;
+    sends.has_subscribe = true;
+    sends.subscribe_lk = generation.load();
+    sends.subscribe_need = subscribe_need_locked();
+  }
+
+  ////////////////////////////////////////////////////////////////////////
+  //
+  // NOTIFICATION_PROTOCOL rule 8 - DEPARTURE HYSTERESIS.
+  //
+  // PERFORMANCE ONLY, and the one part of either protocol that is deliberately
+  //  NOT MODELLED (NOTIFICATION_PROTOCOL section 8.2).  BarrierNotify lets
+  //  'Depart' fire on any eligible node at any time and lets 'Trigger' apply
+  //  ANY subset of the collected requests, which is strictly more general than
+  //  any tuning - so no choice of K, J or shrink policy can be wrong, and
+  //  nothing below can produce anything worse than wasted bandwidth.  What
+  //  carries correctness is rule 6 (a node removed while holding a waiter
+  //  re-subscribes at once, verified) and the pull path, which has to exist
+  //  anyway.
+  //
+
+  // Action C step 3 - THE CONSULTATION SIGNAL.
+  //
+  // Idleness is measured as the WATERMARK DELTA since this node last consulted
+  //  the barrier, NOT as a count of notifications received.  That distinction
+  //  is the point: the owner coalesces a whole contiguous run of triggers into
+  //  a single delta notification whenever it can (action T), so counting
+  //  messages would make a busy barrier look idle exactly when it is busiest.
+  //
+  // Consulting is add_waiter, subscribe, and external_wait / external_timedwait
+  //  (which reach this through subscribe).  It is emphatically NOT
+  //  has_triggered(): that stays one lock-free acquire load with no member
+  //  write of any kind, and putting this signal on it is the regression
+  //  tla/STATE_AND_LOCKING.md section 4 spells out.  Every caller of this
+  //  function is already holding 'mutex' for other reasons.
+  void BarrierImpl::note_consultation_locked(void)
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    last_consult_wm = generation.load();
+    // whatever this node asked for while it believed itself idle, it is not
+    //  idle now.  This is also what makes a DECLINED request eventually
+    //  retryable without any acknowledgement from the owner.
+    depart_outstanding = false;
+  }
+
+  // A node that had asked to leave wants back in.  This is the first metric
+  //  IMPLEMENTATION_PLAN section 5 asks for ("leave->rejoin cycles per
+  //  barrier; near zero is the expectation"), and it is the same signal the
+  //  adaptation uses: a rejoin within DEPART_CHURN_WINDOW generations means K
+  //  was too small for this barrier's access pattern, so K doubles.
+  //
+  // 'last_depart_wm' is the guard, so a node that has never asked to leave -
+  //  including one subscribing for the very first time - is never counted.
+  void BarrierImpl::note_rejoin_locked(void)
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    // 0 is an unambiguous "never asked": a departure cannot fire below
+    //  watermark DEPART_K_INITIAL, because the eligibility threshold is at
+    //  least K generations of watermark movement.
+    if(last_depart_wm == 0) {
+      return;
+    }
+
+    const gen_t wm = generation.load();
+    counters.leave_rejoin_cycles++;
+    if((wm - last_depart_wm) <= DEPART_CHURN_WINDOW) {
+      counters.churn_backoffs++;
+      if(depart_K < DEPART_K_MAX) {
+        depart_K = ((depart_K * 2) < DEPART_K_MAX) ? (depart_K * 2) : DEPART_K_MAX;
+      }
+      log_barrier.info() << "barrier departure churn: " << me << " wm=" << wm
+                         << " asked_to_leave_at=" << last_depart_wm
+                         << " new_K=" << depart_K;
+    }
+    last_depart_wm = 0;
+  }
+
+  // Action N step 6 / action RP - the eligibility test.  It lives where the
+  //  WATERMARK MOVES, because that is the unit the idle counter is measured in;
+  //  it is not a timer and there is nothing to poll.
+  //
+  // Every guard here is an optimisation.  The "do not depart while holding a
+  //  waiter" one in particular is the model's single NEGATIVE CONTROL: removing
+  //  it was checked and found benign, so it is here to reduce churn and for no
+  //  other reason.  It is NOT sufficient on its own either - a waiter can be
+  //  registered after this fires and before the owner applies the shrink -
+  //  which is exactly why rule 6's recovery is the correctness rule.
+  void BarrierImpl::consider_departure_locked(PendingSends &sends)
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    if(owner == Network::my_node_id) {
+      // the owner is never in its own subscriber set
+      return;
+    }
+    if(member != MEMBER_YES) {
+      // not covered, or a pull is still in flight - either way there is nothing
+      //  to give up, and asking to leave while PENDING would race the reply
+      //  that is about to add us
+      return;
+    }
+    if(pull_outstanding) {
+      // A node that is asking the owner for the watermark is not idle, and
+      //  action N step 5 can record a GAP pull without ever moving 'member' off
+      //  MEMBER_YES - so without this guard one critical section could emit
+      //  both a subscribe and a departure, and whichever the owner happened to
+      //  process second would win.  Cleared by the reply, where the test is
+      //  re-run, so nothing is lost by waiting.
+      return;
+    }
+    if(depart_outstanding) {
+      // one request per idle episode.  A DECLINED request is simply never
+      //  retried until this node consults again, which is what keeps a machine
+      //  full of idle nodes from re-asking every generation.
+      return;
+    }
+    if(has_waiters_locked()) {
+      return;
+    }
+
+    const gen_t wm = generation.load();
+    // THE STAGGER, and it is expressed in GENERATIONS rather than in time, so
+    //  the protocol stays feed-forward and needs no timer.  Phase changes
+    //  retire many nodes at once, so this is load bearing rather than
+    //  defensive: without it the owner takes an O(N) unicast burst inside a
+    //  single generation.  J is sized for spike smoothing and not for
+    //  asymptotics - the subscribe path is ALREADY O(N) unicast, so an O(N)
+    //  unsubscribe burst is not a new complexity class.
+    const gen_t threshold =
+        depart_K + static_cast<gen_t>(Network::my_node_id % DEPART_STAGGER_J);
+    if((wm - last_consult_wm) < threshold) {
+      return;
+    }
+
+    if(!shrink_hint) {
+      // rule 8's advisory byte.  The owner's cost test declined the last shrink
+      //  it weighed, so this request would only be declined as well; suppressing
+      //  it saves the round trip and keeps this node's single request for a
+      //  moment when it might actually be granted.
+      counters.departs_suppressed++;
+      return;
+    }
+
+    depart_outstanding = true;
+    last_depart_wm = wm;
+    counters.departs_sent++;
+    sends.has_depart = true;
+  }
+
+  namespace {
+    // A nominal per-delivery cost, in bytes, for the cost test below.  Only its
+    //  RATIO to a target encoding's size matters, and the whole comparison is a
+    //  heuristic: NOTIFICATION_PROTOCOL section 8.4 is explicit that what is
+    //  verified is that ANY shrink the owner chooses is safe, not that it
+    //  chooses well.
+    const size_t MULTICAST_ENVELOPE_COST_BYTES = 64;
+
+    // What EncodedMulticastTargets::encode() would produce, WITHOUT producing
+    //  it: encode() evaluates every representation that can express the set and
+    //  keeps the smallest, and encoded_size() answers that per kind in
+    //  O(num_ranges) with no allocation at all.  This runs inside 'mutex', so
+    //  not allocating is worth the loop.
+    size_t best_encoded_size(const MulticastTargetSet &targets, NodeID num_nodes)
+    {
+      size_t best = 0;
+      for(size_t k = 0; k < MULTICAST_ENCODING_KINDS; k++) {
+        const size_t sz = EncodedMulticastTargets::encoded_size(
+            targets, num_nodes, static_cast<MulticastTargetEncoding>(k));
+        // 0 means "this kind cannot represent this set"
+        if((sz != 0) && ((best == 0) || (sz < best))) {
+          best = sz;
+        }
+      }
+      return best;
+    }
+
+    // The scalar rule 3's cost test compares:
+    //
+    //    cost(S) = |S| * (ENVELOPE + encoded_size(S))
+    //
+    // The two factors are the two quantities the rule names - "bytes and
+    //  deliveries" - and the PRODUCT is not an accident.  The multicast layer
+    //  plans a fresh forwarding tree from the encoded set on every send and
+    //  every hop carries a target encoding, so the encoding is paid ONCE PER
+    //  DELIVERY rather than once per multicast.  That is precisely why dropping
+    //  scattered nodes from an ALL_NODES set can LOSE: it trades away a handful
+    //  of deliveries and buys a per-hop bitmap paid |S| times over.
+    size_t multicast_cost(const MulticastTargetSet &targets, NodeID num_nodes)
+    {
+      if(targets.empty()) {
+        return 0;
+      }
+      return targets.size() *
+             (MULTICAST_ENVELOPE_COST_BYTES + best_encoded_size(targets, num_nodes));
+    }
+  } // namespace
+
+  // OWNER ONLY - RULE 3's COST TEST.  "Adds are mandatory, removals are
+  //  discretionary": refusing an add strands a waiter, refusing a removal only
+  //  costs bandwidth, and that asymmetry is the entire licence for this
+  //  function to say no.  A declined removal is simply a publication in which
+  //  the node still appears - no message, no state, no recovery needed.
+  //
+  // All-or-nothing on the requested set.  Rule 3 permits ANY subset R, so
+  //  taking either the whole of 'departing' or none of it is a legal choice and
+  //  is the simple one; searching for the best-paying subset is not justified
+  //  by anything measured.
+  bool BarrierImpl::shrink_pays_locked(const MulticastTargetSet &departing) const
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    if(departing.empty()) {
+      return false;
+    }
+
+    MulticastTargetSet after = sub_set;
+    for(MulticastTargetSet::const_iterator it = departing.begin(); it != departing.end();
+        ++it) {
+      after.remove(*it);
+    }
+
+    const NodeID num_nodes = Network::max_node_id + 1;
+    return multicast_cost(after, num_nodes) < multicast_cost(sub_set, num_nodes);
+  }
+
+  // 'mutex' must NOT be held (S2)
+  /*static*/ void BarrierImpl::deliver_waiters(EventWaiter::EventWaiterList &clean,
+                                               EventWaiter::EventWaiterList &poisoned,
+                                               TimeLimit work_until)
+  {
+    if(!clean.empty()) {
+      get_runtime()->event_triggerer.trigger_event_waiters(clean, false, work_until);
+    }
+    if(!poisoned.empty()) {
+      get_runtime()->event_triggerer.trigger_event_waiters(poisoned, true, work_until);
     }
   }
+
+  // OWNER ONLY.  D4: on the scalable path every accumulator counts UP, so the
+  //  test is "have we accounted for exactly the arrivals we expect", never the
+  //  legacy path's count-down.  The owner's accepted total is child_sum - the
+  //  model's ownerAcc[g] - which the report handler maintains by REPLACING each
+  //  child's previous contribution.
+  bool BarrierImpl::generation_complete_locked(gen_t gen, const Generation &g) const
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    // expected(gen) is base_arrival_count until somebody alters the barrier,
+    //  so both tests below are exactly what they were before stage C6 for a
+    //  barrier nobody alters.
+    if(redop_id != 0) {
+      // legacy/reduction path: the count-down convention stays here (D4)
+      return (expected_locked(gen) + g.unguarded_delta) == 0;
+    }
+    // the model's ownerAcc[g] + localTotal[Owner][g] + TsTotal(g) = expected[g]
+    return (g.local_total + g.child_sum + g.ts_acc) == expected_locked(gen);
+  }
+
+  // OWNER ONLY.  Drains the contiguous run of complete generations.  Nothing is
+  //  sent and no waiter is run here (S2) - the caller emits after the unlock.
+  EventImpl::gen_t BarrierImpl::check_triggers_locked(
+      EventWaiter::EventWaiterList &local_notifications,
+      EventWaiter::EventWaiterList &poisoned_notifications,
+      std::vector<RemoteNotification> &remote_notifications, gen_t &oldest_previous,
+      PendingSends &sends)
+  {
+    REALM_BARRIER_ASSERT_LOCKED();
+    gen_t trigger_gen = 0;
+
+    // BarrierNotify's 'Trigger' shares this section (action T).  'prev' has to
+    //  be the watermark BEFORE the whole contiguous chain, so it is captured
+    //  here rather than inside the drain: coalescing several triggers into one
+    //  delta notification is explicitly supported.
+    const gen_t old_watermark = generation.load();
+    // the generations in (old_watermark, trigger_gen] that were poisoned, which
+    //  is exactly what the notification will carry (rule 4: the poison WITHIN
+    //  the announced range, so the message never grows with the barrier's
+    //  poison history)
+    std::vector<gen_t> newly_poisoned;
+
+    // ARRIVAL_PROTOCOL section 11.2/11.3 - the aggregation structure, and it is
+    //  a LOCAL.  It is merged out of each drained generation's flush maps at
+    //  the last moment those maps exist, and it is destroyed when this function
+    //  returns.  There is deliberately no member to forget (D9).
+    std::map<NodeID, int64_t> agg;
+    bool have_agg = false;
+    // the arrivals the gathered generation took THROUGH THE TREE, which is what
+    //  a complete set of maps has to add up to (section 11.2).  Bypassed
+    //  arrivals (rule 8.1) never touch a 'local_total' and so are in no map.
+    int64_t agg_tree_arrivals = 0;
+
+    std::map<gen_t, Generation *>::iterator it = generations.begin();
+    while((it != generations.end()) && (it->first == (generation.load() + 1)) &&
+          generation_complete_locked(it->first, *(it->second))) {
+      // Gather from a generation the owner was in FLUSH mode for - those are
+      //  the only ones whose reports carried per-node maps.  The highest one
+      //  that yields anything wins OUTRIGHT rather than being merged in:
+      //  counts are per generation, so combining two generations' maps would
+      //  describe an arrival pattern that never happened.
+      // 'flush_mode_locked' and not the bare 'flushing' flag: an alteration
+      //  retires the plan (rule 9) rather than setting a per-generation flag,
+      //  and a retired plan is exactly the state in which every node - and so
+      //  every report reaching us - is eager and carrying a map.
+      if((redop_id == 0) && plan_rebuild_pending &&
+         flush_mode_locked(it->first, *(it->second))) {
+        std::map<NodeID, int64_t> merged;
+        merge_counts_locked(*(it->second), merged);
+        if(!merged.empty()) {
+          agg.swap(merged);
+          have_agg = true;
+          // this generation completed, so its accounting is exact:
+          //  local_total + child_sum + ts_acc == expected(gen).  Everything but
+          //  'ts_acc' came up the tree and is therefore describable by the maps.
+          agg_tree_arrivals = expected_locked(it->first) - it->second->ts_acc;
+        }
+      }
+
+      // decision Q4 - the generation is poisoned if any arrival on it had a
+      //  poisoned precondition.  PUBLISHED BEFORE THE WATERMARK
+      //  (tla/STATE_AND_LOCKING.md section 3.5), so a lock-free has_triggered()
+      //  that sees the new watermark necessarily sees the poison with it.
+      if(it->second->poisoned) {
+        add_poison_locked(it->first);
+        newly_poisoned.push_back(it->first);
+        poisoned_notifications.absorb_append(it->second->local_waiters);
+      } else {
+        // keep the list of local waiters to wake up once we release the lock
+        local_notifications.absorb_append(it->second->local_waiters);
+      }
+      trigger_gen = it->first;
+      generation.store_release(it->first);
+
+      // AND HERE THE GATHERED MAPS DIE, with the generation record that owns
+      //  them (section 11.3)
+      delete it->second;
+      generations.erase(it);
+      it = generations.begin();
+    }
+
+    if(trigger_gen == 0) {
+      return 0;
+    }
+
+    // ARRIVAL_PROTOCOL section 8.8 - the alteration state a triggered
+    //  generation put beyond reach is reclaimed here, while the watermark that
+    //  makes it unreachable has just moved.
+    prune_alter_state_locked(trigger_gen);
+
+    // RULE 5 - the plan switch, in the SAME critical section as the trigger
+    //  that motivated it (section 12: "count comparison and the plan switch
+    //  that follows it").  At most one switch per section, which keeps this a
+    //  faithful refinement of BarrierArrive's one-switch-per-Trigger.
+    if(have_agg) {
+      // consumed whether or not the build is accepted: retrying against the
+      //  same evidence would reach the same answer, and the next deviation
+      //  sets the flag again
+      plan_rebuild_pending = false;
+      build_new_plan_locked(agg, agg_tree_arrivals, sends);
+    }
+
+    if(redop_id != 0) {
+      // LEGACY / REDUCTION PATH: one message per subscriber, sliced out of
+      //  'final_values' by that node's own 'previous_gen', which is why the
+      //  owner has to keep the O(N) per-node map here.  Left exactly as it was.
+      std::map<unsigned, gen_t>::iterator it2 = remote_subscribe_gens.begin();
+      while(it2 != remote_subscribe_gens.end()) {
+        RemoteNotification rn;
+        rn.node = it2->first;
+        if(it2->second <= trigger_gen) {
+          // we have fulfilled the entire subscription
+          rn.trigger_gen = it2->second;
+          std::map<unsigned, gen_t>::iterator to_nuke = it2++;
+          remote_subscribe_gens.erase(to_nuke);
+        } else {
+          // subscription remains valid
+          rn.trigger_gen = trigger_gen;
+          ++it2;
+        }
+        // also figure out what the previous generation this node knew about was
+        LegacyReductionState &ls = legacy_state();
+        std::map<unsigned, gen_t>::iterator it3 = ls.remote_trigger_gens.find(rn.node);
+        if(it3 != ls.remote_trigger_gens.end()) {
+          rn.previous_gen = it3->second;
+          it3->second = rn.trigger_gen;
+        } else {
+          rn.previous_gen = first_generation;
+          ls.remote_trigger_gens[rn.node] = rn.trigger_gen;
+        }
+
+        if(remote_notifications.empty() || (rn.previous_gen < oldest_previous)) {
+          oldest_previous = rn.previous_gen;
+        }
+
+        remote_notifications.push_back(rn);
+      }
+    } else {
+      // ---- NOTIFICATION_PROTOCOL action T, the notification half -----------
+      //
+      // Step 1: choose the shrink.  RULE 3 - removals are DISCRETIONARY, so ANY
+      //  subset of the collected intents is a legal choice and the model checks
+      //  exactly that ("the owner may shrink by ANY subset").
+      MulticastTargetSet departing;
+      for(MulticastTargetSet::const_iterator wit = want_out.begin();
+          wit != want_out.end(); ++wit) {
+        // only a node that is actually IN the set is being removed; anything
+        //  else in 'want_out' is a stale intent and changes no version
+        if(sub_set.contains(*wit)) {
+          departing.append_increasing_node(*wit);
+        }
+      }
+
+      // Step 1b: RULE 3's COST TEST, and rule 8's advisory byte.  A shrink is
+      //  applied only if it actually reduces what a notification costs; if it
+      //  does not, 'departing' is emptied and the removal is DECLINED, which
+      //  needs no protocol at all - it is just the next publication with the
+      //  node still in it.
+      //
+      // The verdict is published as the hint so the rest of the machine stops
+      //  asking for something that is not going to be granted, and it is
+      //  STICKY: a trigger with nothing to weigh leaves it alone, because a
+      //  verdict does not go stale until the set it was about changes shape.
+      //  An add is the thing that changes shape, so action S is what puts the
+      //  hint back to optimistic.  Resetting it here instead would make the
+      //  suppression last exactly one notification and buy nothing.
+      if(!departing.empty()) {
+        if(shrink_pays_locked(departing)) {
+          shrink_pays = true;
+          counters.shrinks_applied++;
+          counters.nodes_removed += departing.size();
+        } else {
+          shrink_pays = false;
+          counters.shrinks_declined++;
+          log_barrier.info() << "declining barrier subscriber shrink: " << me
+                             << " set=" << sub_set.size()
+                             << " departing=" << departing.size();
+          departing.clear();
+        }
+      }
+
+      // Step 2: SNAPSHOT THE PRE-SHRINK SET.  RULE 1 - "any shrink must be
+      //  published to the PRE-SHRINK set", so a node being removed always hears
+      //  about its own removal.  This is the one thing in this protocol that
+      //  message reordering cannot repair, which is why it is handled by
+      //  snapshotting inside the section rather than by ordering (S5).
+      sends.notify.targets = sub_set;
+
+      // Step 3: apply the shrink and bump the version.  RULE 2 - 'set_ver'
+      //  moves on EVERY change to the set and is stamped on every publication;
+      //  when nothing changes it does not move, every recipient's version gate
+      //  says "stale", and no membership is applied at all.
+      if(!departing.empty()) {
+        for(MulticastTargetSet::const_iterator dit = departing.begin();
+            dit != departing.end(); ++dit) {
+          sub_set.remove(*dit);
+        }
+        set_ver += 1;
+      }
+      want_out.clear();
+
+      // Step 4: compose the delta.  There is nobody to tell if the set is
+      //  empty - and a node that is not in it pulls, which is the correctness
+      //  guarantee; the set is only a cache.
+      if(!sends.notify.targets.empty()) {
+        sends.notify.valid = true;
+        sends.notify.wm = trigger_gen;
+        sends.notify.prev = old_watermark;
+        sends.notify.set_ver = set_ver;
+        // rule 8's one-byte hint rides the notification that was going out
+        //  anyway, so it costs nothing on the wire
+        sends.notify.shrink_hint = shrink_pays;
+        sends.notify.poison.swap(newly_poisoned);
+        if(!departing.empty()) {
+          // only carried when 'set_ver' moved: with an unchanged version no
+          //  recipient would apply membership, so the bytes would be waste
+          EncodedMulticastTargets enc =
+              EncodedMulticastTargets::encode(departing, Network::max_node_id + 1);
+          const unsigned char *encp = static_cast<const unsigned char *>(enc.data());
+          sends.notify.departing.assign(encp, encp + enc.bytes());
+        }
+      }
+    }
+
+    // external waiters need to be signalled inside the lock
+    if(has_external_waiters) {
+      has_external_waiters = false;
+      // also need external waiter mutex
+      AutoLock<KernelMutex> al2(external_waiter_mutex);
+      external_waiter_condvar.broadcast();
+    }
+
+    return trigger_gen;
+  }
+
+  // 'mutex' must NOT be held (S2).  Everything this needs was materialised
+  //  inside the critical section; the only members it touches are immutable
+  //  ones (S3).
+  void BarrierImpl::emit_trigger_notifications(
+      gen_t trigger_gen, const std::vector<RemoteNotification> &remote_notifications,
+      gen_t oldest_previous, const void *final_values_copy, size_t sizeof_lhs)
+  {
+    for(std::vector<RemoteNotification>::const_iterator it = remote_notifications.begin();
+        it != remote_notifications.end(); it++) {
+      // send each remote waiter data up to the generation they asked for
+      gen_t tgt_trigger_gen = (*it).trigger_gen;
+      log_barrier.info() << "sending remote trigger notification: " << me << "/"
+                         << (*it).previous_gen << " -> " << tgt_trigger_gen
+                         << ", dest=" << (*it).node;
+      const void *data = 0;
+      size_t datalen = 0;
+      if(final_values_copy) {
+        data = static_cast<const char *>(final_values_copy) +
+               (((*it).previous_gen - oldest_previous) * sizeof_lhs);
+        datalen = (tgt_trigger_gen - (*it).previous_gen) * sizeof_lhs;
+      }
+      BarrierTriggerMessage::send_request((*it).node, me.id, tgt_trigger_gen,
+                                          (*it).previous_gen, first_generation, redop_id,
+                                          data, datalen);
+    }
+  }
+
+  ////////////////////////////////////////////////////////////////////////
 
   // used to adjust a barrier's arrival count either up or down
   // if delta > 0, timestamp is current time (on requesting node)
   // if delta < 0, timestamp says which positive adjustment this arrival must wait for
   void BarrierImpl::adjust_arrival(gen_t barrier_gen, int delta,
                                    Barrier::timestamp_t timestamp, Event wait_on,
-                                   NodeID sender, bool forwarded,
-                                   const void *reduce_value, size_t reduce_value_size,
-                                   TimeLimit work_until)
+                                   NodeID sender, const void *reduce_value,
+                                   size_t reduce_value_size, TimeLimit work_until,
+                                   bool poisoned /*= false*/)
   {
     Barrier b = make_barrier(barrier_gen, timestamp);
 
@@ -741,34 +3295,47 @@ namespace Realm {
       // only forward deferred arrivals if the precondition is not one that looks like
       // it'll
       //  trigger here first
+      //
+      // ARRIVAL_PROTOCOL rule 8: an arrival that has to be GATED may not be
+      //  relocated.  Forwarding it makes it an arrival AT THE OWNER, which
+      //  knows neither the handle's causal timestamp nor this node's arrival
+      //  floor, so the alteration it depends on would stop holding it back -
+      //  and an arrival counted before its alteration lands is a barrier that
+      //  triggers too early.  The floor is read here, at the moment the
+      //  application issued the arrival, which is the moment that decides
+      //  whether it witnessed an alteration.
       if(owner != Network::my_node_id) {
-        ID wait_id(wait_on);
-        int wait_node;
-        if(wait_id.is_event()) {
-          wait_node = wait_id.event_creator_node();
-        } else {
-          wait_node = wait_id.barrier_creator_node();
+        bool must_gate = (timestamp != 0);
+        if(!must_gate) {
+          AutoLock<> a(mutex);
+          must_gate = (ts_floor_locked(barrier_gen) != 0);
         }
-        if(wait_node != (int)Network::my_node_id) {
-          // let deferral happen on owner node (saves latency if wait_on event
-          //   gets triggered there)
-          // printf("sending deferred arrival to %d for " IDFMT "/%d (" IDFMT "/%d)\n",
-          //       owner, e.id, e.gen, wait_on.id, wait_on.gen);
-          log_barrier.info() << "forwarding deferred barrier arrival: delta=" << delta
-                             << " in=" << wait_on << " out=" << b << " (" << timestamp
-                             << ")";
-          BarrierAdjustMessage::send_request(owner, b, delta, wait_on, sender,
-                                             (sender != Network::my_node_id),
-                                             reduce_value, reduce_value_size);
-          return;
+        if(!must_gate) {
+          ID wait_id(wait_on);
+          int wait_node;
+          if(wait_id.is_event()) {
+            wait_node = wait_id.event_creator_node();
+          } else {
+            wait_node = wait_id.barrier_creator_node();
+          }
+          if(wait_node != (int)Network::my_node_id) {
+            // let deferral happen on owner node (saves latency if wait_on event
+            //   gets triggered there)
+            log_barrier.info() << "forwarding deferred barrier arrival: delta=" << delta
+                               << " in=" << wait_on << " out=" << b << " (" << timestamp
+                               << ")";
+            BarrierAdjustMessage::send_request(owner, b, delta, wait_on, sender,
+                                               reduce_value, reduce_value_size);
+            return;
+          }
         }
       }
 
       log_barrier.info() << "deferring barrier arrival: delta=" << delta
                          << " in=" << wait_on << " out=" << b << " (" << timestamp << ")";
-      EventImpl::add_waiter(wait_on,
-                            new DeferredBarrierArrival(b, delta, sender, forwarded,
-                                                       reduce_value, reduce_value_size));
+      EventImpl::add_waiter(
+          wait_on,
+          new DeferredBarrierArrival(b, delta, sender, reduce_value, reduce_value_size));
       return;
     }
 
@@ -790,139 +3357,220 @@ namespace Realm {
     // can't actually trigger while holding the lock, so remember which generation(s),
     //  if any, to trigger and do it at the end
     gen_t trigger_gen = 0;
-    EventWaiter::EventWaiterList local_notifications;
+    EventWaiter::EventWaiterList local_notifications, poisoned_notifications;
     std::vector<RemoteNotification> remote_notifications;
-    std::vector<NodeID> remote_broadcast_targets;
-    gen_t broadcast_previous = 0;
     gen_t oldest_previous = 0;
     void *final_values_copy = 0;
-    NodeID migration_target = (NodeID)-1;
+    size_t sizeof_lhs = 0;
     NodeID forward_to_node = (NodeID)-1;
-    NodeID inform_migration = (NodeID)-1;
+    // reports and flush announcements are RECORDED under the lock and emitted
+    //  after it (S2); the emit phase reads only these locals (S3)
+    PendingSends sends;
 
     do { // so we can use 'break' from the middle
       AutoLock<> a(mutex);
 
-      bool generation_updated = false;
+      // ROUTE DECISION (tla/STATE_AND_LOCKING.md D2).  A non-owner cannot know
+      //  whether this is a reduction barrier - it learns 'redop_id' only from a
+      //  trigger message that carries reduction data - so it takes the scalable
+      //  path only when everything about this adjustment says that is safe.
+      //  Reduction barriers and alterations (delta > 0, which only ever reaches
+      //  here from the legacy path now that alter_arrival_count has its own
+      //  entry point) stay on the legacy eager path.  A TIMESTAMPED ARRIVAL no
+      //  longer disqualifies the scalable path: rule 8.1 gives it its own
+      //  bypass of the tree instead.
+      const bool scalable_route =
+          (redop_id == 0) && (reduce_value_size == 0) && (delta < 0);
 
-      // ownership can change, so check it inside the lock
+      // ARRIVAL_PROTOCOL rule 8.1 - THE GATE THIS ARRIVAL CARRIES.  Two
+      //  independent dependencies, either or both of which may be absent:
+      //  the handle's own causal timestamp, and this node's arrival floor
+      //  (the model's myTs[n][g], set by every alteration this node has issued
+      //  for this generation or an earlier one).  A non-zero gate means the
+      //  arrival BYPASSES THE TREE - a relay would collapse it into a single
+      //  integer and erase the timestamps with it.
+      Generation::TsKey gate;
+      if(scalable_route) {
+        gate.ts = timestamp;
+        gate.local_ts = ts_floor_locked(barrier_gen);
+      }
+      const bool bypass = ((gate.ts != 0) || (gate.local_ts != 0));
+
+      // barriers are owned by their creator node for their whole life, but a
+      //  non-owner still has to hand the arrival on
       if(owner != Network::my_node_id) {
-        forward_to_node = owner;
-        break;
-      } else {
-        // if this message had to be forwarded to get here, tell the original sender we
-        // are the
-        //  new owner
-        if(forwarded && (sender != Network::my_node_id)) {
-          inform_migration = sender;
+        if(!scalable_route) {
+          forward_to_node = owner;
+          break;
         }
+
+        // ---- ARRIVAL_PROTOCOL action A, on a non-owner --------------------
+        // Guard evaluation, the state update and the send DECISION are all in
+        //  this one critical section (section 12).
+        // Arriving on a generation that has already triggered is an
+        //  APPLICATION error (action A step 1).  That is a different thing from
+        //  a stale MESSAGE, which action R drops silently.
+        assert(barrier_gen > generation.load());
+        Generation *g = get_generation_locked(barrier_gen);
+
+        // decision Q4 - a POISONED PRECONDITION poisons the generation.  The
+        //  arrival itself still counts: refusing to count it would hang the
+        //  barrier rather than poison it, and every waiter would then be told
+        //  nothing at all instead of being told the truth.  The bit is sticky
+        //  and travels with the count on whichever of the two paths below this
+        //  arrival takes.
+        if(poisoned) {
+          g->poisoned = true;
+        }
+
+        if(bypass) {
+          // RULE 8.1 - straight to the owner, carrying this node's CUMULATIVE
+          //  count of arrivals issued for this generation under this gate (D4:
+          //  replace-if-higher, exactly like every other accumulator here).
+          //  'local_total' is deliberately NOT touched - a bypassed arrival
+          //  never enters the tree's accounting.
+          int64_t &issued = g->ts_issued[gate];
+          issued += -static_cast<int64_t>(delta);
+          sends.has_ts_arrival = true;
+          sends.ts_arrival.gen = barrier_gen;
+          sends.ts_arrival.val = issued;
+          sends.ts_arrival.ts = gate.ts;
+          sends.ts_arrival.local_ts = gate.local_ts;
+          sends.ts_arrival.poisoned = g->poisoned;
+
+          // RULE 8.3, generalised to the arrival rather than the alteration:
+          //  an arrival that bypasses the tree never reaches 'local_total', so
+          //  this node's quota just became that much less reachable.  A relay
+          //  waiting on an unreachable quota goes silent and strands its
+          //  children, so it stops aggregating for this generation and reports
+          //  what it is already holding.  (Over-signalling a flush is always
+          //  safe - it only ever causes MORE eager reporting.)
+          enter_flush_locked(*g, barrier_gen, sends);
+          break;
+        }
+
+        g->local_total += -static_cast<int64_t>(delta);
+
+        // the '!flushing' test here is load-bearing, not just idempotence: once
+        //  this node IS flushing, every arrival has to fall through to the
+        //  reporting branch below instead of being absorbed by the (idempotent,
+        //  and therefore silent) flush entry.
+        if(!g->flushing && cur_plan.inplan &&
+           (g->local_total > static_cast<int64_t>(cur_plan.quota))) {
+          // RULE 2 - OVER-ARRIVAL.  A node the plan DID predict has just taken
+          //  more arrivals than its quota, so the plan is wrong: the
+          //  completion condition this node would otherwise wait for can never
+          //  be met, and waiting is exactly the silence that deadlocks the
+          //  generation.  It enters eager-flush mode, reports its cumulative
+          //  total upward IMMEDIATELY and fans a flush announcement out to its
+          //  children - they are aggregating under the same wrong plan.  From
+          //  then on every arrival for this generation reports immediately,
+          //  which falls out of the 'flushing' test in should_report_locked().
+          enter_flush_locked(*g, barrier_gen, sends);
+        } else if(should_report_locked(barrier_gen, *g)) {
+          // already flushing, rule 3 (no plan record - report DIRECT to the
+          //  owner), or rule 1's steady state (quota met and every predicted
+          //  child has spoken)
+          record_report_locked(*g, barrier_gen, sends);
+        }
+        // otherwise: SILENCE.  Below quota, or missing a child, this node says
+        //  nothing at all - that is the aggregation that makes this scalable.
+        break;
       }
 
       // sanity checks - is this a valid barrier?
       // assert(generation < free_generation);
       assert(base_arrival_count > 0);
 
-      // update whatever generation we're told to
+      // update whatever generation we're told to.  NOTE: the owner DOES know
+      //  whether this is a reduction barrier, so its accumulator choice is
+      //  'redop_id == 0' and not the (deliberately conservative) route test
+      //  above - otherwise a timestamped arrival on a scalable barrier would
+      //  land in the legacy count-down and be lost.
       {
         assert(barrier_gen > generation.load());
-        Generation *g;
-        std::map<gen_t, Generation *>::iterator it = generations.find(barrier_gen);
-        if(it != generations.end()) {
-          g = it->second;
-        } else {
-          g = new Generation;
-          generations[barrier_gen] = g;
-          log_barrier.info() << "added tracker for barrier " << me << ", generation "
-                             << barrier_gen;
+        Generation *g = get_generation_locked(barrier_gen);
+
+        // decision Q4, at the owner.  The scalable path publishes this when the
+        //  generation triggers; the legacy path has no poison plumbing at all,
+        //  so the bit is simply carried and never read there.
+        if(poisoned && (redop_id == 0)) {
+          g->poisoned = true;
         }
 
-        g->handle_adjustment(timestamp, delta);
-      }
-
-      // if the update was to the next generation, it may cause one or more generations
-      //  to trigger
-      if(barrier_gen == (generation.load() + 1)) {
-        std::map<gen_t, Generation *>::iterator it = generations.begin();
-        while((it != generations.end()) && (it->first == (generation.load() + 1)) &&
-              ((base_arrival_count + it->second->unguarded_delta) == 0)) {
-          // keep the list of local waiters to wake up once we release the lock
-          local_notifications.absorb_append(it->second->local_waiters);
-          trigger_gen = it->first;
-          generation.store_release(it->first);
-          generation_updated = true;
-
-          delete it->second;
-          generations.erase(it);
-          it = generations.begin();
-        }
-
-        // if any triggers occurred, figure out
-        //  which remote nodes need notifications (i.e. any who subscribed)
-        if(trigger_gen >= barrier_gen) {
-          std::map<unsigned, gen_t>::iterator it = remote_subscribe_gens.begin();
-          while(it != remote_subscribe_gens.end()) {
-            RemoteNotification rn;
-            rn.node = it->first;
-            if(it->second <= trigger_gen) {
-              // we have fulfilled the entire subscription
-              rn.trigger_gen = it->second;
-              std::map<unsigned, gen_t>::iterator to_nuke = it++;
-              remote_subscribe_gens.erase(to_nuke);
-            } else {
-              // subscription remains valid
-              rn.trigger_gen = trigger_gen;
-              ++it;
-            }
-            // also figure out what the previous generation this node knew about was
-            {
-              std::map<unsigned, gen_t>::iterator it2 = remote_trigger_gens.find(rn.node);
-              if(it2 != remote_trigger_gens.end()) {
-                rn.previous_gen = it2->second;
-                it2->second = rn.trigger_gen;
-              } else {
-                rn.previous_gen = first_generation;
-                remote_trigger_gens[rn.node] = rn.trigger_gen;
-              }
-            }
-
-            if(remote_notifications.empty() || (rn.previous_gen < oldest_previous)) {
-              oldest_previous = rn.previous_gen;
-            }
-
-            remote_notifications.push_back(rn);
-
-            if(remote_notifications.size() == 1) {
-              broadcast_previous = rn.previous_gen;
-            } else {
-              broadcast_previous = std::min(broadcast_previous, rn.previous_gen);
-            }
+        if(delta > 0) {
+          // An ALTERATION that came in through the arrival path.  Nothing
+          //  generates this on the scalable path any more - alter_arrival_count
+          //  has its own entry point and its own message - but the legacy
+          //  forward of a positive delta still lands here, and applying it
+          //  persistently (rules 8 and 9) is the whole point of stage C6.
+          //
+          // rule 8.1, as in handle_remote_alter: an altering node never belongs
+          //  in a plan again.  Leaving a node out is always safe, so this errs
+          //  towards excluding one that might not have needed it.
+          if(redop_id == 0) {
+            ts_bypass_nodes.insert(sender);
           }
+          apply_alter_locked(barrier_gen, delta, timestamp, /*prev_ts=*/0, sends);
+        } else if(bypass) {
+          // RULE 8.1 at the owner: the arrival still bypasses the tree, but
+          //  the "message" is applied inline rather than sent to ourselves.
+          //  Action A step 4 and action TS, fused into one section (S1).
+          int64_t &issued = g->ts_issued[gate];
+          issued += -static_cast<int64_t>(delta);
+          apply_ts_arrival_locked(Network::my_node_id, *g, gate, issued);
+          enter_flush_locked(*g, barrier_gen, sends);
+        } else if((redop_id != 0) && (timestamp != 0)) {
+          // A LEGACY arrival that names an alteration.  Reduction barriers stay
+          //  on the eager path, but the ordering question is the same one rule
+          //  8.2 answers, so they get the same EXACT-SET gate rather than the
+          //  "ts <= the highest timestamp from that node" comparison that used
+          //  to live here.  The value is accumulated rather than replaced
+          //  because a legacy adjustment message carries an INCREMENT - only
+          //  the scalable path's own message is cumulative.
+          Generation::TsKey lgate;
+          lgate.ts = timestamp;
+          Generation::TsStreamKey lkey;
+          lkey.from = sender;
+          lkey.gate = lgate;
+          const int64_t sofar = g->ts_streams[lkey].seen;
+          apply_ts_arrival_locked(sender, *g, lgate,
+                                  sofar + -static_cast<int64_t>(delta));
+        } else if(redop_id != 0) {
+          // legacy/reduction path: arrivals count DOWN (D4)
+          g->unguarded_delta += delta;
+        } else {
+          g->local_total += -static_cast<int64_t>(delta);
         }
 
-#ifndef DISABLE_BARRIER_MIGRATION
-        // if there were zero local waiters and a single remote waiter, this barrier is
-        // an obvious
-        //  candidate for migration
-        // don't migrate a barrier more than once though (i.e. only if it's on the
-        // creator node still) also, do not migrate a barrier if we have any local
-        // involvement in future generations
-        //  (either arrivals or waiters or a subscription that will become a waiter)
-        // finally (hah!), do not migrate barriers using reduction ops
-        if(local_notifications.empty() && (remote_notifications.size() == 1) &&
-           generations.empty() && (gen_subscribed.load() <= generation.load()) &&
-           (redop == 0) &&
-           (NodeID(ID(me).barrier_creator_node()) == Network::my_node_id)) {
-          log_barrier.info() << "barrier migration: " << me << " -> "
-                             << remote_notifications[0].node;
-          migration_target = remote_notifications[0].node;
-          owner = migration_target;
-          // remember that we had up to date information up to this generation so that
-          // we don't try to
-          //   subscribe to things we already know about
-          gen_subscribed.store(generation.load());
+        // The owner arriving on its own barrier is still action A, and the
+        //  owner is a node in the tree like any other.  The model writes the
+        //  two deviation cases as a message the owner sends to ITSELF - a
+        //  'direct' when it is outside the plan (rule 3), a flush fan when it
+        //  is in the plan and over quota (rule 2) - and its RecvReport step 5
+        //  then puts the owner into flush mode.  We apply that inline rather
+        //  than round-tripping a message to ourselves, and deliberately do NOT
+        //  route the arrival through 'child_acc' the way the model's literal
+        //  self-message does: it is already in 'local_total', and BarrierArrive's
+        //  Trigger guard adds localTotal[Owner] to ownerAcc separately, so
+        //  doing both would double-count it.
+        //
+        // Either way the owner has just learned its plan does not describe
+        //  reality, and the flush fan-out is how the rest of the tree finds
+        //  out.  The owner itself never reports (it has no parent), so
+        //  enter_flush_locked() records only the announcements - and it is
+        //  idempotent, so it does nothing at all after the first one.
+        if((redop_id == 0) && (!cur_plan.inplan ||
+                               (g->local_total > static_cast<int64_t>(cur_plan.quota)))) {
+          enter_flush_locked(*g, barrier_gen, sends);
         }
-#endif
       }
+
+      // this may have completed one or more generations - and, with them, a
+      //  plan rebuild and the notification, both recorded into 'sends' like
+      //  everything else
+      trigger_gen = check_triggers_locked(local_notifications, poisoned_notifications,
+                                          remote_notifications, oldest_previous, sends);
 
       // do we have reduction data to apply?  we can do this even if the actual
       // adjustment is
@@ -963,78 +3611,30 @@ namespace Realm {
         final_values_copy =
             bytedup(final_values.data() + ((rel_gen - 1) * redop->sizeof_lhs),
                     count * redop->sizeof_lhs);
+        sizeof_lhs = redop->sizeof_lhs;
       }
-
-      // external waiters need to be signalled inside the lock
-      if(generation_updated && has_external_waiters) {
-        has_external_waiters = false;
-        // also need external waiter mutex
-        AutoLock<KernelMutex> al2(external_waiter_mutex);
-        external_waiter_condvar.broadcast();
-      }
-
-#ifdef BARRIER_ENABLE_BROADCAST
-      NodeID node = (Network::my_node_id - owner + Network::max_node_id + 1) %
-                    (Network::max_node_id + 1);
-      get_broadcast_targets(node, remote_notifications.size(), broadcast_radix,
-                            remote_broadcast_targets);
-#endif
     } while(0);
 
     if(forward_to_node != (NodeID)-1) {
+      // decision Q8 - straight to the active message interface, no communicator
+      //  indirection
       Barrier b = make_barrier(barrier_gen, timestamp);
-      barrier_comm->adjust(forward_to_node, b, delta, Event::NO_EVENT, sender,
-                           (sender != Network::my_node_id), reduce_value,
-                           reduce_value_size);
+      BarrierAdjustMessage::send_request(forward_to_node, b, delta, Event::NO_EVENT,
+                                         sender, reduce_value, reduce_value_size);
       return;
     }
 
-    if(inform_migration != (NodeID)-1) {
-      Barrier b = make_barrier(barrier_gen, timestamp);
-      BarrierMigrationMessage::send_request(inform_migration, b, Network::my_node_id);
-    }
+    // everything recorded inside the critical section goes out now (S2)
+    emit_pending_sends(sends);
 
     if(trigger_gen != 0) {
       log_barrier.info() << "barrier trigger: event=" << me << "/" << trigger_gen;
 
       // notify local waiters first
-      if(!local_notifications.empty()) {
-        get_runtime()->event_triggerer.trigger_event_waiters(local_notifications,
-                                                             POISON_FIXME, work_until);
-      }
+      deliver_waiters(local_notifications, poisoned_notifications, work_until);
 
-#ifndef BARRIER_ENABLE_BROADCAST
-      for(std::vector<RemoteNotification>::const_iterator it =
-              remote_notifications.begin();
-          it != remote_notifications.end(); it++) {
-        // normally we'll just send a remote waiter data up to the
-        //  generation they asked for - the exception is the target of a
-        //  migration, who must get up to date data
-        gen_t tgt_trigger_gen = (*it).trigger_gen;
-        if((*it).node == migration_target)
-          tgt_trigger_gen = trigger_gen;
-        log_barrier.info() << "sending remote trigger notification: " << me << "/"
-                           << (*it).previous_gen << " -> " << tgt_trigger_gen
-                           << ", dest=" << (*it).node;
-        void *data = 0;
-        size_t datalen = 0;
-        if(final_values_copy) {
-          data = (char *)final_values_copy +
-                 (((*it).previous_gen - oldest_previous) * redop->sizeof_lhs);
-          datalen = (tgt_trigger_gen - (*it).previous_gen) * redop->sizeof_lhs;
-        }
-        BarrierTriggerMessage::send_request(
-            (*it).node, me.id, tgt_trigger_gen, (*it).previous_gen, first_generation,
-            redop_id, migration_target, base_arrival_count, data, datalen);
-#else
-      if(!remote_notifications.empty()) {
-        AutoLock<> al(mutex);
-
-        broadcast_trigger(remote_notifications, remote_broadcast_targets, oldest_previous,
-                          broadcast_previous, first_generation, migration_target,
-                          base_arrival_count, redop_id, final_values_copy, /*datalen=*/0);
-#endif
-      }
+      emit_trigger_notifications(trigger_gen, remote_notifications, oldest_previous,
+                                 final_values_copy, sizeof_lhs);
     }
 
     // free our copy of the final values, if we had one
@@ -1043,84 +3643,754 @@ namespace Realm {
     }
   }
 
+  ////////////////////////////////////////////////////////////////////////
+  //
+  // ARRIVAL_PROTOCOL action R - RecvReport / DropStale (BarrierArrive RecvReport).
+  //  One critical section covers the staleness test, the accumulator update,
+  //  the recomputed subtree total and the forwarding decision (section 12).
+  //
+  void BarrierImpl::handle_remote_report(NodeID from, gen_t report_gen, int64_t val,
+                                         bool is_direct, bool poisoned, const void *data,
+                                         size_t datalen, TimeLimit work_until)
+  {
+    gen_t trigger_gen = 0;
+    EventWaiter::EventWaiterList local_notifications, poisoned_notifications;
+    std::vector<RemoteNotification> remote_notifications;
+    gen_t oldest_previous = 0;
+    void *final_values_copy = 0;
+    size_t sizeof_lhs = 0;
+    PendingSends sends;
+
+    // ARRIVAL_PROTOCOL section 11.1 - decode the eager-flush (node,count) map
+    //  BEFORE taking the lock.  It touches nothing but the message buffer, and
+    //  a payload that is O(subtree) has no business lengthening a critical
+    //  section (section 12).  This is also the copy out of the active-message
+    //  buffer, which is dead the moment this handler returns.
+    std::map<NodeID, int64_t> counts;
+    bool have_counts = false;
+    if(datalen > 0) {
+      have_counts = decode_flush_map(data, datalen, counts);
+      if(!have_counts) {
+        log_barrier.fatal() << "malformed barrier flush map: " << me << "/" << report_gen
+                            << " from=" << from << " bytes=" << datalen;
+        abort();
+      }
+    }
+
+    do {
+      AutoLock<> a(mutex);
+
+      // step 1: a report for a generation that has already triggered is dropped
+      //  SILENTLY.  This is exactly what makes freeing a triggered generation's
+      //  record safe: without it the absent child_acc entry would make a late
+      //  report look like an increase and it would be counted, and forwarded,
+      //  all over again.
+      if(report_gen <= generation.load()) {
+        log_barrier.info() << "dropping barrier report for triggered generation: " << me
+                           << "/" << report_gen << " from=" << from
+                           << " direct=" << is_direct;
+        break;
+      }
+
+      Generation *g = get_generation_locked(report_gen);
+
+      // decision Q4 - the poison bit is OR-ed in BEFORE the staleness test.
+      //  It is monotone, so it cannot go backwards and a duplicate costs
+      //  nothing; doing it after would let the sticky bit be thrown away with a
+      //  report whose COUNT was stale but whose poison was news.
+      if(poisoned) {
+        g->poisoned = true;
+      }
+
+      // step 3 - RULE 7.  Cumulative totals only ever increase: a report whose
+      //  value does not STRICTLY exceed what we have stored for this sender is
+      //  stale and is discarded.  Never treat a report as an increment -
+      //  accepting stale reports lets the accepted count go DOWN, which is a
+      //  mutation TLC catches.
+      //
+      // NOTE: the accumulator is keyed on the SENDER and is never checked
+      //  against cur_plan.kids.  A receiver MUST accept a report from a node it
+      //  does not list as a child (ARRIVAL_PROTOCOL section 8.2): a node whose
+      //  parent has already switched plans and dropped it still reports to that
+      //  old parent, and the defensive check that looks worth adding here
+      //  silently loses those arrivals.
+      std::map<NodeID, Generation::ChildReport>::iterator it = g->child_acc.find(from);
+      const int64_t prev = (it == g->child_acc.end()) ? 0 : it->second.total;
+      if(val <= prev) {
+        log_barrier.info() << "dropping stale barrier report: " << me << "/" << report_gen
+                           << " from=" << from << " val=" << val << " have=" << prev;
+        break;
+      }
+      if(it == g->child_acc.end()) {
+        it = g->child_acc.insert(std::make_pair(from, Generation::ChildReport())).first;
+      }
+      it->second.total = val;
+
+      // step 4, second half (section 11.1): the (node,count) map is cumulative
+      //  in exactly the same way as the count - a relay re-sends its WHOLE
+      //  subtree map, so a later report supersedes an earlier one and
+      //  reordering stays harmless.  Replace it WHOLESALE when one is carried;
+      //  leave the stored map alone when one is not, because "no map" is what a
+      //  cheap steady-state report looks like and is not a claim that the
+      //  subtree is empty.
+      if(have_counts) {
+        it->second.counts.swap(counts);
+      }
+
+      // rule 3, propagated (see record_report_locked): 'direct' means "your
+      //  plan did not account for me", and a relay has to carry that flag on
+      //  because the node that raised it still reports through the retired tree
+      //  rather than straight to the owner.
+      if(is_direct) {
+        g->saw_direct = true;
+      }
+
+      // D2 fallback: the sender could not know this was a reduction barrier (it
+      //  learns redop_id only from a trigger message carrying data), so it
+      //  reported cumulatively.  The report is exact, so the increment it
+      //  represents goes into the legacy count-down accumulator that path uses,
+      //  and 'child_sum' - which only the scalable test reads - is left alone.
+      const bool legacy_fold = (owner == Network::my_node_id) && (redop_id != 0);
+      if(legacy_fold) {
+        g->unguarded_delta -= static_cast<int>(val - prev);
+      } else {
+        // REPLACE this child's contribution, never add to it.  'child_sum' is
+        //  the incremental maintenance of the model's
+        //  ownerAcc' = @ - childAcc[Owner][from][gen] + val.
+        g->child_sum += val - prev;
+      }
+
+      if(owner == Network::my_node_id) {
+        // step 5 - RULE 3.  A 'direct' is a node telling the owner "your plan
+        //  did not predict me": the sender holds no plan record, so it has no
+        //  parent and no completion condition it could ever wait for, and it
+        //  reported straight here.  The owner treats that as proof its plan is
+        //  wrong, enters eager-flush mode FOR THIS GENERATION and fans a flush
+        //  out through its children, so that every node still aggregating
+        //  under the stale plan stops waiting and speaks.
+        //
+        // This runs BEFORE the trigger check below, because a trigger frees
+        //  '*g'.  Fanning a flush for a generation that then triggers in the
+        //  same section is harmless - the recipients' own reports come back
+        //  for an already-triggered generation and action R step 1 drops them.
+        if(is_direct && (redop_id == 0)) {
+          enter_flush_locked(*g, report_gen, sends);
+        }
+
+        trigger_gen = check_triggers_locked(local_notifications, poisoned_notifications,
+                                            remote_notifications, oldest_previous, sends);
+        if(trigger_gen && redop) {
+          int rel_gen = oldest_previous + 1 - first_generation;
+          assert(rel_gen > 0);
+          int count = trigger_gen - oldest_previous;
+          final_values_copy =
+              bytedup(final_values.data() + ((rel_gen - 1) * redop->sizeof_lhs),
+                      count * redop->sizeof_lhs);
+          sizeof_lhs = redop->sizeof_lhs;
+        }
+      } else {
+        // step 6, first half - RULE 10.5, A STALE EDGE (BarrierArrive RecvReport
+        //  :293-304, 'm.from \notin KidsOf(m.to)').  The sender pinned this
+        //  edge for this generation and a plan change has since moved it out
+        //  of our child list.  We are still the only route its contribution
+        //  has, so it must be passed on AT ONCE - holding it behind our own
+        //  quota strands it, because nothing will ever make that quota
+        //  relevant again.  Caught by MCDouble, MCStrand and MCStrand2
+        //  (deadlock); ARRIVAL_PROTOCOL rule 10.5 records that it evaded five
+        //  scenarios and looked deletable, and is load-bearing.
+        //
+        // The SENDER-side half of this (record_report_locked flagging
+        //  'is_direct' when its pinned target differs from its current parent)
+        //  is not enough on its own: it fires only once the sender has SEEN
+        //  the newer plan, and the receiver always switches first - the
+        //  receiver is the one that forwards the sender's invalidation - so a
+        //  report already in flight across that window arrives unflagged.
+        //  Only the receiver can see that its own child list has moved on,
+        //  which is why the spec puts this disjunct at RecvReport.
+        const bool stale_edge =
+            g->holding() && (std::find(cur_plan.kids.begin(), cur_plan.kids.end(),
+                                       from) == cur_plan.kids.end());
+        // step 6, second half: accepting this report may be exactly what
+        //  completes this relay
+        if(stale_edge) {
+          counters.stale_edge_forwards++;
+        }
+        if(stale_edge || should_report_locked(report_gen, *g)) {
+          record_report_locked(*g, report_gen, sends);
+        }
+      }
+    } while(0);
+
+    // everything recorded inside the critical section goes out now (S2)
+    emit_pending_sends(sends);
+
+    if(trigger_gen != 0) {
+      log_barrier.info() << "barrier trigger: event=" << me << "/" << trigger_gen;
+
+      deliver_waiters(local_notifications, poisoned_notifications, work_until);
+
+      emit_trigger_notifications(trigger_gen, remote_notifications, oldest_previous,
+                                 final_values_copy, sizeof_lhs);
+    }
+
+    if(final_values_copy) {
+      free(final_values_copy);
+    }
+  }
+
+  ////////////////////////////////////////////////////////////////////////
+  //
+  // ARRIVAL_PROTOCOL action F - RecvFlush (BarrierArrive RecvFlush).  Rule 4:
+  //  flush is PER GENERATION and IDEMPOTENT.  One critical section covers the
+  //  idempotence test, the flag, the re-fan and the report of held work
+  //  (section 12).
+  //
+  void BarrierImpl::handle_remote_flush(gen_t flush_gen)
+  {
+    PendingSends sends;
+
+    {
+      AutoLock<> a(mutex);
+
+      // A flush for a generation that has already triggered HERE has nothing
+      //  left to collect: this node's watermark only moves when the owner has
+      //  accounted for every arrival in that generation.  Dropping it also
+      //  keeps the generation record's lifetime simple - the record is created
+      //  once and freed exactly once, when the generation triggers - whereas
+      //  creating one below the watermark would leave a record nothing ever
+      //  frees.  Action R step 1 drops stale reports for the same reason.
+      if(flush_gen <= generation.load()) {
+        log_barrier.info() << "dropping barrier flush for triggered generation: " << me
+                           << "/" << flush_gen;
+      } else {
+        // find OR CREATE.  The record has to exist even when no arrival has
+        //  happened here yet: without it a later arrival for this generation
+        //  would not know it is in flush mode and would go back to
+        //  aggregating, which is the silence the announcement came to break.
+        Generation *g = get_generation_locked(flush_gen);
+        enter_flush_locked(*g, flush_gen, sends);
+      }
+    }
+
+    // recorded under the lock, emitted now (S2).  Nothing is triggered here -
+    //  a flush moves no counts, so it can never complete a generation.
+    emit_pending_sends(sends);
+  }
+
+  ////////////////////////////////////////////////////////////////////////
+  //
+  // ARRIVAL_PROTOCOL action I - RecvInvalidate (BarrierArrive RecvInvalidate,
+  //  rule 6).  ONE critical section, and THE ORDER INSIDE IT IS LOAD-BEARING:
+  //  two of the three steps below have their own mutation in the battery, and
+  //  TLC catches both.
+  //
+  void BarrierImpl::handle_remote_invalidate(uint32_t epoch)
+  {
+    PendingSends sends;
+
+    {
+      AutoLock<> a(mutex);
+
+      // step 1 - EPOCH NUMBERING.  An invalidation that is not newer than what
+      //  this node has already retired is stale: it is consumed and ignored.
+      //  Nothing is forwarded, which is what terminates the fan-out.
+      if(inval_epoch >= epoch) {
+        log_barrier.info() << "dropping stale barrier invalidate: " << me
+                           << " epoch=" << epoch << " have=" << inval_epoch;
+      } else {
+        // step 2 - FORWARD FIRST, through the CURRENT (old) child list, before
+        //  anything below can replace it.  Dropping the child list first
+        //  strands the entire subtree underneath - a caught mutation.  The
+        //  targets are resolved into 'sends' here, inside the section, so S3
+        //  makes this survive step 5 for free.
+        sends.fwd_inval_epoch = epoch;
+        sends.inval_to.insert(sends.inval_to.end(), cur_plan.kids.begin(),
+                              cur_plan.kids.end());
+
+        // step 3 - FLUSH EVERY OPEN GENERATION, not just the one that caused
+        //  the switch.  A node may be holding arrivals for generations beyond
+        //  it (a node running ahead of the owner), and every one of them was
+        //  being aggregated for a tree that is going away.  Flushing only the
+        //  switch generation is a caught mutation.
+        //
+        // Generations this node has no record for yet are covered by
+        //  plan_retired_locked() rather than by a flag - see
+        //  should_report_locked().
+        //
+        // 'saw_direct' goes on with it, so that everything reported out of here
+        //  is flagged.  Each of these generations STRADDLES the switch: its
+        //  counts were accumulated for a tree that is going away, and the node
+        //  the new tree gives them to may have no record of them at all and no
+        //  reason of its own to speak.  The flag is what carries that fact to
+        //  the OWNER, which flushes the generation across the NEW tree.
+        //
+        // ONLY GENERATIONS THIS NODE HAS STATE ON (BarrierArrive RecvInvalidate
+        //  :452-456, 'IF ~triggered[g] /\ SubtreeKnown(m.to, g) > 0').
+        //  Generations with no activity are governed by the plan record alone
+        //  (:448-451) - planless nodes are outsiders, planned nodes start
+        //  planned - so nothing here is sticky across future generations.  A
+        //  record CAN exist with zero state: add_waiter creates one for any
+        //  future generation a local task waits on, and flagging it would
+        //  convert a perfectly predicted generation to eager mode until it
+        //  triggers - every arrival reporting an O(subtree) map, and the owner
+        //  rebuilding an identical plan under a new epoch.
+        const gen_t watermark = generation.load();
+        for(std::map<gen_t, Generation *>::iterator it = generations.begin();
+            it != generations.end(); ++it) {
+          if((it->first > watermark) && (it->second->subtree_known() > 0)) {
+            it->second->flushing = true;
+            it->second->saw_direct = true;
+          }
+        }
+        report_held_locked(sends);
+
+        // step 4
+        inval_epoch = epoch;
+
+        // step 5 - and only NOW apply any parked plan.  This is the other half
+        //  of rule 5's deferral: the node did its invalidation work first, so
+        //  the retiring tree was fully served before the new one is adopted.
+        //
+        // THE LIVE GUARD (BarrierArrive RecvInvalidate 'live', a caught mutation on
+        //  MCStrand2): a parked plan whose epoch does not exceed THIS
+        //  invalidation's is being delivered by its own death notice.
+        //  Installing it would return this node to planned mode under a dead
+        //  plan, having just consumed the only invalidation that will ever
+        //  name it; forwarding it would do the same to every descendant, who
+        //  additionally never see that invalidation at all - the one node
+        //  positioned to route it down the dead plan's edges spent it in this
+        //  very action.  A dead parked plan is DISCARDED: not installed, not
+        //  forwarded.  plan_retired_locked() then keeps this node eager and
+        //  its reports flagged 'direct' until a genuinely newer plan arrives.
+        if(defer_epoch > epoch) {
+          counters.parked_plans_applied++;
+          apply_plan_locked(defer_epoch, deferred_plan_payload.data(),
+                            deferred_plan_payload.size(), defer_parent, sends);
+        } else {
+          if(defer_epoch != 0) {
+            counters.dead_plans_discarded++;
+            log_barrier.info() << "discarding dead parked barrier plan: " << me
+                               << " parked=" << defer_epoch << " retired-by=" << epoch;
+          }
+          // RETROACTIVE CASE 3 (BarrierArrive RecvInvalidate :418-437, rule 10.4).
+          //  This node has been invalidated with NO live replacement.  A node
+          //  that ran ahead arrived believing itself a plan member, so the
+          //  outsider rule never fired: its count reached the owner, but a
+          //  count is not a signal, and nothing tells the owner the plan
+          //  mis-predicts this generation.  On learning it is planless, the
+          //  node delivers case 3 late - a COUNT-FREE flush signal to the
+          //  owner for each open generation it has arrivals on.  The owner
+          //  fans the flush down the CURRENT tree, which is what unsticks
+          //  contributions parked behind quotas the retired plan
+          //  over-predicted.  Caught by MCStale (deadlock).
+          //
+          // report_held_locked above is NOT a substitute: it only speaks when
+          //  this node is HOLDING (Unreported > 0), and the run-ahead node
+          //  that already reported its full count holds nothing - the
+          //  'saw_direct' flag set in step 3 has no report left to ride on.
+          //  This is the spec's condition exactly: localTotal > 0, independent
+          //  of whether anything is unreported.  The signal is count-free (a
+          //  flush, idempotent at the owner); the count itself stays on the
+          //  pinned edge, because a cumulative value sent off-pin
+          //  double-counts.
+          if(owner != Network::my_node_id) {
+            for(std::map<gen_t, Generation *>::iterator it = generations.begin();
+                it != generations.end(); ++it) {
+              if((it->first <= watermark) || (it->second->local_total <= 0)) {
+                continue;
+              }
+              counters.retro_flushes_sent++;
+              sends.flushes.push_back(PendingFlush());
+              PendingFlush &pf = sends.flushes.back();
+              pf.gen = it->first;
+              pf.to.push_back(owner);
+            }
+          }
+        }
+        if(defer_epoch != 0) {
+          defer_epoch = 0;
+          defer_parent = -1;
+          // BoundedRetention: give the bytes back, do not just clear()
+          std::vector<unsigned char>().swap(deferred_plan_payload);
+        }
+      }
+    }
+
+    // recorded under the lock, emitted now (S2).  An invalidation moves no
+    //  counts, so nothing can have triggered and no waiter can be woken here.
+    emit_pending_sends(sends);
+  }
+
+  ////////////////////////////////////////////////////////////////////////
+  //
+  // ARRIVAL_PROTOCOL action P - RecvNewPlan (BarrierArrive RecvNewPlan, rule 5).
+  //
+  // The owner sends the invalidation down the tree being retired and the new
+  //  plan down the new tree at the same moment, and the two RACE.  The
+  //  resolution is entirely local and needs no global knowledge:
+  //
+  //   A node that receives a new plan while it is still an UN-INVALIDATED
+  //   MEMBER of the retiring plan PARKS it.
+  //
+  // The condition is the node's OWN membership plus 'my invalidation has not
+  //  arrived yet', and it is self-clearing: once the invalidation has passed,
+  //  the node looks like it was never in the old plan and the new plan installs
+  //  immediately.  Disabling the deferral is the first mutation in the battery
+  //  and TLC reports ReachableWhileHolding violated in about 46 seconds.
+  //
+  void BarrierImpl::handle_remote_new_plan(NodeID parent, uint32_t epoch,
+                                           const void *data, size_t datalen)
+  {
+    PendingSends sends;
+
+    {
+      AutoLock<> a(mutex);
+
+      // step 1 - EPOCH NUMBERING.  A plan that is not newer than the one this
+      //  node holds is stale: consumed and ignored.
+      //
+      // THE INSTALL GUARD (BarrierArrive RecvNewPlan, a caught mutation on
+      //  MCStrand2): 'newer than what I hold' is NOT enough.  Messages
+      //  reorder, so a newplan can arrive after both of its own broadcast's
+      //  invalidations have overtaken it - and a plan whose RETIREMENT this
+      //  node has already witnessed (inval_epoch >= epoch) is dead on
+      //  arrival.  Installing it would re-enter planned mode under a dead
+      //  plan with no future signal coming, and forwarding it would strand
+      //  every descendant the same way.  One principle, two doors - see the
+      //  live guard in handle_remote_invalidate.
+      if((my_epoch >= epoch) || (inval_epoch >= epoch)) {
+        if((my_epoch < epoch) && (inval_epoch >= epoch)) {
+          // genuinely DEAD (install guard), not merely stale: this plan would
+          //  have installed but its retirement was already witnessed here
+          counters.dead_plans_discarded++;
+        }
+        log_barrier.info() << "dropping dead barrier newplan: " << me
+                           << " epoch=" << epoch << " have=" << my_epoch
+                           << " inval=" << inval_epoch;
+      } else if(cur_plan.inplan && (inval_epoch < my_epoch)) {
+        counters.plans_parked++;
+        // step 2 - PARK IT.  At most ONE parked plan per node, so a second one
+        //  simply replaces the first; that is safe because epochs are monotone
+        //  and the newer plan is the one that will be current when the
+        //  invalidation finally lands (BarrierArrive BoundedRetention).
+        //
+        // The payload is COPIED: the active-message buffer is dead once this
+        //  handler returns, and the node has to be able to forward each child's
+        //  slice of it later.
+        log_barrier.info() << "parking barrier newplan: " << me << " epoch=" << epoch
+                           << " (holding epoch " << my_epoch << ", inval " << inval_epoch
+                           << ")";
+        defer_epoch = epoch;
+        defer_parent = parent;
+        deferred_plan_payload.clear();
+        if(datalen > 0) {
+          const unsigned char *p = static_cast<const unsigned char *>(data);
+          deferred_plan_payload.assign(p, p + datalen);
+        }
+      } else {
+        // step 3 - install it, and pass it on
+        apply_plan_locked(epoch, data, datalen, parent, sends);
+      }
+    }
+
+    // recorded under the lock, emitted now (S2).  Like the invalidation, a plan
+    //  carries no counts, so nothing can trigger here.
+    emit_pending_sends(sends);
+  }
+
+  ////////////////////////////////////////////////////////////////////////
+  //
+  // ARRIVAL_PROTOCOL action AL - alter_arrival_count, rules 8 and 9.
+  //
+  // ONE critical section covers the whole action (section 12): minting the
+  //  causal timestamp, installing the arrival floor that makes this node's
+  //  subsequent arrivals bypass the tree, entering eager flush for every
+  //  affected open generation, and recording the message.  The timestamp used
+  //  to be minted by Barrier::alter_arrival_count and consumed much later, in a
+  //  different section - one spec action split in two, which is a defect even
+  //  though both halves were locked.
+  //
+  // THE RESERVED-ARRIVAL CONTRACT (event.h:290-292) is what makes this safe and
+  //  the runtime cannot check it: before altering, the application must still
+  //  hold at least one unissued arrival from the pre-alteration count.  That
+  //  arrival is what keeps the generation open until the alteration lands.  The
+  //  runtime's half of the bargain is the arrival floor below - once this node
+  //  has altered, EVERY arrival it issues for an affected generation is gated,
+  //  including one made on a pre-alteration handle, which is exactly the
+  //  reserved arrival.
+  //
+  Barrier::timestamp_t BarrierImpl::alter_arrival_count(gen_t barrier_gen, int delta)
+  {
+    Barrier::timestamp_t ts = 0;
+    PendingSends sends;
+
+    // only reachable when this node is the owner and applies the alteration
+    //  inline, but the trigger bookkeeping is the same either way
+    gen_t trigger_gen = 0;
+    EventWaiter::EventWaiterList local_notifications, poisoned_notifications;
+    std::vector<RemoteNotification> remote_notifications;
+    gen_t oldest_previous = 0;
+    void *final_values_copy = 0;
+    size_t sizeof_lhs = 0;
+
+    {
+      AutoLock<> a(mutex);
+
+      // step 1 - MINT THE TIMESTAMP, inside the section.  The counter is seeded
+      //  with (my_node_id << 48) + 1, so a timestamp is globally unique, never
+      //  zero, and monotone per node.
+      ts = barrier_adjustment_timestamp.fetch_add(1);
+
+      // step 2 - the chain.  'prev_ts' names the alteration this one follows at
+      //  this node, and the owner will not apply this one before that one.  It
+      //  is what lets a single timestamp on an arrival stand for every
+      //  alteration this node issued before it.
+      const Barrier::timestamp_t prev_ts = last_alter_ts;
+      last_alter_ts = ts;
+
+      // step 3 - THE ARRIVAL FLOOR (the model's myTs[n][g]).  Alterations are
+      //  persistent, so this entry covers 'barrier_gen' and every generation
+      //  after it; entries above it named earlier alterations, all of which are
+      //  behind this one in the chain, so this timestamp supersedes them and
+      //  they go.
+      ts_floor.erase(ts_floor.upper_bound(barrier_gen), ts_floor.end());
+      ts_floor[barrier_gen] = ts;
+
+      // step 4 - RULE 8.3, eager flush for every affected open generation
+      enter_flush_from_locked(barrier_gen, sends);
+
+      // step 5 - to the owner, or applied right here if we are the owner
+      //  (action RA fused into this section, which S1 permits: a sequence of
+      //  whole actions, never a fraction of one)
+      if(owner == Network::my_node_id) {
+        // rule 8.1 - from here on this node's arrivals bypass the tree, so it
+        //  must never be given a quota in a plan again (build_new_plan_locked)
+        if(redop_id == 0) {
+          ts_bypass_nodes.insert(Network::my_node_id);
+        }
+        apply_alter_locked(barrier_gen, delta, ts, prev_ts, sends);
+        trigger_gen = check_triggers_locked(local_notifications, poisoned_notifications,
+                                            remote_notifications, oldest_previous, sends);
+        if(trigger_gen && redop) {
+          int rel_gen = oldest_previous + 1 - first_generation;
+          assert(rel_gen > 0);
+          int count = trigger_gen - oldest_previous;
+          final_values_copy =
+              bytedup(final_values.data() + ((rel_gen - 1) * redop->sizeof_lhs),
+                      count * redop->sizeof_lhs);
+          sizeof_lhs = redop->sizeof_lhs;
+        }
+      } else {
+        sends.has_alter = true;
+        sends.alter.gen = barrier_gen;
+        sends.alter.delta = delta;
+        sends.alter.ts = ts;
+        sends.alter.prev_ts = prev_ts;
+      }
+
+      log_barrier.info() << "barrier alteration: " << make_barrier(barrier_gen, ts)
+                         << " delta=" << delta;
+    }
+
+    emit_pending_sends(sends);
+
+    if(trigger_gen != 0) {
+      log_barrier.info() << "barrier trigger: event=" << me << "/" << trigger_gen;
+      deliver_waiters(local_notifications, poisoned_notifications,
+                      TimeLimit::responsive());
+      emit_trigger_notifications(trigger_gen, remote_notifications, oldest_previous,
+                                 final_values_copy, sizeof_lhs);
+    }
+
+    if(final_values_copy) {
+      free(final_values_copy);
+    }
+
+    return ts;
+  }
+
+  ////////////////////////////////////////////////////////////////////////
+  //
+  // ARRIVAL_PROTOCOL action RA - an alteration reaches the owner (rules 8, 9).
+  //
+  void BarrierImpl::handle_remote_alter(NodeID from, gen_t alter_gen, int delta,
+                                        Barrier::timestamp_t ts,
+                                        Barrier::timestamp_t prev_ts,
+                                        TimeLimit work_until)
+  {
+    gen_t trigger_gen = 0;
+    EventWaiter::EventWaiterList local_notifications, poisoned_notifications;
+    std::vector<RemoteNotification> remote_notifications;
+    gen_t oldest_previous = 0;
+    void *final_values_copy = 0;
+    size_t sizeof_lhs = 0;
+    PendingSends sends;
+
+    {
+      AutoLock<> a(mutex);
+
+      // barriers are owned by their creator for their whole life (migration is
+      //  gone), so an alteration can only ever arrive here
+      if(owner != Network::my_node_id) {
+        log_barrier.fatal() << "barrier alteration delivered to a non-owner: " << me
+                            << "/" << alter_gen << " from=" << from;
+        abort();
+      }
+
+      // RULE 8.1 - the sender's arrivals BYPASS THE TREE from 'alter_gen' on,
+      //  and an alteration is persistent, so that is true of every generation
+      //  after it too.  Its 'local_total' will never move again, so any quota a
+      //  future plan gave it would be unreachable and its parent would wait on
+      //  rule 1's child-wait forever.  The owner is the only node that learns
+      //  this, and 'applied_ts' is keyed by timestamp and so cannot answer
+      //  "which nodes" - hence the set.  (Not modelled: MCAlter deliberately
+      //  makes its altering node a relay whose parent is the Owner, which has
+      //  no child-wait.)
+      if(redop_id == 0) {
+        ts_bypass_nodes.insert(from);
+      }
+
+      apply_alter_locked(alter_gen, delta, ts, prev_ts, sends);
+
+      // applying it may have raised the count this generation waits for, or
+      //  lowered it, or released a pile of arrivals that were parked behind it
+      trigger_gen = check_triggers_locked(local_notifications, poisoned_notifications,
+                                          remote_notifications, oldest_previous, sends);
+      if(trigger_gen && redop) {
+        int rel_gen = oldest_previous + 1 - first_generation;
+        assert(rel_gen > 0);
+        int count = trigger_gen - oldest_previous;
+        final_values_copy =
+            bytedup(final_values.data() + ((rel_gen - 1) * redop->sizeof_lhs),
+                    count * redop->sizeof_lhs);
+        sizeof_lhs = redop->sizeof_lhs;
+      }
+    }
+
+    emit_pending_sends(sends);
+
+    if(trigger_gen != 0) {
+      log_barrier.info() << "barrier trigger: event=" << me << "/" << trigger_gen;
+      deliver_waiters(local_notifications, poisoned_notifications, work_until);
+      emit_trigger_notifications(trigger_gen, remote_notifications, oldest_previous,
+                                 final_values_copy, sizeof_lhs);
+    }
+
+    if(final_values_copy) {
+      free(final_values_copy);
+    }
+  }
+
+  ////////////////////////////////////////////////////////////////////////
+  //
+  // ARRIVAL_PROTOCOL action TS - a bypassed arrival reaches the owner (rule
+  //  8.1).  It is a report like any other: cumulative, replace-if-higher, and
+  //  dropped outright once the generation has triggered - that last test is
+  //  what makes freeing a triggered generation's record safe.
+  //
+  void BarrierImpl::handle_remote_ts_arrival(NodeID from, gen_t arrival_gen, int64_t val,
+                                             Barrier::timestamp_t ts,
+                                             Barrier::timestamp_t local_ts, bool poisoned,
+                                             TimeLimit work_until)
+  {
+    gen_t trigger_gen = 0;
+    EventWaiter::EventWaiterList local_notifications, poisoned_notifications;
+    std::vector<RemoteNotification> remote_notifications;
+    gen_t oldest_previous = 0;
+    void *final_values_copy = 0;
+    size_t sizeof_lhs = 0;
+    PendingSends sends;
+
+    {
+      AutoLock<> a(mutex);
+
+      if(owner != Network::my_node_id) {
+        log_barrier.fatal() << "barrier ts arrival delivered to a non-owner: " << me
+                            << "/" << arrival_gen << " from=" << from;
+        abort();
+      }
+
+      if(arrival_gen <= generation.load()) {
+        log_barrier.info() << "dropping barrier ts arrival for triggered generation: "
+                           << me << "/" << arrival_gen << " from=" << from;
+      } else {
+        Generation *g = get_generation_locked(arrival_gen);
+        // decision Q4 - as on the report path, OR-ed in before anything can
+        //  discard the message as stale
+        if(poisoned) {
+          g->poisoned = true;
+        }
+        Generation::TsKey gate;
+        gate.ts = ts;
+        gate.local_ts = local_ts;
+        apply_ts_arrival_locked(from, *g, gate, val);
+
+        trigger_gen = check_triggers_locked(local_notifications, poisoned_notifications,
+                                            remote_notifications, oldest_previous, sends);
+        if(trigger_gen && redop) {
+          int rel_gen = oldest_previous + 1 - first_generation;
+          assert(rel_gen > 0);
+          int count = trigger_gen - oldest_previous;
+          final_values_copy =
+              bytedup(final_values.data() + ((rel_gen - 1) * redop->sizeof_lhs),
+                      count * redop->sizeof_lhs);
+          sizeof_lhs = redop->sizeof_lhs;
+        }
+      }
+    }
+
+    emit_pending_sends(sends);
+
+    if(trigger_gen != 0) {
+      log_barrier.info() << "barrier trigger: event=" << me << "/" << trigger_gen;
+      deliver_waiters(local_notifications, poisoned_notifications, work_until);
+      emit_trigger_notifications(trigger_gen, remote_notifications, oldest_previous,
+                                 final_values_copy, sizeof_lhs);
+    }
+
+    if(final_values_copy) {
+      free(final_values_copy);
+    }
+  }
+
   bool BarrierImpl::has_triggered(gen_t needed_gen, bool &poisoned)
   {
-    poisoned = POISON_FIXME;
-
-    // no need to take lock to check current generation
+    // TIER 0 ONLY.  No lock, no allocation, no message, no member write.  This
+    //  is the ONE carve-out from ARRIVAL_PROTOCOL section 12
+    //  (tla/STATE_AND_LOCKING.md section 4), and it is why the consultation
+    //  signal of NOTIFICATION_PROTOCOL rule 8 is explicitly NOT recorded here.
+    //
+    // The acquire load below synchronises with the release store of the
+    //  watermark, and the poison slots were published BEFORE that store
+    //  (section 3.5), so anything that could have poisoned a generation at or
+    //  below 'wm' is already visible to is_generation_poisoned().
     if(needed_gen <= generation.load_acquire()) {
+      poisoned = is_generation_poisoned(needed_gen);
       return true;
     }
 
-#ifdef BARRIER_HAS_TRIGGERED_DOES_SUBSCRIBE
-    // update the subscription (even on the local node), but do a
-    //  quick test first to avoid taking a lock if the subscription is
-    //  clearly already done
-    if(needed_gen > gen_subscribed.load()) {
-      // looks like it needs an update - take lock to avoid duplicate
-      //  subscriptions
-      gen_t previous_subscription;
-      bool send_subscription_request = false;
-      NodeID cur_owner = (NodeID)-1;
-      {
-        AutoLock<> a(mutex);
-        previous_subscription = gen_subscribed.load();
-        if(needed_gen > previous_subscription) {
-          gen_subscribed.store(needed_gen);
-          // test ownership while holding the mutex
-          if(owner != Network::my_node_id) {
-            send_subscription_request = true;
-            cur_owner = owner;
-          }
-        }
-      }
-
-      // if we're not the owner, send subscription if we haven't already
-      if(send_subscription_request) {
-        log_barrier.info() << "subscribing to barrier " << make_barrier(needed_gen)
-                           << " (prev=" << previous_subscription << ")";
-        BarrierSubscribeMessage::send_request(cur_owner, me.id, needed_gen,
-                                              Network::my_node_id, false /*!forwarded*/);
-      }
-    }
-#endif
-
-    // whether or not we subscribed, the answer for now is "no"
+    poisoned = false;
     return false;
   }
 
+  // NOTIFICATION_PROTOCOL action C, the explicit-subscribe entry point.  One
+  //  critical section; the send is recorded in it and emitted after (S2).
   void BarrierImpl::subscribe(gen_t subscribe_gen)
   {
-    // update the subscription (even on the local node), but do a
-    //  quick test first to avoid taking a lock if the subscription is
-    //  clearly already done
-    if(subscribe_gen > gen_subscribed.load()) {
-      // looks like it needs an update - take lock to avoid duplicate
-      //  subscriptions
-      gen_t previous_subscription;
-      bool send_subscription_request = false;
-      NodeID cur_owner = (NodeID)-1;
-      {
-        AutoLock<> a(mutex);
-        previous_subscription = gen_subscribed.load();
-        if(previous_subscription < subscribe_gen) {
-          gen_subscribed.store(subscribe_gen);
-          // test ownership while holding the mutex
-          if(owner != Network::my_node_id) {
-            send_subscription_request = true;
-            cur_owner = owner;
-          }
-        }
+    PendingSends sends;
+    {
+      AutoLock<> a(mutex);
+      if(subscribe_gen > gen_subscribed.load()) {
+        gen_subscribed.store(subscribe_gen);
       }
-
-      // if we're not the owner, send subscription if we haven't already
-      if(send_subscription_request) {
-        log_barrier.info() << "subscribing to barrier " << make_barrier(subscribe_gen)
-                           << " (prev=" << previous_subscription << ")";
-        barrier_comm->subscribe(cur_owner, me.id, subscribe_gen, Network::my_node_id,
-                                false);
-      }
+      // step 4: a node not covered by the owner's published set pulls.  It is
+      //  'member' that decides this, NOT a per-generation watermark: membership
+      //  on the scalable path is persistent, so a node already in the set needs
+      //  nothing at all for a later generation.
+      consult_subscribe_locked(sends);
     }
+
+    emit_pending_sends(sends);
   }
 
   void BarrierImpl::external_wait(gen_t gen_needed, bool &poisoned)
@@ -1193,15 +4463,24 @@ namespace Realm {
     return true;
   }
 
+  // NOTIFICATION_PROTOCOL action C.  This is a CONSULTATION - one of the three
+  //  the departure hysteresis of rule 8 will count (the others are 'subscribe'
+  //  and 'external_wait'), and explicitly not 'has_triggered'.
   bool BarrierImpl::add_waiter(gen_t needed_gen,
                                EventWaiter *waiter /*, bool pre_subscribed = false*/)
   {
     bool trigger_now = false;
-    gen_t previous_subscription;
-    bool send_subscription_request = false;
-    NodeID cur_owner = (NodeID)-1;
+    bool trigger_poisoned = false;
+    PendingSends sends;
     {
       AutoLock<> a(mutex);
+
+      // RULE 8 step 3 - THE CONSULTATION SIGNAL, and it is recorded on BOTH
+      //  branches below.  Action C records it even when the generation has
+      //  already triggered ("skip to 3"): a node repeatedly asking about
+      //  generations it has already seen is still using this barrier, and
+      //  retiring it would only cost it a pull the next time it waits.
+      note_consultation_locked();
 
       if(needed_gen > generation.load()) {
         Generation *g;
@@ -1215,28 +4494,28 @@ namespace Realm {
         }
         g->local_waiters.push_back(waiter);
 
-        // check to see if we need to subscribe
-        if((owner != Network::my_node_id) && (gen_subscribed.load() < needed_gen)) {
-          previous_subscription = gen_subscribed.load();
+        if(needed_gen > gen_subscribed.load()) {
           gen_subscribed.store(needed_gen);
-          send_subscription_request = true;
-          cur_owner = owner;
         }
+        // step 4: pull if this node is not covered.  A node already in the
+        //  owner's published set is covered for EVERY generation, so needing a
+        //  higher one is not on its own a reason to speak.
+        consult_subscribe_locked(sends);
       } else {
         // needed generation has already occurred - trigger this waiter once we let go
-        // of lock
+        // of lock.  Its poison status is whatever we know, which
+        // PoisonAccurate says is exactly the truth up to our own watermark.
         trigger_now = true;
+        trigger_poisoned = is_generation_poisoned(needed_gen);
       }
     }
 
-    if(send_subscription_request) {
-      log_barrier.info() << "subscribing to barrier " << make_barrier(needed_gen)
-                         << " (prev=" << previous_subscription << ")";
-      barrier_comm->subscribe(cur_owner, me.id, needed_gen, Network::my_node_id, false);
-    }
+    emit_pending_sends(sends);
 
     if(trigger_now) {
-      waiter->event_triggered(POISON_FIXME, TimeLimit::responsive());
+      // the CALLER's budget, never a manufactured one
+      //  (tla/STATE_AND_LOCKING.md section 5 R2)
+      waiter->event_triggered(trigger_poisoned, TimeLimit::responsive());
     }
 
     return true;
@@ -1259,10 +4538,17 @@ namespace Realm {
     return true;
   }
 
+  ////////////////////////////////////////////////////////////////////////
+  //
+  // NOTIFICATION_PROTOCOL action S - a pull reaches the owner (rules 3 and 5).
+  //  One critical section covers the set mutation and the version stamp,
+  //  because rule 2 requires the 'set_ver' a recipient gates on to be the one
+  //  that describes the set it is gating against.
+  //
   void BarrierImpl::handle_remote_subscription(NodeID subscriber,
                                                EventImpl::gen_t subscribe_gen,
-                                               bool forwarded, const void *data,
-                                               size_t datalen)
+                                               EventImpl::gen_t last_known,
+                                               const void *data, size_t datalen)
   {
     // take the lock and add the subscribing node - notice if they need to be notified
     // for
@@ -1272,7 +4558,11 @@ namespace Realm {
     void *final_values_copy = 0;
     size_t final_values_size = 0;
     NodeID forward_to_node = (NodeID)-1;
-    NodeID inform_migration = (NodeID)-1;
+    // the scalable reply (rule 5).  Composed here, sent after the unlock (S2).
+    bool send_reply = false;
+    EventImpl::gen_t reply_wm = 0;
+    uint64_t reply_sv = 0;
+    std::vector<gen_t> reply_poison;
 
     do {
       AutoLock<> a(mutex);
@@ -1283,16 +4573,59 @@ namespace Realm {
       if(owner != Network::my_node_id) {
         forward_to_node = owner;
         break;
-      } else {
-        if(forwarded) {
-          // our own request wrapped back around can be ignored - we've already added
-          // the local waiter
-          if(subscriber == Network::my_node_id) {
-            break;
-          }
-          inform_migration = subscriber;
-        }
       }
+
+      if(redop_id == 0) {
+        // ---- THE SCALABLE PATH ------------------------------------------
+        //
+        // RULE 3 - THE ADD IS MANDATORY.  Refusing it strands a waiter;
+        //  refusing a REMOVAL only costs bandwidth, which is the asymmetry the
+        //  whole discretionary-shrink cost test rests on.  A subscribe also
+        //  retracts any departure intent this node had collected - the model's
+        //  'wantOut' = 'wantOut \ {m.from}'.
+        const bool was_in = sub_set.contains(subscriber);
+        sub_set.add(subscriber);
+        if(!was_in) {
+          // RULE 2 - the version moves on EVERY change to the set
+          set_ver += 1;
+          // rule 8 - the set just changed SHAPE, so whatever the cost test
+          //  last concluded about shrinking it no longer describes anything.
+          //  This is the only thing that clears a declined verdict, which is
+          //  what makes the hint sticky enough to be worth publishing.
+          shrink_pays = true;
+        }
+        want_out.remove(subscriber);
+
+        // RULE 5 - the reply is a DELTA keyed on what the subscriber said it
+        //  already knew.  A notification cannot do this: it goes to nodes with
+        //  different watermarks, and keying it per recipient is precisely the
+        //  per-node map this design deleted.
+        //
+        // THE REPLY MUST CARRY THE WATERMARK, and it is sent even when nothing
+        //  has triggered.  That is what covers the trigger-during-subscribe
+        //  race, and it is what closes the subscriber's rule-7 pull window.
+        // IMPLEMENTATION_PLAN section 5 - SUBSCRIBE FAN-IN.  This is the last
+        //  unaggregated O(N) path in the design, so it is the number that says
+        //  whether the escape hatch is ever needed.
+        counters.subscribe_fan_in++;
+
+        send_reply = true;
+        reply_wm = active_generation;
+        reply_sv = set_ver;
+        const int npg = num_poisoned_generations.load();
+        for(int i = 0; i < npg; i++) {
+          const gen_t pg = poisoned_generations[i];
+          if((pg > last_known) && (pg <= reply_wm)) {
+            reply_poison.push_back(pg);
+          }
+        }
+        break;
+      }
+
+      // ---- THE LEGACY / REDUCTION PATH, unchanged ------------------------
+      // One subscribe message type, two reply shapes, forked HERE at the owner
+      //  - which is exactly why a remote node never has to know in advance
+      //  whether this is a reduction barrier (D2).
 
       // make sure the subscription is for this "lifetime" of the barrier
       assert(subscribe_gen > first_generation);
@@ -1311,9 +4644,7 @@ namespace Realm {
             it->second = subscribe_gen;
           }
         } else {
-          // new subscription - don't reset remote_trigger_gens because the node may
-          // have
-          //  been subscribed in the past
+          // new subscription - the node may have been subscribed in the past
           // NOTE: remote_subscribe_gens should only hold subscriptions for
           //  generations that haven't triggered, so if we're subscribing to
           //  an old generation, don't add it
@@ -1326,75 +4657,47 @@ namespace Realm {
       // as long as we're not already subscribed to this generation, check to see if
       //  any trigger notifications are needed
       if(!already_subscribed && (active_generation > first_generation)) {
+        // the reply has to carry the reduction values the subscriber has not
+        //  seen, so the owner needs a per-node record of what it last told each
+        //  node.  This is the map the scalable path replaced with 'lk'.
+        LegacyReductionState &ls = legacy_state();
         std::map<unsigned, EventImpl::gen_t>::iterator it =
-            remote_trigger_gens.find(subscriber);
-        if((it == remote_trigger_gens.end()) || (it->second < generation.load())) {
+            ls.remote_trigger_gens.find(subscriber);
+        if((it == ls.remote_trigger_gens.end()) || (it->second < active_generation)) {
           previous_gen =
-              ((it == remote_trigger_gens.end()) ? first_generation : it->second);
-          trigger_gen = generation.load();
-          remote_trigger_gens[subscriber] = active_generation;
+              ((it == ls.remote_trigger_gens.end()) ? first_generation : it->second);
+          trigger_gen = active_generation;
+          ls.remote_trigger_gens[subscriber] = active_generation;
 
-          if(redop) {
-            int rel_gen = previous_gen + 1 - first_generation;
-            assert(rel_gen > 0);
-            final_values_size = (trigger_gen - previous_gen) * redop->sizeof_lhs;
-            final_values_copy =
-                bytedup(final_values.data() + ((rel_gen - 1) * redop->sizeof_lhs),
-                        final_values_size);
-          }
+          int rel_gen = previous_gen + 1 - first_generation;
+          assert(rel_gen > 0);
+          final_values_size = (trigger_gen - previous_gen) * redop->sizeof_lhs;
+          final_values_copy =
+              bytedup(final_values.data() + ((rel_gen - 1) * redop->sizeof_lhs),
+                      final_values_size);
         }
       }
     } while(0);
 
     if(forward_to_node != (NodeID)-1) {
-      barrier_comm->subscribe(forward_to_node, me.id, subscribe_gen, subscriber,
-                              (subscriber != Network::my_node_id));
+      BarrierSubscribeMessage::send_request(forward_to_node, me.id, subscribe_gen,
+                                            last_known, subscriber);
     }
 
-    if(inform_migration != (NodeID)-1) {
-      ID id(me);
-      id.barrier_generation() = subscribe_gen;
-      Barrier b = id.convert<Barrier>();
-      BarrierMigrationMessage::send_request(inform_migration, b, Network::my_node_id);
+    if(send_reply) {
+      log_barrier.info() << "replying to barrier subscribe: " << me
+                         << " dest=" << subscriber << " lk=" << last_known
+                         << " wm=" << reply_wm << " sv=" << reply_sv
+                         << " pois=" << reply_poison.size();
+      BarrierSubscribeReplyMessage::send_request(subscriber, me.id, reply_wm, reply_sv,
+                                                 reply_poison);
     }
 
     // send trigger message outside of lock, if needed
     if(trigger_gen > 0) {
-#ifndef BARRIER_ENABLE_BROADCAST
-      BarrierTriggerMessage::send_request(
-          subscriber, me.id, trigger_gen, previous_gen, first_generation, redop_id,
-          (NodeID)-1 /*no migration*/, 0 /*dummy arrival count*/, final_values_copy,
-          final_values_size);
-#else
-      BarrierTriggerMessageArgs trigger_args;
-      trigger_args.internal.trigger_gen = trigger_gen;
-      trigger_args.internal.previous_gen = previous_gen;
-      trigger_args.internal.first_generation = first_generation;
-      trigger_args.internal.redop_id = redop_id;
-      trigger_args.internal.migration_target = (NodeID)-1;
-      trigger_args.internal.base_arrival_count = 0;
-      trigger_args.internal.broadcast_index = 0;
-
-      const size_t header_size =
-          sizeof(BarrierTriggerMessageArgsInternal) + sizeof(size_t);
-      Serialization::DynamicBufferSerializer dbs(header_size);
-      bool ok = dbs & trigger_args;
-      assert(ok);
-      if(final_values_size > 0) {
-        BarrierTriggerPayload payload;
-        payload.reduction.insert(
-            payload.reduction.end(), static_cast<const char *>(final_values_copy),
-            static_cast<const char *>(final_values_copy) + final_values_size);
-        ok = dbs & payload;
-        assert(ok);
-      }
-
-      size_t max_payload_size = barrier_comm->recommend_max_payload(
-          forward_to_node, sizeof(BarrierTriggerMessage));
-
-      barrier_comm->trigger(subscriber, me.id, dbs.get_buffer(), dbs.bytes_used(),
-                            max_payload_size);
-#endif
+      BarrierTriggerMessage::send_request(subscriber, me.id, trigger_gen, previous_gen,
+                                          first_generation, redop_id, final_values_copy,
+                                          final_values_size);
     }
 
     if(final_values_copy) {
@@ -1402,142 +4705,199 @@ namespace Realm {
     }
   }
 
-  void BarrierImpl::handle_remote_trigger(
-      NodeID sender, ID::IDType barrier_id, EventImpl::gen_t trigger_gen,
-      EventImpl::gen_t previous_gen, EventImpl::gen_t first_gen, ReductionOpID redop_id,
-      NodeID migration_target, int broadcast_index, unsigned base_count, const void *data,
-      size_t datalen, TimeLimit work_until)
+  ////////////////////////////////////////////////////////////////////////
+  //
+  // NOTIFICATION_PROTOCOL action D, OWNER SIDE - rule 8.
+  //
+  // One critical section, and it does exactly one thing: remember that this
+  //  node would like to be dropped.  Nothing is decided here.  The shrink is
+  //  chosen - or declined - inside action T, which is the only place it can be,
+  //  because rule 1 requires the shrink to be published to the PRE-SHRINK set
+  //  and action T is where that snapshot is taken.
+  //
+  void BarrierImpl::handle_remote_depart(NodeID from)
   {
-    // Make a copy here because this can change later
-    const EventImpl::gen_t original_gen = trigger_gen;
+    AutoLock<> a(mutex);
 
-    BarrierTriggerPayload payload;
-
-    if(datalen > 0) {
-      assert(data);
-      Serialization::FixedBufferDeserializer payload_fbd(data, datalen);
-      bool ok = payload_fbd & payload;
-      assert(ok);
+    if(owner != Network::my_node_id) {
+      // 'owner' is write-once now that migration is gone, so a departure
+      //  reaching a non-owner is not a state this protocol can produce.  Drop
+      //  it rather than forward: an intent is worth nothing, rule 8 is free to
+      //  lose them, and the node's own idle counter will offer another.
+      return;
+    }
+    if(redop_id != 0) {
+      // reduction barriers stay on the legacy eager path (D1) and have no
+      //  subscriber set to shrink
+      return;
     }
 
-    if(!payload.reduction.empty()) {
-      assert(redop_id != 0);
-      if(redop == 0) {
-        log_barrier.fatal() << "no reduction op registered for ID " << redop_id;
-        abort();
-      }
-      first_generation = first_gen;
+    counters.departs_received++;
 
-      int rel_gen = trigger_gen - first_generation;
-      assert(rel_gen > 0);
-      if(value_capacity < static_cast<size_t>(rel_gen)) {
-        size_t new_capacity = rel_gen;
-        final_values.resize(new_capacity * redop->sizeof_lhs);
-        // no need to initialize new entries - we'll overwrite them now or when data
-        // does show up
-        value_capacity = new_capacity;
-      }
-
-      assert(original_gen <= trigger_gen);
-      // trigger_gen might have changed so make sure you use original_gen here
-      assert(payload.reduction.size() ==
-             (redop->sizeof_lhs * (original_gen - previous_gen)));
-      assert(previous_gen >= first_gen);
-      memcpy(final_values.data() +
-                 ((previous_gen - first_generation) * redop->sizeof_lhs),
-             payload.reduction.data(), payload.reduction.size());
+    if(!sub_set.contains(from)) {
+      // a stale intent: the node has already been removed, or never joined.
+      //  Recording it would make the next cost test weigh a removal that is not
+      //  actually on offer, and 'want_out' is filtered against 'sub_set' again
+      //  at action T anyway.
+      return;
     }
 
-    if(!payload.remotes.empty()) {
-      std::vector<RemoteNotification> ordered_notifications = payload.remotes;
-      std::vector<NodeID> broadcast_targets;
-      get_broadcast_targets(broadcast_index, ordered_notifications.size(),
-                            broadcast_radix, broadcast_targets);
+    want_out.add(from);
+  }
 
-      const void *red_data =
-          payload.reduction.empty() ? nullptr : payload.reduction.data();
-      size_t red_size = payload.reduction.size();
+  ////////////////////////////////////////////////////////////////////////
+  //
+  // NOTIFICATION_PROTOCOL action N - a notification arrives (BarrierNotify
+  //  RecvNotify).  ONE critical section, in this order.
+  //
+  void BarrierImpl::handle_remote_notify(gen_t wm, gen_t prev, uint64_t sv,
+                                         const gen_t *poison, size_t num_poisoned,
+                                         bool inset, bool hint, TimeLimit work_until)
+  {
+    EventWaiter::EventWaiterList local_notifications, poisoned_notifications;
+    PendingSends sends;
 
-      broadcast_trigger(ordered_notifications, broadcast_targets,
-                        /*oldest_previous=*/0, /*broadcast_previous=*/0, first_gen,
-                        migration_target, base_arrival_count, redop_id, red_data,
-                        red_size);
-    }
-
-    // we'll probably end up with a list of local waiters to notify
-    EventWaiter::EventWaiterList local_notifications;
     {
       AutoLock<> a(mutex);
 
-      bool generation_updated = false;
+      // STEP 0 - RULE 8's advisory byte.  Not version gated and not ordered
+      //  against anything: it is a hint, the worst a stale one can do is waste
+      //  or withhold one unicast, and both are bandwidth.
+      shrink_hint = hint;
 
-      // handle migration of the barrier ownership (possibly to us)
-      if(migration_target != (NodeID)-1) {
-        owner = migration_target;
-        base_arrival_count = base_count;
+      // STEP 1 - MEMBERSHIP, VERSION GATED, AND APPLIED EVEN ON A GAP.
+      //  RULE 2: only a strictly newer version may change what this node
+      //  believes, or a stale in-flight notification resurrects membership the
+      //  owner has already dropped and the node hangs on its next wait.
+      //  RULE 1: this message may be this node's ONLY notice of its own
+      //  removal, so the membership half runs before - and independently of -
+      //  the delta half below.
+      if(sv > my_set_ver) {
+        my_set_ver = sv;
+        member = (inset ? MEMBER_YES : MEMBER_NO);
+        if(member == MEMBER_NO) {
+          // rule 8 - the request this node made has been granted, so the latch
+          //  that kept it from asking twice has done its job
+          depart_outstanding = false;
+        }
       }
 
-      // it's theoretically possible for multiple trigger messages to arrive out
-      //  of order, so check if this message triggers the oldest possible range
-      // NOTE: it's ok for previous_gen to be earlier than our current generation - this
-      //  occurs with barrier migration because the new owner may not know which
-      //  notifications have already been performed
-      if(previous_gen <= generation.load()) {
-        // see if we can pick up any of the held triggers too
-        while(!held_triggers.empty()) {
-          std::map<EventImpl::gen_t, EventImpl::gen_t>::iterator it =
-              held_triggers.begin();
-          // if it's not contiguous, we're done
-          if(it->first != trigger_gen) {
-            break;
-          }
-          // it is contiguous, so absorb it into this message and remove the held
-          // trigger
-          log_barrier.info("collapsing future trigger: " IDFMT "/%d -> %d -> %d",
-                           barrier_id, previous_gen, trigger_gen, it->second);
-          trigger_gen = it->second;
-          held_triggers.erase(it);
-        }
+      // STEP 2 - the gap test.  A delta is only applicable if this node has
+      //  already seen everything below 'prev'.
+      const gen_t known = generation.load();
+      const bool gap = (prev > known);
+      const bool fresh = (!gap) && (wm > known);
 
-        if(trigger_gen > generation.load()) {
-          generation.store_release(trigger_gen);
-          generation_updated = true;
-        }
-
-        // now iterate through any generations up to and including the latest triggered
-        //  generation, and accumulate local waiters to notify
-        while(!generations.empty()) {
-          std::map<EventImpl::gen_t, BarrierImpl::Generation *>::iterator it =
-              generations.begin();
-          if(it->first > trigger_gen) {
-            break;
-          }
-
-          local_notifications.absorb_append(it->second->local_waiters);
-          delete it->second;
-          generations.erase(it);
-        }
-      } else {
-        // hold this trigger until we get messages for the earlier generation(s)
-        log_barrier.info("holding future trigger: " IDFMT "/%d (%d -> %d)", barrier_id,
-                         generation.load(), previous_gen, trigger_gen);
-        held_triggers[previous_gen] = trigger_gen;
+      if(gap) {
+        // STEP 3a - RULE 4: DISCARD THE DELTA ENTIRELY.  Applying it would
+        //  advance the watermark over generations whose poison status this node
+        //  cannot know, which is a waiter woken with the wrong poison status.
+        //  It is NOT buffered: 'held_triggers' is not coming back, because the
+        //  pull path has to exist anyway and is strictly simpler.
+        counters.gap_pulls++;
+        log_barrier.info() << "discarding barrier notify with gap: " << me
+                           << " known=" << known << " (" << prev << " -> " << wm << ")";
+      } else if(fresh) {
+        // STEP 3b - poison first, then the watermark (section 3.5)
+        publish_watermark_locked(wm, poison, num_poisoned, local_notifications,
+                                 poisoned_notifications);
       }
 
-      // external waiters need to be signalled inside the lock
-      if(generation_updated && has_external_waiters) {
-        has_external_waiters = false;
-        // also need external waiter mutex
-        AutoLock<KernelMutex> al2(external_waiter_mutex);
-        external_waiter_condvar.broadcast();
+      // STEP 4 - RULE 6.  A node removed while it still holds an outstanding
+      //  waiter RE-SUBSCRIBES AT ONCE.  This is the correctness rule: the idle
+      //  counter advances with the watermark, so a node waiting on a far-future
+      //  generation LOOKS IDLE and can be dropped.  Declining to depart while
+      //  holding a waiter is only an optimisation and is not sufficient on its
+      //  own, because a waiter can be registered after the departure intent was
+      //  collected and before the owner applies the shrink.
+      const bool resub = (member == MEMBER_NO) && has_waiters_locked();
+      if(resub) {
+        // rule 8 - being dropped and immediately needing back in is the
+        //  clearest churn signal there is, and it is exactly the case rule 6
+        //  describes: a node parked on a far-future generation looks idle
+        //  while the watermark climbs underneath it
+        note_rejoin_locked();
+        member = MEMBER_PENDING;
       }
+
+      // STEP 5 - the pull, rule 7 gated
+      if(gap || resub) {
+        record_pull_locked(sends);
+      }
+
+      // STEP 6 - RULE 8, THE DEPARTURE HYSTERESIS.  It is evaluated here
+      //  because this is where the watermark advances, and the idle counter is
+      //  measured in watermark generations rather than in messages or in time.
+      consider_departure_locked(sends);
     }
 
-    // with lock released, perform any local notifications
-    if(!local_notifications.empty()) {
-      get_runtime()->event_triggerer.trigger_event_waiters(local_notifications,
-                                                           POISON_FIXME, work_until);
+    emit_pending_sends(sends);
+    deliver_waiters(local_notifications, poisoned_notifications, work_until);
+  }
+
+  ////////////////////////////////////////////////////////////////////////
+  //
+  // NOTIFICATION_PROTOCOL action RP - the answer to a pull (BarrierNotify
+  //  RecvReply).
+  //
+  void BarrierImpl::handle_remote_subscribe_reply(gen_t wm, uint64_t sv,
+                                                  const gen_t *poison,
+                                                  size_t num_poisoned,
+                                                  TimeLimit work_until)
+  {
+    EventWaiter::EventWaiterList local_notifications, poisoned_notifications;
+    PendingSends sends;
+
+    {
+      AutoLock<> a(mutex);
+
+      // STEP 1 - the rule-7 window closes
+      pull_outstanding = false;
+
+      // STEP 2 - RULE 2 again.  The SAME version gate is required here: a stale
+      //  reply resurrects membership exactly the way a stale notify does.
+      if(sv > my_set_ver) {
+        my_set_ver = sv;
+        member = MEMBER_YES;
+      }
+
+      // STEP 3 - RULE 5: the poison list is a DELTA above the 'lk' this node
+      //  sent, so it is MERGED (add_poison_locked is idempotent), never
+      //  substituted.  Substituting would drop the poison this node already
+      //  knew about below 'lk'.
+      if(wm > generation.load()) {
+        publish_watermark_locked(wm, poison, num_poisoned, local_notifications,
+                                 poisoned_notifications);
+      }
+      // STEP 4 - if the reply is not fresh, do not merge.  Safe because this
+      //  node's poison knowledge is already exactly the truth up to its own
+      //  (higher) watermark.
+
+      // STEP 5 - re-issue whatever rule 7 suppressed while this pull was
+      //  outstanding.  The model only suppresses while a SUBSCRIBE is in
+      //  flight; from the owner's consumption of it to the reply landing here
+      //  the model WOULD have pulled, so anything recorded in 'pull_deferred'
+      //  is issued now.  A node removed while still holding a waiter also
+      //  recovers here, for the same reason it does in action N.
+      const bool resub = (member == MEMBER_NO) && has_waiters_locked();
+      if(resub) {
+        note_rejoin_locked(); // rule 8 - see action N step 4
+        member = MEMBER_PENDING;
+      }
+      if(pull_deferred || resub) {
+        pull_deferred = false;
+        record_pull_locked(sends);
+      }
+
+      // STEP 6 - RULE 8.  The reply advances the watermark too - often by a
+      //  long way, since it is what a node that had fallen behind catches up
+      //  on - so the eligibility test belongs here for the same reason it
+      //  belongs in action N.
+      consider_departure_locked(sends);
     }
+
+    emit_pending_sends(sends);
+    deliver_waiters(local_notifications, poisoned_notifications, work_until);
   }
 
   bool BarrierImpl::get_result(gen_t result_gen, void *value, size_t value_size)
@@ -1564,11 +4924,16 @@ namespace Realm {
     return true;
   }
 
-#ifdef BARRIER_ENABLE_BROADCAST
-  AutoMessageRegistrar<BarrierTriggerMessage> handler;
-#endif
   ActiveMessageHandlerReg<BarrierTriggerMessage> barrier_handler_trigger;
+  ActiveMessageHandlerReg<BarrierReportMessage> barrier_report_message_handler;
+  ActiveMessageHandlerReg<BarrierFlushMessage> barrier_flush_message_handler;
+  ActiveMessageHandlerReg<BarrierInvalidateMessage> barrier_invalidate_message_handler;
+  ActiveMessageHandlerReg<BarrierNewPlanMessage> barrier_newplan_message_handler;
+  ActiveMessageHandlerReg<BarrierAlterMessage> barrier_alter_message_handler;
+  ActiveMessageHandlerReg<BarrierTsArrivalMessage> barrier_ts_arrival_message_handler;
   ActiveMessageHandlerReg<BarrierAdjustMessage> barrier_adjust_message_handler;
   ActiveMessageHandlerReg<BarrierSubscribeMessage> barrier_subscribe_message_handler;
-  ActiveMessageHandlerReg<BarrierMigrationMessage> barrier_migration_message_handler;
+  ActiveMessageHandlerReg<BarrierNotifyMessage> barrier_notify_message_handler;
+  ActiveMessageHandlerReg<BarrierSubscribeReplyMessage> barrier_subscribe_reply_handler;
+  ActiveMessageHandlerReg<BarrierDepartMessage> barrier_depart_message_handler;
 }; // namespace Realm

--- a/src/realm/barrier_impl.cc
+++ b/src/realm/barrier_impl.cc
@@ -680,15 +680,15 @@ namespace Realm {
       inset = !departing.contains(Network::my_node_id);
     }
 
-    impl->handle_remote_notify(args.wm, args.prev, args.set_ver, poison,
+    impl->handle_remote_notify(args.wm, args.prev, args.gather_gen, args.set_ver, poison,
                                args.num_poisoned, inset, (args.shrink_hint != 0),
                                work_until);
   }
 
   /*static*/ void BarrierNotifyMessage::send_request(
       const MulticastTargetSet &targets, ID::IDType barrier_id, EventImpl::gen_t wm,
-      EventImpl::gen_t prev, uint64_t set_ver, bool shrink_hint,
-      const std::vector<EventImpl::gen_t> &poison,
+      EventImpl::gen_t prev, EventImpl::gen_t gather_gen, uint64_t set_ver,
+      bool shrink_hint, const std::vector<EventImpl::gen_t> &poison,
       const std::vector<unsigned char> &departing)
   {
     if(targets.empty()) {
@@ -709,6 +709,7 @@ namespace Realm {
     hdr.barrier_id = barrier_id;
     hdr.wm = wm;
     hdr.prev = prev;
+    hdr.gather_gen = gather_gen;
     hdr.set_ver = set_ver;
     hdr.num_poisoned = static_cast<uint32_t>(poison.size());
     hdr.departing_bytes = static_cast<uint32_t>(departing.size());
@@ -812,6 +813,7 @@ namespace Realm {
     return (departs_sent | departs_suppressed | leave_rejoin_cycles | churn_backoffs |
             subscribe_fan_in | departs_received | shrinks_applied | shrinks_declined |
             nodes_removed | flush_episodes | flush_report_bytes | plan_rebuilds |
+            plan_rebuilds_declined | gathering_declared | identical_plans_skipped |
             plans_parked | parked_plans_applied | dead_plans_discarded |
             retro_flushes_sent | stale_edge_forwards | report_edges_pinned |
             pin_conflicts_avoided | gap_pulls) != 0;
@@ -842,6 +844,9 @@ namespace Realm {
                        << " flush_report_bytes=" << counters.flush_report_bytes
                        << " flush_report_bytes_max=" << counters.flush_report_bytes_max
                        << " plan_rebuilds=" << counters.plan_rebuilds
+                       << " plan_rebuilds_declined=" << counters.plan_rebuilds_declined
+                       << " gathering_declared=" << counters.gathering_declared
+                       << " identical_plans_skipped=" << counters.identical_plans_skipped
                        << " agg_peak_entries=" << counters.agg_peak_entries
                        << " plans_parked=" << counters.plans_parked
                        << " parked_plans_applied=" << counters.parked_plans_applied
@@ -2252,6 +2257,7 @@ namespace Realm {
         continue;
       }
       if(it->second > static_cast<int64_t>(UINT32_MAX)) {
+        counters.plan_rebuilds_declined++;
         log_barrier.info() << "declining barrier plan rebuild (count overflow): " << me
                            << " node=" << it->first << " count=" << it->second;
         return;
@@ -2305,8 +2311,40 @@ namespace Realm {
     //  complete under the stale plan forces a full flush before it triggers,
     //  and that flush is exactly what makes the gathering complete.
     if((tree_arrivals > 0) && (gathered != tree_arrivals)) {
+      counters.plan_rebuilds_declined++;
       log_barrier.info() << "declining barrier plan rebuild (partial evidence): " << me
-                         << " gathered=" << gathered << " of " << tree_arrivals;
+                         << " gen=" << (generation.load()) << " gathered=" << gathered
+                         << " of " << tree_arrivals;
+      // THE GATHERING GENERATION (ARRIVAL_PROTOCOL section 11.5).  Partial
+      //  evidence is STRUCTURAL, not transient: a deviation discovered
+      //  mid-generation can never yield complete maps, because the traffic
+      //  that flowed before the flush reached its senders was bare rule-1
+      //  counts.  Declining alone therefore never converges - under a
+      //  PERSISTENT pattern shift every generation declines the same way and
+      //  the barrier stays eager forever (the P_STEP probe measures exactly
+      //  this).  So the owner DECLARES the next generation a gathering
+      //  generation: it enters flush for it now, and the fan-out below makes
+      //  every node eager for that generation from its first arrival.  Its
+      //  evidence is then complete BY CONSTRUCTION, the rebuild at its
+      //  trigger succeeds, and the plan it produces governs the generation
+      //  after.  Cost: one fully-eager generation per pattern shift.
+      //  enter_flush_locked is idempotent and re-arms plan_rebuild_pending,
+      //  so repeated declines while the gathering generation is already
+      //  declared collapse into one declaration.
+      if(declines_until_gather > 0) {
+        // backing off: the last gathering(s) reproduced the current plan, so
+        //  this deviation pattern has no better plan to learn right now
+        declines_until_gather--;
+      } else {
+        const gen_t gather_gen = generation.load() + 1;
+        Generation *ng = get_generation_locked(gather_gen);
+        if(!ng->flushing) {
+          counters.gathering_declared++;
+          log_barrier.info() << "declaring gathering generation: " << me
+                             << " gen=" << gather_gen;
+        }
+        enter_flush_locked(*ng, gather_gen, sends);
+      }
       return;
     }
 
@@ -2318,6 +2356,7 @@ namespace Realm {
     const gen_t plan_from = generation.load() + 1;
     const int64_t expected = expected_locked(plan_from);
     if(total > expected) {
+      counters.plan_rebuilds_declined++;
       log_barrier.info() << "declining barrier plan rebuild (would over-predict): " << me
                          << " sum=" << total << " expected=" << expected;
       return;
@@ -2326,6 +2365,39 @@ namespace Realm {
     // IMPLEMENTATION_PLAN section 5 - PLAN REBUILD FREQUENCY.  Counted past the
     //  declines, so it measures plans actually installed: a steady workload
     //  should build one and then stop.
+    // THE IDENTICAL-PLAN SKIP (section 11.5).  Under an ALTERNATING pattern -
+    //  no single plan fits, e.g. every odd generation deviates the same way -
+    //  each gathering generation reproduces the plan already installed, and
+    //  installing it would buy an invalidate+newplan broadcast per rebuild for
+    //  nothing (measured: 65 rebuilds per 128 generations on the OVER probe).
+    //  A 64-bit hash stands in for the last plan; on a match the install is
+    //  skipped and the GATHERING BACKOFF doubles, so an adversarial pattern
+    //  decays to the pre-gathering behaviour (deviating generations flush,
+    //  conforming ones aggregate) instead of gathering forever.  A pattern
+    //  shift that produces a DIFFERENT plan resets the backoff, so a genuine
+    //  step-change still converges immediately.
+    {
+      uint64_t h = 0x9E3779B97F4A7C15ull;
+      for(size_t i = 0; i < tv.size(); i++) {
+        h = (h ^ static_cast<uint64_t>(tv[i])) * 0x100000001B3ull;
+        h = (h ^ static_cast<uint64_t>(quota[i])) * 0x100000001B3ull;
+      }
+      if((my_epoch != 0) && (h == last_plan_hash)) {
+        counters.identical_plans_skipped++;
+        gather_backoff = (gather_backoff == 0)
+                             ? 1
+                             : ((gather_backoff < 32) ? (gather_backoff * 2) : 32);
+        declines_until_gather = gather_backoff;
+        log_barrier.info() << "skipping identical barrier plan: " << me
+                           << " gen=" << generation.load()
+                           << " backoff=" << gather_backoff;
+        return;
+      }
+      last_plan_hash = h;
+      gather_backoff = 0;
+      declines_until_gather = 0;
+    }
+
     counters.plan_rebuilds++;
 
     const uint32_t new_epoch = next_epoch++;
@@ -2520,9 +2592,9 @@ namespace Realm {
                          << " pois=" << sends.notify.poison.size()
                          << " dep=" << sends.notify.departing.size();
       BarrierNotifyMessage::send_request(sends.notify.targets, me.id, sends.notify.wm,
-                                         sends.notify.prev, sends.notify.set_ver,
-                                         sends.notify.shrink_hint, sends.notify.poison,
-                                         sends.notify.departing);
+                                         sends.notify.prev, sends.notify.gather_gen,
+                                         sends.notify.set_ver, sends.notify.shrink_hint,
+                                         sends.notify.poison, sends.notify.departing);
     }
 
     // NOTIFICATION_PROTOCOL rule 8 - the departure intent.  UNICAST to the
@@ -3222,6 +3294,18 @@ namespace Realm {
         sends.notify.valid = true;
         sends.notify.wm = trigger_gen;
         sends.notify.prev = old_watermark;
+        // section 11.5: if the rebuild declined and declared the next
+        //  generation a gathering generation, the declaration RIDES THIS
+        //  NOTIFICATION - the receiver marks it eager in the same critical
+        //  section that wakes its waiters, which is the only ordering that
+        //  beats the wake->arrive race (P_STEP measured the flush-message
+        //  version losing on nearly every generation).
+        {
+          std::map<gen_t, Generation *>::iterator git = generations.find(trigger_gen + 1);
+          sends.notify.gather_gen = ((git != generations.end()) && git->second->flushing)
+                                        ? (trigger_gen + 1)
+                                        : 0;
+        }
         sends.notify.set_ver = set_ver;
         // rule 8's one-byte hint rides the notification that was going out
         //  anyway, so it costs nothing on the wire
@@ -4750,9 +4834,10 @@ namespace Realm {
   // NOTIFICATION_PROTOCOL action N - a notification arrives (BarrierNotify
   //  RecvNotify).  ONE critical section, in this order.
   //
-  void BarrierImpl::handle_remote_notify(gen_t wm, gen_t prev, uint64_t sv,
-                                         const gen_t *poison, size_t num_poisoned,
-                                         bool inset, bool hint, TimeLimit work_until)
+  void BarrierImpl::handle_remote_notify(gen_t wm, gen_t prev, gen_t gather_gen,
+                                         uint64_t sv, const gen_t *poison,
+                                         size_t num_poisoned, bool inset, bool hint,
+                                         TimeLimit work_until)
   {
     EventWaiter::EventWaiterList local_notifications, poisoned_notifications;
     PendingSends sends;
@@ -4780,6 +4865,20 @@ namespace Realm {
           //  that kept it from asking twice has done its job
           depart_outstanding = false;
         }
+      }
+
+      // STEP 2.5 (ordered BEFORE the wake in step 3b) - THE GATHERING
+      //  GENERATION (ARRIVAL_PROTOCOL section 11.5).  The owner declared the
+      //  generation after this trigger fully eager so that the next rebuild's
+      //  evidence completes by construction.  The declaration rides THIS
+      //  message precisely so it can be applied in the same critical section
+      //  that wakes this node's waiters: a woken waiter's next arrival then
+      //  finds 'flushing' already set and reports WITH a map.  A separate
+      //  flush message loses that race on nearly every generation (measured
+      //  by the P_STEP probe: gathered=7-of-8 declines, forever).
+      if(gather_gen > generation.load()) {
+        Generation *ng = get_generation_locked(gather_gen);
+        enter_flush_locked(*ng, gather_gen, sends);
       }
 
       // STEP 2 - the gap test.  A delta is only applicable if this node has

--- a/src/realm/barrier_impl.h
+++ b/src/realm/barrier_impl.h
@@ -865,6 +865,15 @@ namespace Realm {
                                 //  derived - the model's global ParentOf() search
                                 //  is a modelling convenience (section 8.1)
       std::vector<NodeID> kids; // O(radix)
+      // QUOTA-GATED FORWARDING (ARRIVAL_PROTOCOL section 13).  What the plan
+      //  predicts this node's WHOLE subtree contributes per generation - the
+      //  gate in should_report_locked() - and per-child subtree totals, which
+      //  only the owner's receipt valve and switch audit read.  Both computed
+      //  at install from the plan payload (each node receives its entire
+      //  subtree slice), so nothing new travels on the wire and storage stays
+      //  O(radix).
+      int64_t subtree_quota = 0;
+      std::vector<int64_t> kid_subq; // parallel to 'kids'
     };
 
     ArrivalPlan cur_plan;     // curPlan[n]
@@ -1196,6 +1205,15 @@ namespace Realm {
       uint64_t reports_received = 0;  // planned/eager reports delivered here
       uint64_t notifies_received = 0; // trigger notifications delivered here
 
+      // --- QUOTA-GATED FORWARDING (ARRIVAL_PROTOCOL section 13).  The gate's
+      //     exercise proof: 'reports_gated' counts forwards the subtree quota
+      //     held back (each one is a message the ungated design would have
+      //     sent), 'owner_valve_flushes' counts the owner's deviation valve
+      //     firing (receipt tests and the switch-time audit) - the safety
+      //     mechanism that makes gating strand-free.
+      uint64_t reports_gated = 0;
+      uint64_t owner_valve_flushes = 0;
+
       // has anything at all happened worth reporting?
       bool any(void) const;
     };
@@ -1236,10 +1254,10 @@ namespace Realm {
     // find or create the record for 'gen'
     Generation *get_generation_locked(gen_t gen);
 
-    // ARRIVAL_PROTOCOL rule 1, BOTH halves: this node's local arrival count
-    //  equals the quota its plan predicts AND every child the plan predicts has
-    //  reported at least once.
-    bool plan_satisfied_locked(const Generation &g) const;
+    // ARRIVAL_PROTOCOL rule 1 / section 13 - QUOTA-GATED FORWARDING: in
+    //  planned, non-flushing mode a node speaks exactly once per generation,
+    //  when its subtree total reaches (>=) the plan's subtree quota.  The test
+    //  lives inline in should_report_locked().
 
     // where a report from this node goes (section 8.1: the parent is stored)
     NodeID report_target_locked(void) const;

--- a/src/realm/barrier_impl.h
+++ b/src/realm/barrier_impl.h
@@ -1187,6 +1187,15 @@ namespace Realm {
       uint64_t pin_conflicts_avoided = 0; // pinned target differed from current parent
       uint64_t gap_pulls = 0;             // NOTIFICATION rule 4 gap -> pull
 
+      // --- FAST-PATH PROOF (SCALE_TEST_PLAN section 4's scaling assertions).
+      //     In steady PLANNED state the owner and every relay receive ~radix
+      //     reports per generation - flat in N - and every subscriber at most
+      //     one notify per generation (fewer when coalesced).  These state
+      //     "the tree is engaged" in a form timing noise cannot fake, which is
+      //     what the A/B benchmark cross-checks its wall-clock numbers against.
+      uint64_t reports_received = 0;  // planned/eager reports delivered here
+      uint64_t notifies_received = 0; // trigger notifications delivered here
+
       // has anything at all happened worth reporting?
       bool any(void) const;
     };

--- a/src/realm/barrier_impl.h
+++ b/src/realm/barrier_impl.h
@@ -115,6 +115,15 @@ namespace Realm {
     uint64_t set_ver;
     uint32_t num_poisoned;
     uint32_t departing_bytes;
+    // ARRIVAL_PROTOCOL section 11.5 - the GATHERING GENERATION rides the
+    //  trigger notification (0 = none).  It must: the notification is what
+    //  wakes the waiters whose next arrivals the gathering needs to catch,
+    //  and a separate flush message down a multi-hop tree loses that race
+    //  every time (measured: the P_STEP probe declined with gathered=7-of-8
+    //  on almost every post-shift generation).  Carried here, the receiver
+    //  marks the generation eager in the SAME critical section that wakes
+    //  its waiters, so no woken arrival can report planned.
+    EventImpl::gen_t gather_gen;
     // NOTIFICATION_PROTOCOL rule 8, the optional ONE-BYTE HINT: does shrinking
     //  the subscriber set currently pay?  It is the verdict the owner's cost
     //  test returned the last time it actually evaluated one, so a node that
@@ -128,7 +137,8 @@ namespace Realm {
                                const void *data, size_t datalen, TimeLimit work_until);
 
     static void send_request(const MulticastTargetSet &targets, ID::IDType barrier_id,
-                             EventImpl::gen_t wm, EventImpl::gen_t prev, uint64_t set_ver,
+                             EventImpl::gen_t wm, EventImpl::gen_t prev,
+                             EventImpl::gen_t gather_gen, uint64_t set_ver,
                              bool shrink_hint,
                              const std::vector<EventImpl::gen_t> &poison,
                              const std::vector<unsigned char> &departing);
@@ -468,9 +478,9 @@ namespace Realm {
     //  node's own membership, computed by the handler from the departing set
     //  the message carried - see BarrierNotifyMessage.  'shrink_hint' is rule
     //  8's advisory byte.
-    void handle_remote_notify(gen_t wm, gen_t prev, uint64_t sv, const gen_t *poison,
-                              size_t num_poisoned, bool inset, bool hint,
-                              TimeLimit work_until);
+    void handle_remote_notify(gen_t wm, gen_t prev, gen_t gather_gen, uint64_t sv,
+                              const gen_t *poison, size_t num_poisoned, bool inset,
+                              bool hint, TimeLimit work_until);
 
     // NOTIFICATION_PROTOCOL action D, OWNER SIDE (rule 8).  Collect one
     //  departure intent; it is applied - or declined - at the next trigger,
@@ -860,6 +870,13 @@ namespace Realm {
     // The next plan index to hand out.  Epochs are monotone and never reused,
     //  which is what makes the invalidate/newplan race resolvable locally
     //  (rule 5).  0 means "no plan has ever existed", so counting starts at 1.
+    // ARRIVAL_PROTOCOL section 11.5 - the O(1) memory the identical-plan skip
+    //  and the gathering backoff need.  A hash stands in for the last plan
+    //  (storing the plan itself is the O(N^2) blow-up D9 forbids); a false
+    //  match merely skips one install and the continuing deviations retry.
+    uint64_t last_plan_hash = 0;
+    uint32_t gather_backoff = 0;        // doubles on identical outcomes, cap 32
+    uint32_t declines_until_gather = 0; // countdown while backing off
     uint32_t next_epoch = 1;
     // Set by the only thing that can tell the owner its plan is wrong: the
     //  owner entering eager-flush mode (a 'direct' from a node the plan did not
@@ -1006,6 +1023,7 @@ namespace Realm {
       MulticastTargetSet targets; // the PRE-SHRINK subscriber set
       gen_t wm = 0;
       gen_t prev = 0;
+      gen_t gather_gen = 0; // section 11.5, rides the wake (see the message)
       uint64_t set_ver = 0;
       std::vector<gen_t> poison;            // poisoned generations in (prev, wm]
       std::vector<unsigned char> departing; // encoded R; empty if set_ver is
@@ -1133,6 +1151,19 @@ namespace Realm {
       //     the number that would show it silently growing if it ever stopped
       //     being one.
       uint64_t plan_rebuilds = 0;
+      uint64_t identical_plans_skipped = 0; // section 11.5: a rebuild that
+                                            //  reproduced the current plan was
+                                            //  not installed (no broadcast)
+      uint64_t gathering_declared = 0;      // section 11.5: next generation
+                                            //  declared fully eager so its
+                                            //  evidence completes by
+                                            //  construction
+      uint64_t plan_rebuilds_declined = 0;  // partial evidence or overflow: the
+                                            //  gate said no.  A high ratio of
+                                            //  declined:done under a PERSISTENT
+                                            //  pattern shift means the owner
+                                            //  cannot re-learn and is stuck
+                                            //  eager - the P_STEP probe.
       size_t agg_peak_entries = 0;
 
       // --- RULE 10, the pinned-edge machinery (SCALE_TEST_PLAN section 1).

--- a/src/realm/barrier_impl.h
+++ b/src/realm/barrier_impl.h
@@ -23,68 +23,49 @@
 #include "realm/event.h"
 #include "realm/event_impl.h"
 #include "realm/id.h"
+#include "realm/multicast.h"
 #include "realm/nodeset.h"
 #include "realm/redop.h"
 
+#include <cstdint>
 #include <vector>
 #include <map>
 #include <memory>
+#include <set>
 
 namespace Realm {
 
-  struct BarrierTriggerMessageArgsInternal {
-    EventImpl::gen_t trigger_gen = 0;
-    EventImpl::gen_t previous_gen = 0;
-    EventImpl::gen_t first_generation = 0;
-    ReductionOpID redop_id = 0;
-    NodeID migration_target = 0;
-    unsigned base_arrival_count = 0;
-    int broadcast_index = 0;
-  };
+  // NOTE: there is deliberately no 'BarrierCommunicator' indirection here
+  //  (decision Q8).  Every send in this file goes through the active message
+  //  interface directly, and the one place that used to route through a
+  //  communicator - the non-owner forward in adjust_arrival - now calls
+  //  BarrierAdjustMessage::send_request like everything else.
 
-  struct RemoteNotification;
-
-  struct BarrierTriggerPayload {
-    std::vector<RemoteNotification> remotes;
-    std::vector<char> reduction;
-  };
-
-  struct BarrierTriggerMessageArgs {
-    BarrierTriggerMessageArgsInternal internal;
-  };
-
-  class BarrierCommunicator {
-  public:
-    virtual ~BarrierCommunicator() = default;
-
-    virtual void adjust(NodeID target, Barrier barrier, int delta, Event wait_on,
-                        NodeID sender, bool forwarded, const void *data, size_t datalen);
-
-    virtual void trigger(NodeID target, ID::IDType barrier_id, const void *data,
-                         size_t datalen, size_t max_payload_size = 0);
-
-    virtual void subscribe(NodeID target, ID::IDType barrier_id,
-                           EventImpl::gen_t subscribe_gen, NodeID subscriber,
-                           bool forwarded);
-
-    virtual size_t recommend_max_payload(NodeID node, size_t size,
-                                         bool with_congestion = true);
-  };
-
+  // one entry per remote node that has to be told about a trigger.
+  // 'previous_gen' is the last generation that node was told about; it bounds
+  //  the slice of 'final_values' that node is sent, which is why it is
+  //  per-recipient rather than a single watermark.
+  //
+  // LEGACY / REDUCTION PATH ONLY.  The scalable path replaced this with the
+  //  owner's single subscriber set plus a delta notification
+  //  (BarrierNotifyMessage), which is what removes the O(N) per-barrier map.
   struct RemoteNotification {
     NodeID node;
     EventImpl::gen_t trigger_gen, previous_gen;
   };
 
-#ifndef BARRIER_ENABLE_BROADCAST
+  // LEGACY / REDUCTION PATH ONLY.  The owner sends this only when
+  //  'redop_id != 0', because its whole reason to exist is the per-recipient
+  //  slice of 'final_values' it carries.  Receiving one therefore PROVES the
+  //  barrier is a reduction barrier, which is how a non-owner that has never
+  //  been told 'redop_id' learns it (tla/STATE_AND_LOCKING.md D2).
   struct BarrierTriggerMessage {
     ID::IDType barrier_id;
     EventImpl::gen_t trigger_gen;
+    // the generation the recipient was last told about
     EventImpl::gen_t previous_gen;
     EventImpl::gen_t first_generation;
     ReductionOpID redop_id;
-    NodeID migration_target;
-    unsigned base_arrival_count;
 
     static void handle_message(NodeID sender, const BarrierTriggerMessage &msg,
                                const void *data, size_t datalen, TimeLimit work_until);
@@ -92,20 +73,335 @@ namespace Realm {
     static void send_request(NodeID target, ID::IDType barrier_id,
                              EventImpl::gen_t trigger_gen, EventImpl::gen_t previous_gen,
                              EventImpl::gen_t first_generation, ReductionOpID redop_id,
-                             NodeID migration_target, unsigned base_arrival_count,
                              const void *data, size_t datalen);
   };
-#endif
+
+  // NOTIFICATION_PROTOCOL rules 1, 2 and 4 - THE SCALABLE TRIGGER NOTIFICATION.
+  //
+  // It is a DELTA (rule 4): generations '(prev, wm]' have just triggered, and
+  //  the payload names whichever of THOSE are poisoned.  Its size therefore
+  //  never grows with the barrier's poison history - which was the last
+  //  unbounded quantity in the design.  The cost of that is gap sensitivity: a
+  //  recipient whose watermark is below 'prev' cannot splice this range on to
+  //  what it knows, because it would advance over generations whose poison
+  //  status it does not know.  It DISCARDS the delta and PULLS
+  //  (BarrierSubscribeMessage); it does NOT buffer it.
+  //
+  // It is MULTICAST to the owner's subscriber set, and the multicast layer
+  //  plans a fresh forwarding tree from the encoded set on every send, so there
+  //  is no learned tree to go stale and no per-node map at the owner.
+  //
+  // MEMBERSHIP RIDES ALONG (rule 1: published, never self-decided).  A
+  //  per-recipient membership flag cannot survive a multicast - every recipient
+  //  gets identical bytes - so the message carries the DEPARTING SET 'R' and
+  //  each recipient computes its own membership as '(me not in R)'.  That is
+  //  EXACT, because a shrink is published to the PRE-SHRINK set: every
+  //  recipient is in that set, so "in the set afterwards" is precisely "not
+  //  being removed".  'set_ver' version-gates it (rule 2) - apply the
+  //  membership only if it is strictly newer than the highest already applied,
+  //  or a stale in-flight notification resurrects membership the owner has
+  //  dropped and the node hangs on its next wait.  When nothing is being
+  //  removed, 'set_ver' is unchanged and no membership bytes are sent at all.
+  //
+  // Wire format of the payload:
+  //
+  //    num_poisoned x EventImpl::gen_t  (ascending; all in (prev, wm])
+  //    departing_bytes of EncodedMulticastTargets  (R; empty unless set_ver
+  //                                                 changed)
+  struct BarrierNotifyMessage {
+    ID::IDType barrier_id;
+    EventImpl::gen_t wm;   // the owner's watermark AFTER this trigger
+    EventImpl::gen_t prev; // the owner's watermark BEFORE it - the GAP DETECTOR
+    uint64_t set_ver;
+    uint32_t num_poisoned;
+    uint32_t departing_bytes;
+    // NOTIFICATION_PROTOCOL rule 8, the optional ONE-BYTE HINT: does shrinking
+    //  the subscriber set currently pay?  It is the verdict the owner's cost
+    //  test returned the last time it actually evaluated one, so a node that
+    //  would only have its request declined can suppress it and save the
+    //  round trip.  Purely advisory - it is not a permission, and a node that
+    //  ignores it is merely wasteful.  Optimistic by default (1), so the first
+    //  departure of a barrier always gets a hearing.
+    uint8_t shrink_hint;
+
+    static void handle_message(NodeID sender, const BarrierNotifyMessage &msg,
+                               const void *data, size_t datalen, TimeLimit work_until);
+
+    static void send_request(const MulticastTargetSet &targets, ID::IDType barrier_id,
+                             EventImpl::gen_t wm, EventImpl::gen_t prev, uint64_t set_ver,
+                             bool shrink_hint,
+                             const std::vector<EventImpl::gen_t> &poison,
+                             const std::vector<unsigned char> &departing);
+  };
+
+  // NOTIFICATION_PROTOCOL rule 5 - THE ANSWER TO A PULL.
+  //
+  // Point to point, so unlike a notification it can be keyed to exactly what
+  //  the subscriber said it already had: the poison list is the poisoned
+  //  generations in '(lk, wm]', where 'lk' is the subscriber's own last-known
+  //  generation from its BarrierSubscribeMessage.  The receiver MERGES that
+  //  list into what it has - substituting would drop the poison it already knew
+  //  about below 'lk'.
+  //
+  // THE REPLY MUST CARRY THE WATERMARK.  That is what covers the race where the
+  //  generation triggers while the subscribe is still on the wire, and omitting
+  //  it is caught in the model as a deadlock.  The owner therefore replies to
+  //  EVERY subscribe, even one it can answer with "nothing has triggered yet" -
+  //  the reply is also what closes the recipient's rule-7 pull window.
+  //
+  // Payload: num_poisoned x EventImpl::gen_t, ascending.
+  struct BarrierSubscribeReplyMessage {
+    ID::IDType barrier_id;
+    EventImpl::gen_t wm;
+    uint64_t set_ver;
+    uint32_t num_poisoned;
+
+    static void handle_message(NodeID sender, const BarrierSubscribeReplyMessage &msg,
+                               const void *data, size_t datalen, TimeLimit work_until);
+
+    static void send_request(NodeID target, ID::IDType barrier_id, EventImpl::gen_t wm,
+                             uint64_t set_ver,
+                             const std::vector<EventImpl::gen_t> &poison);
+  };
+
+  // NOTIFICATION_PROTOCOL rule 8 - "I have gone idle; drop me if it pays."
+  //
+  // An INTENT, never a command.  Adds are mandatory and removals are
+  //  DISCRETIONARY (rule 3), so the owner is free to decline this after its
+  //  cost test - and a declined removal is simply the next publication in
+  //  which this node still appears.  The node does NOT change its own
+  //  membership on sending one: membership is published, never self-decided
+  //  (rule 1), so the only thing that moves 'member' to MEMBER_NO is a
+  //  version-gated publication naming this node in the departing set.
+  //
+  // UNICAST to the owner, and deliberately NOT aggregated up the multicast ack
+  //  tree.  That tree is real but carries NO PAYLOAD today, so aggregating
+  //  departures would mean adding a payload-reduction facility to the multicast
+  //  layer, designed around one speculative user (NOTIFICATION_PROTOCOL rule
+  //  8).  The subscribe path is already O(N) unicast, so an O(N) unsubscribe
+  //  burst is not a new complexity class; the sender's
+  //  'K + (node_id % J)' stagger is what keeps a phase change that retires many
+  //  nodes at once from arriving as one spike.
+  //
+  // Nothing about this message is load bearing.  Rule 8 is unmodelled on
+  //  purpose (NOTIFICATION_PROTOCOL section 8.2): 'Depart' may fire on ANY
+  //  eligible node and 'Trigger' may apply ANY subset of the requests, which is
+  //  strictly more general than any tuning, so its failure modes are bandwidth
+  //  and never correctness.
+  struct BarrierDepartMessage {
+    ID::IDType barrier_id;
+    // carried explicitly, exactly like BarrierSubscribeMessage's 'subscriber',
+    //  rather than inferred from the active message's sender
+    NodeID departing;
+
+    static void handle_message(NodeID sender, const BarrierDepartMessage &msg,
+                               const void *data, size_t datalen);
+
+    static void send_request(NodeID target, ID::IDType barrier_id, NodeID departing);
+  };
+
+  // a cumulative subtree total travelling toward the barrier owner.
+  // ARRIVAL_PROTOCOL rule 7: 'val' is the SENDER'S RUNNING TOTAL for this
+  //  generation, never an increment.  The receiver REPLACES the value it has
+  //  stored for the sender, and a report that does not strictly increase that
+  //  value is stale and is discarded.  That is what makes duplicate and
+  //  out-of-order delivery harmless.
+  //
+  // The PAYLOAD, when there is one, is the eager-flush report's PER-NODE
+  //  ARRIVAL COUNT MAP (ARRIVAL_PROTOCOL section 11.1) - which nodes had
+  //  arrivals in this generation and how many each, for the whole subtree the
+  //  sender speaks for.  It is what the owner builds the next plan out of.
+  //  Wire format:
+  //
+  //    flushmap := varint set_bytes
+  //                set_bytes of EncodedMulticastTargets  (the node SET)
+  //                one varint count per node, in ASCENDING node order
+  //
+  //  The node set uses the multicast codec (realm/multicast.h) rather than a
+  //  naive list, so a contiguous run of nodes costs a couple of bytes instead
+  //  of one entry each; the counts ride alongside in the set's own (sorted)
+  //  iteration order, so no node id is ever repeated on the wire.
+  //
+  //  A map is carried ONLY when the sender is in eager-flush mode - a
+  //  steady-state rule-1 report is O(1) and carries none, which is the whole
+  //  point of the tree.  datalen == 0 therefore means "this report carries no
+  //  map", and the receiver LEAVES the map it already has for this sender
+  //  alone; it does not clear it.  The maps merge cumulatively, exactly like
+  //  the counts (section 11.1), so they only ever grow.
+  struct BarrierReportMessage {
+    ID::IDType barrier_id;
+    EventImpl::gen_t gen;
+    int64_t val;
+    // the node the total is FOR.  Always the sender today, but the receiver
+    //  keys its accumulator on this and never on its own child list - see
+    //  ARRIVAL_PROTOCOL section 8.2.
+    NodeID from;
+    // 'direct' (rule 3): the sender holds no plan record, so it has no parent
+    //  and no completion condition to wait for, and reports straight to the
+    //  owner.  The owner treats a 'direct' as evidence its plan is wrong.
+    bool is_direct;
+    // decision Q4: an arrival whose PRECONDITION was poisoned poisons the
+    //  generation it arrives on.  The bit is STICKY per generation and is OR-ed
+    //  along the tree, so it is monotone and reordering cannot lose it.  It is
+    //  applied by the receiver BEFORE the rule-7 staleness test, and it always
+    //  rides the same report as the arrival COUNT that carried it - a count the
+    //  generation cannot complete without - so it can never arrive too late.
+    bool poisoned;
+
+    static void handle_message(NodeID sender, const BarrierReportMessage &msg,
+                               const void *data, size_t datalen, TimeLimit work_until);
+
+    static void send_request(NodeID target, ID::IDType barrier_id, EventImpl::gen_t gen,
+                             int64_t val, NodeID from, bool is_direct, bool poisoned,
+                             const void *data, size_t datalen);
+  };
+
+  // "enter eager-flush mode for this generation" (ARRIVAL_PROTOCOL rule 4).
+  //  It carries no count - it is an announcement, not data - and it is
+  //  IDEMPOTENT: a node already flushing this generation drops it, which is
+  //  what terminates the fan-out down the tree.  Flush state is PER
+  //  GENERATION; the next generation starts back in planned mode.
+  struct BarrierFlushMessage {
+    ID::IDType barrier_id;
+    EventImpl::gen_t gen;
+
+    static void handle_message(NodeID sender, const BarrierFlushMessage &msg,
+                               const void *data, size_t datalen);
+
+    static void send_request(NodeID target, ID::IDType barrier_id, EventImpl::gen_t gen);
+  };
+
+  // "the plan you hold is being retired" (ARRIVAL_PROTOCOL rules 5 and 6).
+  //  Broadcast by the owner down the tree BEING RETIRED at the same moment the
+  //  new plan goes down the NEW tree; the two race, and the deferral rule of
+  //  BarrierArrive RecvNewPlan is the verified resolution.  'epoch' is the plan
+  //  index being retired: an invalidation that is not newer than what this node
+  //  has already retired is stale, and is consumed and ignored.
+  struct BarrierInvalidateMessage {
+    ID::IDType barrier_id;
+    uint32_t epoch;
+
+    static void handle_message(NodeID sender, const BarrierInvalidateMessage &msg,
+                               const void *data, size_t datalen);
+
+    static void send_request(NodeID target, ID::IDType barrier_id, uint32_t epoch);
+  };
+
+  // "install plan 'epoch'" (ARRIVAL_PROTOCOL rule 5).
+  //
+  // The payload is the SUBTREE rooted at the recipient (ARRIVAL_PROTOCOL
+  //  section 11.4: a newplan must carry the recipient's own plan record, not
+  //  just an epoch).  It is a pre-order encoding in which every child's record
+  //  is a CONTIGUOUS, length-prefixed slice, so a relay forwards each child's
+  //  sub-subtree verbatim without re-encoding anything:
+  //
+  //    subtree := u32 quota
+  //               u32 num_kids
+  //               num_kids x ( i32 kid_node, u32 kid_bytes, kid_bytes of subtree )
+  //
+  //  The sender of the message is the recipient's parent - that is how
+  //  ArrivalPlan::parent is filled in, since section 8.1 stores the parent
+  //  rather than deriving it.
+  struct BarrierNewPlanMessage {
+    ID::IDType barrier_id;
+    uint32_t epoch;
+
+    static void handle_message(NodeID sender, const BarrierNewPlanMessage &msg,
+                               const void *data, size_t datalen);
+
+    static void send_request(NodeID target, ID::IDType barrier_id, uint32_t epoch,
+                             const void *data, size_t datalen);
+  };
+
+  // ARRIVAL_PROTOCOL rule 8 - an alter_arrival_count on its way to the owner.
+  //
+  // The change is PERSISTENT (event.h:268-273, decision D5): 'delta' applies to
+  //  'gen' AND to every generation after it.  The implementation this replaces
+  //  folded the delta into a single generation and never touched the base
+  //  count, which is not what event.h documents and not what Legion expects.
+  //
+  // 'ts' is this alteration's causal timestamp - globally unique (the issuing
+  //  node id sits in the high bits) and monotone per issuing node.  'prev_ts'
+  //  is the timestamp of the PREVIOUS alteration the same node issued on this
+  //  barrier, or 0 for its first.  The owner HOLDS an alteration whose
+  //  predecessor it has not applied yet, so one node's alterations are always
+  //  applied in issue order even though active messages may reorder.  That is
+  //  what lets a single timestamp on an arrival stand for the whole chain
+  //  behind it, and it is the answer to the "TODO: really need two timestamps
+  //  to properly order increments" the old ordering code carried.
+  struct BarrierAlterMessage {
+    ID::IDType barrier_id;
+    EventImpl::gen_t gen;
+    int delta;
+    Barrier::timestamp_t ts;
+    Barrier::timestamp_t prev_ts;
+
+    static void handle_message(NodeID sender, const BarrierAlterMessage &msg,
+                               const void *data, size_t datalen, TimeLimit work_until);
+
+    static void send_request(NodeID target, ID::IDType barrier_id, EventImpl::gen_t gen,
+                             int delta, Barrier::timestamp_t ts,
+                             Barrier::timestamp_t prev_ts);
+  };
+
+  // ARRIVAL_PROTOCOL rule 8.1 - AN ARRIVAL CARRYING A TIMESTAMP BYPASSES THE
+  //  TREE.  A relay collapses its whole subtree into a single integer, which
+  //  ERASES the timestamps, so an arrival that has to be gated on an alteration
+  //  is reported straight to the owner instead.  Alterations are rare relative
+  //  to arrivals, so the direct traffic is negligible.
+  //
+  // 'val' is CUMULATIVE (rule 7, decision D4), exactly like a report: it is how
+  //  many arrivals this sender has issued for 'gen' under this pair of
+  //  timestamps, so the owner REPLACES rather than adds and reordering is
+  //  harmless.  No message ever carries a SET of timestamps - that is where the
+  //  previous design's causal-DAG machinery came from.
+  //
+  // The gate is the pair below, and the owner may not count the arrival until
+  //  BOTH have been applied (EXACT SET MEMBERSHIP, never "ts <= the highest
+  //  applied timestamp"):
+  //
+  //   'ts'       - the timestamp of the handle the application arrived on,
+  //                naming the alteration this arrival is the promised use of
+  //                (event.h:275-281).  0 if the handle carries none.
+  //   'local_ts' - the SENDER'S OWN alteration floor for 'gen' (the model's
+  //                myTs[n][g]).  Once a node has altered, EVERY arrival it
+  //                issues for an affected generation is gated, including one
+  //                made on a pre-alteration handle: that reserved arrival is
+  //                what holds the generation open until the alteration lands,
+  //                and counting it early is exactly the "barrier that triggered
+  //                too early" of event.h:305.  0 if this node has never altered
+  //                this barrier.
+  //
+  // Two timestamps rather than one because the two dependencies are
+  //  independent: the handle names somebody else's alteration, the floor is
+  //  this node's own.  Each is the tip of a per-node chain (see 'prev_ts'
+  //  above), so a pair is the whole witnessed set and not a truncation of it.
+  struct BarrierTsArrivalMessage {
+    ID::IDType barrier_id;
+    EventImpl::gen_t gen;
+    int64_t val;
+    Barrier::timestamp_t ts;
+    Barrier::timestamp_t local_ts;
+    // decision Q4 - see BarrierReportMessage::poisoned.  A bypassed arrival
+    //  carries the bit for exactly the same reason a report does.
+    bool poisoned;
+
+    static void handle_message(NodeID sender, const BarrierTsArrivalMessage &msg,
+                               const void *data, size_t datalen, TimeLimit work_until);
+
+    static void send_request(NodeID target, ID::IDType barrier_id, EventImpl::gen_t gen,
+                             int64_t val, Barrier::timestamp_t ts,
+                             Barrier::timestamp_t local_ts, bool poisoned);
+  };
 
   class BarrierImpl : public EventImpl {
   public:
     static const ID::ID_Types ID_TYPE = ID::ID_BARRIER;
 
-    static const int BARRIER_TIMESTAMP_NODEID_SHIFT = 48;
+    static constexpr int BARRIER_TIMESTAMP_NODEID_SHIFT = 48;
     static atomic<Barrier::timestamp_t> barrier_adjustment_timestamp;
 
     BarrierImpl(void);
-    BarrierImpl(BarrierCommunicator *_barrier_comm, int _broadcast_radix = 4);
     ~BarrierImpl(void);
 
     void init(ID _me, unsigned _init_owner);
@@ -143,40 +439,118 @@ namespace Realm {
     // used to adjust a barrier's arrival count either up or down
     // if delta > 0, timestamp is current time (on requesting node)
     // if delta < 0, timestamp says which positive adjustment this arrival must wait for
+    // 'poisoned' is decision Q4: the arrival's PRECONDITION was poisoned, which
+    //  poisons the generation it arrives on.  The arrival itself still counts -
+    //  refusing to count it would hang the barrier instead of poisoning it.
     void adjust_arrival(gen_t barrier_gen, int delta, Barrier::timestamp_t timestamp,
-                        Event wait_on, NodeID sender, bool forwarded,
-                        const void *reduce_value, size_t reduce_value_size,
-                        TimeLimit work_until);
+                        Event wait_on, NodeID sender, const void *reduce_value,
+                        size_t reduce_value_size, TimeLimit work_until,
+                        bool poisoned = false);
 
+    // ARRIVAL_PROTOCOL rules 8 and 9 - alter_arrival_count, the whole of action
+    //  AL in ONE critical section.  The causal timestamp is MINTED INSIDE that
+    //  section, together with the floor it installs and the eager flush it
+    //  enters, and it is returned so the caller can put it on the new handle.
+    //  (It used to be minted by Barrier::alter_arrival_count and consumed much
+    //  later, in a different section - two halves of one spec action.)
+    Barrier::timestamp_t alter_arrival_count(gen_t barrier_gen, int delta);
+
+    // NOTIFICATION_PROTOCOL action S (rules 3 and 5), owner only for the
+    //  scalable path.  'last_known' is the subscriber's own watermark - what
+    //  lets the reply be an exact delta and what replaces the per-node map the
+    //  owner used to keep.  'subscribe_gen' is what the subscriber NEEDS, and
+    //  is used only by the legacy path's one-shot 'remote_subscribe_gens'.
     void handle_remote_subscription(NodeID subscriber, EventImpl::gen_t subscribe_gen,
-                                    bool forwarded, const void *data, size_t datalen);
+                                    EventImpl::gen_t last_known, const void *data,
+                                    size_t datalen);
 
-    void handle_remote_trigger(NodeID sender, ID::IDType barrier_id,
-                               EventImpl::gen_t trigger_gen,
-                               EventImpl::gen_t previous_gen, EventImpl::gen_t first_gen,
-                               ReductionOpID redop_id, NodeID migration_target,
-                               int broadcast_index, unsigned base_count, const void *data,
-                               size_t datalen, TimeLimit work_until);
+    // NOTIFICATION_PROTOCOL action N (rules 1, 2, 4, 6, 7, 8).  'inset' is this
+    //  node's own membership, computed by the handler from the departing set
+    //  the message carried - see BarrierNotifyMessage.  'shrink_hint' is rule
+    //  8's advisory byte.
+    void handle_remote_notify(gen_t wm, gen_t prev, uint64_t sv, const gen_t *poison,
+                              size_t num_poisoned, bool inset, bool hint,
+                              TimeLimit work_until);
+
+    // NOTIFICATION_PROTOCOL action D, OWNER SIDE (rule 8).  Collect one
+    //  departure intent; it is applied - or declined - at the next trigger,
+    //  which is also where the resulting shrink is published to the PRE-SHRINK
+    //  set.
+    void handle_remote_depart(NodeID from);
+
+    // NOTIFICATION_PROTOCOL action RP (rules 2, 5, 7)
+    void handle_remote_subscribe_reply(gen_t wm, uint64_t sv, const gen_t *poison,
+                                       size_t num_poisoned, TimeLimit work_until);
+
+    // a cumulative subtree total from 'from' (ARRIVAL_PROTOCOL rules 1 and 7).
+    //  'data'/'datalen' is the eager-flush (node,count) map, or empty - see
+    //  BarrierReportMessage.
+    void handle_remote_report(NodeID from, gen_t report_gen, int64_t val, bool is_direct,
+                              bool poisoned, const void *data, size_t datalen,
+                              TimeLimit work_until);
+
+    // "enter eager-flush mode for 'flush_gen'" (ARRIVAL_PROTOCOL rule 4)
+    void handle_remote_flush(gen_t flush_gen);
+
+    // "the plan you hold is being retired" (ARRIVAL_PROTOCOL rule 6)
+    void handle_remote_invalidate(uint32_t epoch);
+
+    // "install plan 'epoch'" (ARRIVAL_PROTOCOL rule 5).  'parent' is the node
+    //  that sent it - see ArrivalPlan::parent.
+    void handle_remote_new_plan(NodeID parent, uint32_t epoch, const void *data,
+                                size_t datalen);
+
+    // OWNER ONLY - ARRIVAL_PROTOCOL rules 8 and 9 (action RA).  Apply one
+    //  alteration persistently, open the gate on every arrival that was waiting
+    //  for it, and let go of any alteration that was waiting for THIS one.
+    void handle_remote_alter(NodeID from, gen_t alter_gen, int delta,
+                             Barrier::timestamp_t ts, Barrier::timestamp_t prev_ts,
+                             TimeLimit work_until);
+
+    // OWNER ONLY - ARRIVAL_PROTOCOL rule 8.1 (action TS).  A cumulative count
+    //  of arrivals that BYPASSED the tree because they carry a timestamp.
+    void handle_remote_ts_arrival(NodeID from, gen_t arrival_gen, int64_t val,
+                                  Barrier::timestamp_t ts, Barrier::timestamp_t local_ts,
+                                  bool poisoned, TimeLimit work_until);
 
     bool get_result(gen_t result_gen, void *value, size_t value_size);
 
-  protected:
-    void broadcast_trigger(const std::vector<RemoteNotification> &ordered_notifications,
-                           const std::vector<NodeID> &broadcast_targets,
-                           EventImpl::gen_t oldest_previous,
-                           EventImpl::gen_t broadcast_previous,
-                           EventImpl::gen_t first_generation, NodeID migration_target,
-                           unsigned base_arrival_count, ReductionOpID redop_id,
-                           const void *data, size_t datalen,
-                           bool include_notifications = true);
-
   public:
+    // ---- TIER 0: readable with NO lock ------------------------------------
+    // Written ONLY inside 'mutex'.  Publication order is fixed
+    //  (tla/STATE_AND_LOCKING.md section 3.5) and add_poison_locked() /
+    //  publish_watermark_locked() are the only writers:
+    //    poison slots -> num_poisoned_generations (release)
+    //                 -> generation (release)
+    // has_triggered() is the reader and must stay a lock-free, side-effect-free
+    //  load - the consultation signal of NOTIFICATION_PROTOCOL rule 8 is
+    //  explicitly NOT on that path (section 4).
     atomic<gen_t> generation = atomic<gen_t>(0);
+
+    // decision Q3/D7 - the SAME representation GenEventImpl uses
+    //  (event_impl.h:326-332): an append-only array that is never reallocated,
+    //  plus an atomic count published with a release store.  Entries below the
+    //  published count are immutable, so a reader that acquire-loads the count
+    //  can scan them without a lock.  On the OWNER this doubles as the
+    //  retention required by NOTIFICATION_PROTOCOL section 8.5 - a new
+    //  subscriber has to be told every poisoned generation above its 'lk'.
+    // 'constexpr' rather than 'const': this is streamed into a log message in
+    //  add_poison_locked(), which binds it to a reference and therefore ODR-uses
+    //  it.  A 'static const int' with no out-of-line definition does not link.
+    static constexpr int POISONED_GENERATION_LIMIT = 16;
+    atomic<int> num_poisoned_generations = atomic<int>(0);
+    gen_t *poisoned_generations = nullptr;
+
+    // lock-free (Q3): acquire-load the count, then scan the published slots
+    bool is_generation_poisoned(gen_t gen) const;
+
+    // The highest generation this node has ever needed.  It is NOT the
+    //  scalable path's subscription state any more - membership is 'member'
+    //  plus 'my_set_ver' - it only fills the 'subscribe_gen' field the LEGACY
+    //  path's one-shot 'remote_subscribe_gens' is keyed on.
     atomic<gen_t> gen_subscribed = atomic<gen_t>(0);
     gen_t first_generation = 0;
     BarrierImpl *next_free = nullptr;
-
-    std::unique_ptr<BarrierCommunicator> barrier_comm;
 
     Mutex mutex; // controls which local thread has access to internal data (not
                  // runtime-visible event)
@@ -184,19 +558,152 @@ namespace Realm {
     // class to track per-generation status
     class Generation {
     public:
-      struct PerNodeUpdates {
-        Barrier::timestamp_t last_ts;
-        std::map<Barrier::timestamp_t, int> pending;
+      EventWaiter::EventWaiterList local_waiters;
+
+      // ---- SCALABLE ARRIVAL (redop_id == 0) --------------------------------
+      // Every accumulator here is CUMULATIVE, replace-if-higher, and counts UP
+      //  (tla/STATE_AND_LOCKING.md D4).  Never mix in an incrementing counter
+      //  and never carry the legacy path's count-down convention in here.
+      int64_t local_total = 0; // localTotal[n][g] - arrivals issued at this node
+      int64_t reported_up = 0; // reportedUp[n][g] - what we last told our parent
+      int64_t child_sum = 0;   // running sum of child_acc[*].total
+      // THE PINNED REPORT TARGET for this generation, -1 until the first report
+      //  goes out.  A report is CUMULATIVE, and the receiver keys its
+      //  accumulator on the SENDER and REPLACES that sender's previous
+      //  contribution (rule 7) - so one node's contribution to one generation
+      //  must live in exactly ONE accumulator chain.  Re-aiming a report at a
+      //  different target part-way through a generation puts the SAME arrivals
+      //  under two different sender keys at their common ancestor, and nothing
+      //  can ever retract the first one: the owner's count steps over
+      //  'expected' (a hang) or reaches it early (a barrier that triggers
+      //  before every arrival is in).
+      //
+      // 'cur_plan.parent' changes whenever a new plan is installed - including
+      //  the very first one, which moves a node from "direct to the owner" to
+      //  "under a relay" - so the plan record cannot be the report target for a
+      //  generation this node has already spoken about.  It is pinned here
+      //  instead, and the stale edge is flagged 'is_direct' so the path it
+      //  travels goes eager rather than aggregating (see record_report_locked).
+      //
+      // A PINNED EDGE POINTS INTO A PLAN THAT NO LONGER EXISTS, so what stops
+      //  two of them forming a CYCLE - A still reporting to its old parent B
+      //  while B reports to its new parent A, each report growing the other's
+      //  subtree total without bound - is an invariant of plan CONSTRUCTION:
+      //  build_new_plan_locked lays 'tv' out with the owner at index 0 and
+      //  every other member in ASCENDING NodeID order, and the heap parent of
+      //  index i is (i-1)/radix, which is strictly less than i.  So in EVERY
+      //  plan a node's parent is either the owner (which never reports) or a
+      //  node with a SMALLER NodeID; any report edge, from any plan, strictly
+      //  decreases the NodeID; and no cycle can exist.  This is the same
+      //  property that already bounds a retired node's reports to its old
+      //  parent.  A construction that assigns parents in some other order has
+      //  to re-establish it.
+      NodeID report_to = -1;
+      // flushing[n][g] - eager-flush mode, PER GENERATION (rules 2, 3 and 4).
+      //  Once set, every arrival for this generation reports immediately
+      //  instead of aggregating.  It is NOT carried into the next generation:
+      //  a deviation at generation g says nothing about g+1, so g+1 starts
+      //  back in planned mode.
+      bool flushing = false;
+      // ARRIVAL_PROTOCOL rule 3, propagated.  A 'direct' says "your plan did
+      //  not predict me", and only the OWNER acts on it - but a node whose
+      //  plan has been retired still reports to its STORED parent (changing
+      //  the target mid-generation would let the same arrivals reach the owner
+      //  down two paths and be counted twice), so without this the signal is
+      //  swallowed by the first relay.  It is sticky for the generation and
+      //  OR-ed into every report this node forwards.
+      bool saw_direct = false;
+
+      // decision Q4 - an arrival on this generation had a POISONED
+      //  PRECONDITION, so the generation itself is poisoned.  Sticky, OR-ed
+      //  with every child's bit as reports come up the tree, and read at the
+      //  owner when the generation triggers.  It travels with the arrival COUNT
+      //  that set it (see BarrierReportMessage::poisoned), so the owner cannot
+      //  complete the generation without having seen it.
+      bool poisoned = false;
+
+      struct ChildReport {
+        // the staleness key of rule 7: the highest cumulative total accepted
+        //  from this child for this generation
+        int64_t total = 0;
+        // ARRIVAL_PROTOCOL section 11.1 - the per-node arrival counts this
+        //  child's last EAGER-FLUSH report carried, for its whole subtree.
+        //  NON-EMPTY ONLY in flush mode: a steady-state report is O(1) and
+        //  carries no map at all.  Replaced wholesale when a report carries
+        //  one, left alone when it does not.
+        //
+        // THIS IS THE PLAN-GATHERING STRUCTURE (section 11.3), and it lives
+        //  HERE, inside the generation record, precisely so that it is DELETED
+        //  when that generation triggers.  It is never copied into a member of
+        //  BarrierImpl - see build_new_plan_locked().
+        std::map<NodeID, int64_t> counts;
+      };
+      // childAcc[n][c][g], keyed by SENDER and never by the current child list:
+      //  ARRIVAL_PROTOCOL section 8.2 requires accepting reports from nodes
+      //  that are not in cur_plan.kids.
+      std::map<NodeID, ChildReport> child_acc;
+
+      // ---- ARRIVAL_PROTOCOL rule 8 - arrivals that BYPASS the tree ----------
+      // The gate one bypassed arrival is counted behind.  See
+      //  BarrierTsArrivalMessage for what the two timestamps mean and why there
+      //  are two of them.  Both may not be zero: an arrival with no timestamp
+      //  at all does not bypass anything.
+      struct TsKey {
+        Barrier::timestamp_t ts = 0;       // the handle's causal timestamp
+        Barrier::timestamp_t local_ts = 0; // the issuing node's own floor
+
+        bool operator<(const TsKey &rhs) const
+        {
+          if(ts != rhs.ts) {
+            return (ts < rhs.ts);
+          }
+          return (local_ts < rhs.local_ts);
+        }
       };
 
-      int unguarded_delta;
-      EventWaiter::EventWaiterList local_waiters;
-      std::map<int, PerNodeUpdates *> pernode;
+      // ISSUING NODE: how many arrivals this node has issued for this
+      //  generation under each gate.  It is what makes the message CUMULATIVE
+      //  (D4) rather than an increment.  In every realistic case there is
+      //  exactly one entry - a second one only appears if a node arrives on
+      //  two different alteration branches within one generation.
+      std::map<TsKey, int64_t> ts_issued;
 
-      Generation(void);
-      ~Generation(void);
+      // OWNER: one bypass stream per (sender, gate).  Each stream is
+      //  cumulative and replace-if-higher, exactly like child_acc, and is
+      //  folded into the count only once EVERY timestamp in its gate has been
+      //  applied.  Keying by the gate as well as the sender is what keeps
+      //  "cumulative" meaningful when one node's arrivals for a generation sit
+      //  behind different alterations.
+      struct TsStream {
+        int64_t seen = 0;     // highest cumulative value this sender reported
+        bool counted = false; // whether 'seen' has been credited yet
+      };
+      struct TsStreamKey {
+        NodeID from = -1;
+        TsKey gate;
 
-      void handle_adjustment(Barrier::timestamp_t ts, int delta);
+        bool operator<(const TsStreamKey &rhs) const
+        {
+          if(from != rhs.from) {
+            return (from < rhs.from);
+          }
+          return (gate < rhs.gate);
+        }
+      };
+      std::map<TsStreamKey, TsStream> ts_streams;
+      // the model's TsTotal(g): the sum of 'seen' over every COUNTED stream.
+      //  Never an independent counter - it is maintained as those streams are
+      //  credited, so it moves in exactly one direction (D4).
+      int64_t ts_acc = 0;
+
+      // derived, never stored (ARRIVAL_PROTOCOL section 3)
+      int64_t subtree_known(void) const { return local_total + child_sum; }
+      int64_t unreported(void) const { return subtree_known() - reported_up; }
+      bool holding(void) const { return unreported() > 0; }
+
+      // ---- LEGACY / REDUCTION PATH ONLY ------------------------------------
+      // the count-down accumulator: expected(gen) + unguarded_delta == 0
+      int unguarded_delta = 0;
     };
 
     std::map<gen_t, Generation *> generations;
@@ -207,11 +714,242 @@ namespace Realm {
     KernelMutex external_waiter_mutex;
     KernelMutex::CondVar external_waiter_condvar;
 
-    // a list of remote waiters and the latest generation they're interested in
-    // also the latest generation that each node (that has ever subscribed) has been told
-    // about
-    std::map<unsigned, gen_t> remote_subscribe_gens, remote_trigger_gens;
-    std::map<gen_t, gen_t> held_triggers;
+    // a list of remote waiters and the latest generation they're interested in.
+    //  LEGACY / REDUCTION PATH ONLY - the scalable path's replacement is
+    //  'sub_set' plus 'set_ver', which is a bitmask rather than an O(N) map.
+    std::map<unsigned, gen_t> remote_subscribe_gens;
+
+    // ---- NOTIFICATION, NODE SIDE (needed on BOTH paths) --------------------
+    // NB: this is THIS NODE's belief about ITS OWN membership of the owner's
+    //  subscriber set.  It is one enum per barrier, NOT a map over nodes: the
+    //  owner keeps no per-node map (NOTIFICATION_PROTOCOL section 3).
+    //
+    // MEMBERSHIP IS PUBLISHED, NEVER SELF-DECIDED (rule 1).  The only writers
+    //  that may set YES/NO are the two publication paths - a notification and a
+    //  subscribe reply - and both are VERSION GATED on 'my_set_ver' (rule 2).
+    //  PENDING means "I have asked and have not been answered", and it is what
+    //  keeps a second consultation from issuing a second subscribe.
+    enum MemberState : uint8_t
+    {
+      MEMBER_NO = 0,
+      MEMBER_PENDING = 1,
+      MEMBER_YES = 2
+    };
+    MemberState member = MEMBER_NO;
+    // rule 2: the highest 'set_ver' applied here.  A membership update is
+    //  applied only if it is STRICTLY newer, on BOTH the notify and the reply
+    //  path.  Without this a stale in-flight notification resurrects membership
+    //  the owner has already dropped, and the node hangs on its next wait.
+    uint64_t my_set_ver = 0;
+    // rule 7: at most one outstanding pull.  Set when a subscribe goes out,
+    //  cleared by the reply (or, on the legacy path, by the trigger message
+    //  that serves as the reply).
+    bool pull_outstanding = false;
+    // The model suppresses a pull only while a SUBSCRIBE is in flight
+    //  (BarrierNotify:157); 'pull_outstanding' stays set until the REPLY lands,
+    //  which is a strictly longer window.  A pull the gap rule wanted during
+    //  that extra window is remembered here and issued when the reply closes
+    //  it - otherwise a notification discarded for a gap while a subscribe was
+    //  being answered would never be recovered, and a node whose barrier has no
+    //  further generations would wait forever.
+    bool pull_deferred = false;
+
+    // ---- NOTIFICATION_PROTOCOL rule 8: DEPARTURE HYSTERESIS, node side -----
+    //
+    // PERFORMANCE ONLY, and deliberately unverified.  BarrierNotify abstracts
+    //  this whole mechanism as nondeterminism - 'Depart' may fire on ANY
+    //  eligible node and 'Trigger' may apply ANY subset of the requests - which
+    //  is strictly more general than any tuning, so NO CHOICE OF THESE
+    //  CONSTANTS CAN BE WRONG (section 8.2).  The failure modes are bandwidth;
+    //  correctness is carried by rule 6 (a node removed while holding a waiter
+    //  re-subscribes at once) and by the pull path, which has to exist anyway.
+    //
+    // K, in GENERATIONS.  A node asks to leave after this many consecutive
+    //  triggered generations without consulting the barrier.
+    static constexpr unsigned DEPART_K_INITIAL = 8;
+    // the ceiling the churn adaptation doubles toward.  A node that keeps being
+    //  dropped and re-subscribing eventually stops asking altogether, which is
+    //  the correct steady state for a node that is simply slow rather than idle.
+    static constexpr unsigned DEPART_K_MAX = 1024;
+    // J.  The eligibility threshold is 'K + (my_node_id % J)', so a phase change
+    //  that retires many nodes at once spreads their requests over J
+    //  generations instead of delivering them as one spike.  EXPRESSED IN
+    //  GENERATIONS, NOT IN TIME - so it needs no timer and the protocol stays
+    //  feed-forward.  Sized for spike smoothing, not for asymptotics: the
+    //  subscribe path is already O(N) unicast.
+    static constexpr unsigned DEPART_STAGGER_J = 32;
+    // "shortly after having left", in generations: a re-subscribe this soon
+    //  after a departure request is CHURN, and doubles K.
+    static constexpr gen_t DEPART_CHURN_WINDOW = 64;
+
+    // THE IDLE COUNTER, measured as the WATERMARK DELTA since this node last
+    //  consulted the barrier - not as a count of notifications received, which
+    //  would be wrong the moment the owner coalesced several triggers into one
+    //  message (and coalescing is explicitly supported: see action T).
+    //
+    // CONSULTING means add_waiter, subscribe, or external_wait /
+    //  external_timedwait - and explicitly NOT has_triggered(), which must stay
+    //  a lock-free single atomic load (tla/STATE_AND_LOCKING.md section 4).
+    //  This field is written ONLY from action C, which already holds 'mutex'
+    //  for other reasons.
+    gen_t last_consult_wm = 0;
+    // the watermark at which this node last ASKED to leave (0 = never).  It is
+    //  the churn window's origin, and it is not evidence the node actually left
+    //  - the owner may have declined.
+    gen_t last_depart_wm = 0;
+    // K, doubled on observed churn and capped at DEPART_K_MAX
+    unsigned depart_K = DEPART_K_INITIAL;
+    // one request per idle episode.  Cleared when this node next consults
+    //  (action C) or when it is actually removed (action N step 1), which is
+    //  what keeps a declined request from turning into a retry storm - a
+    //  decline costs one message and then silence.
+    bool depart_outstanding = false;
+    // the owner's advisory byte from the last notification.  Optimistic until
+    //  told otherwise, so the first departure always gets a hearing.
+    bool shrink_hint = true;
+
+    // ---- NOTIFICATION, OWNER SIDE (NOTIFICATION_PROTOCOL section 3) --------
+    // D8: the wire form IS the storage form.  There is deliberately no learned
+    //  notification tree - the multicast layer plans a fresh forwarding tree
+    //  from the encoded set on every send, so a set change can never leave a
+    //  stale tree behind.  This is the ONLY O(N) term on the scalable path, and
+    //  it is a bitmask (or a couple of runs), not a map.
+    MulticastTargetSet sub_set;
+    // rule 2 - bumped on EVERY change to 'sub_set' and stamped onto every
+    //  notification and every reply
+    uint64_t set_ver = 0;
+    // rule 8 - departure intents collected but not yet applied.  Normally
+    //  empty.  Applied (or declined - removals are DISCRETIONARY, rule 3) at
+    //  the next trigger, which is also where the shrink is published to the
+    //  PRE-SHRINK set.  It is CLEARED at every trigger whether or not the
+    //  shrink was applied: a declined intent is forgotten rather than retried,
+    //  and the node's own one-request-per-idle-episode latch is what stops it
+    //  being re-sent.
+    MulticastTargetSet want_out;
+    // rule 8's advisory byte, as the owner currently believes it: the verdict
+    //  the cost test returned the last time it actually evaluated a shrink.
+    //  STICKY - a trigger with nothing to weigh leaves it alone.  The only
+    //  thing that clears a declined verdict is an ADD, because that is what
+    //  changes the shape of the set the verdict was about.  Optimistic to
+    //  start, so the first departure of a barrier always gets a hearing.
+    bool shrink_pays = true;
+
+    // ---- SCALABLE ARRIVAL: the plan record, on every node -------------------
+    // curPlan[n].  MEMBERSHIP RULE (ARRIVAL_PROTOCOL section 3): only nodes
+    //  with a NON-ZERO expected contribution are in a plan at all.  A node with
+    //  no plan is not a leaf, not a relay, not anything - it has no parent and
+    //  no completion condition it could wait for, so every arrival goes
+    //  straight to the owner (rule 3) and it is permanently in eager-flush
+    //  mode.  That is what stops a relay ever waiting on a child that will
+    //  never speak.
+    struct ArrivalPlan {
+      uint32_t quota = 0;       // arrivals this plan predicts at this node
+      bool inplan = false;      // quota 0 => not in the tree at all
+      NodeID parent = -1;       // -1 => report direct to the owner.  STORED, not
+                                //  derived - the model's global ParentOf() search
+                                //  is a modelling convenience (section 8.1)
+      std::vector<NodeID> kids; // O(radix)
+    };
+
+    ArrivalPlan cur_plan;     // curPlan[n]
+    uint32_t my_epoch = 0;    // myEpoch[n]   - which plan index cur_plan is
+    uint32_t inval_epoch = 0; // invalEpoch[n] - highest plan index retired here
+    uint32_t defer_epoch = 0; // deferEpoch[n] - a parked new plan, 0 = none
+
+    // ---- OWNER ONLY: the plan lifecycle (ARRIVAL_PROTOCOL section 11) ------
+    // The next plan index to hand out.  Epochs are monotone and never reused,
+    //  which is what makes the invalidate/newplan race resolvable locally
+    //  (rule 5).  0 means "no plan has ever existed", so counting starts at 1.
+    uint32_t next_epoch = 1;
+    // Set by the only thing that can tell the owner its plan is wrong: the
+    //  owner entering eager-flush mode (a 'direct' from a node the plan did not
+    //  predict, or an over-arrival at the owner itself).  Consumed by the next
+    //  trigger, which is where the aggregated maps are still in hand.
+    //
+    // NOTE what is NOT here: the merged node->count structure of section 11.2.
+    //  It is a LOCAL of the trigger path, merged out of the generation record
+    //  that is about to be freed and destroyed with the stack frame.  O(N)
+    //  barriers each retaining an O(N) participant map is the O(N^2) blow-up
+    //  this whole design exists to avoid (section 11.3, decision D9), and
+    //  nothing fails loudly if it leaks - so it has no home to leak into.
+    bool plan_rebuild_pending = false;
+    // At most ONE parked plan (BarrierArrive BoundedRetention).  Holds the encoded
+    //  SUBTREE payload, not just an epoch, because the node has to forward it
+    //  to its own children when the invalidation lands.  COPIED out of the
+    //  active-message buffer, which is dead once the handler returns.
+    std::vector<unsigned char> deferred_plan_payload;
+    // who sent the parked plan - it becomes cur_plan.parent when the plan is
+    //  finally applied, so it has to be remembered with the payload
+    NodeID defer_parent = -1;
+
+    // ---- ARRIVAL_PROTOCOL rule 8: alteration state on the ISSUING node -----
+    // myTs[n][g] as a STEP FUNCTION: the greatest entry with key <= g gives the
+    //  timestamp this node's arrivals for g must carry, and 0 (no entry) means
+    //  they carry none.  It is a step function because alterations are
+    //  PERSISTENT - one covers every later generation too - and installing an
+    //  entry at 'g' therefore drops every entry above 'g', which is superseded
+    //  by it.
+    std::map<gen_t, Barrier::timestamp_t> ts_floor;
+    // the last alteration this node issued on this barrier: the 'prev_ts' of
+    //  the next one.  That chain is what keeps one node's alterations applied
+    //  at the owner in the order they were issued, and therefore what lets a
+    //  single timestamp on an arrival stand for everything behind it.
+    Barrier::timestamp_t last_alter_ts = 0;
+
+    // ---- OWNER ONLY: the expected arrival count, as a step function --------
+    // expected(g) == base_arrival_count + alter_floor
+    //                + sum of alter_steps entries with key <= g
+    //
+    // ALTERATIONS ARE PERSISTENT (D5, event.h:268-271): a delta applies to the
+    //  generation it names and to every generation after it, which is why this
+    //  is a step function and not a per-generation delta.  'alter_floor'
+    //  absorbs the steps at or below the watermark as generations trigger, so
+    //  the map holds only the breakpoints still in front of us.
+    //  (tla/STATE_AND_LOCKING.md 2.4.4 writes the same quantity as a single
+    //  'expected_floor' seeded from base_arrival_count; keeping the base
+    //  separate means nothing has to be re-seeded after create_barrier sets
+    //  it.)
+    int64_t alter_floor = 0;
+    std::map<gen_t, int64_t> alter_steps;
+
+    // appliedTs.  A bypassed arrival is counted only when EVERY timestamp in
+    //  its gate is IN THIS SET - exact membership, never "ts <= the highest
+    //  applied".  Two alterations can be applied out of order (the transport
+    //  reorders), and a "highest applied" comparison admits an arrival whose
+    //  own alteration has not landed: a barrier that triggers too early.  The
+    //  value is the generation the alteration applies from, kept for pruning.
+    std::map<Barrier::timestamp_t, gen_t> applied_ts;
+
+    // OWNER ONLY - the nodes whose arrivals BYPASS THE TREE (rule 8.1), and so
+    //  the nodes that must never appear in a plan.
+    //
+    // An alteration is PERSISTENT: once a node has altered, myTs[n][g] is
+    //  non-zero for that generation and EVERY later one, so from then on every
+    //  arrival it issues is a 'tsdirect' and its 'local_total' stays at zero
+    //  forever.  Giving such a node a quota hands it a completion condition it
+    //  can never reach: as a relay it goes silent, and as a LEAF its parent
+    //  waits on rule 1's child-wait for a report that will never come
+    //  (ARRIVAL_PROTOCOL section 11.2 - "only nodes with a non-zero count
+    //  appear ... it is what stops a relay ever waiting on a child that will
+    //  never speak").  The plan is built from 'agg', which is one PAST
+    //  generation's local totals, so a node that altered for a LATER generation
+    //  is still in that evidence and would be re-admitted on every rebuild.
+    //
+    // Bounded by the number of distinct nodes that ever alter this barrier, and
+    //  strictly smaller than 'applied_ts', which already retains one entry per
+    //  alteration.
+    std::set<NodeID> ts_bypass_nodes;
+
+    // alterations whose PREDECESSOR (BarrierAlterMessage::prev_ts) has not been
+    //  applied yet, keyed by the timestamp they are waiting for.  A multimap
+    //  because nothing stops two alterations naming the same predecessor.
+    //  Bounded by the alterations actually in flight.
+    struct HeldAlter {
+      gen_t gen = 0;
+      int delta = 0;
+      Barrier::timestamp_t ts = 0;
+    };
+    std::multimap<Barrier::timestamp_t, HeldAlter> held_alters;
 
     unsigned base_arrival_count = 0;
     ReductionOpID redop_id = 0;
@@ -219,9 +957,458 @@ namespace Realm {
     std::unique_ptr<char[]> initial_value{};
     unsigned value_capacity = 0;
     std::vector<char> final_values;
-    bool needs_ordering;
-    std::vector<std::pair<int, std::vector<RemoteNotification>>> ordered_buffer;
-    int broadcast_radix;
+
+    // ---- LEGACY / REDUCTION PATH ONLY ------------------------------------
+    // Reduction barriers stay on the existing non-scalable path (see
+    //  tla/STATE_AND_LOCKING.md D1).  Everything in here is unreachable when
+    //  redop_id == 0, so the scalable path pays neither the memory nor the
+    //  per-node bookkeeping.
+    struct LegacyReductionState {
+      // the latest generation that each node (that has ever subscribed) has
+      //  been told about.  This is what slices 'final_values' per recipient, so
+      //  it cannot be collapsed into a single owner-side watermark the way the
+      //  scalable path's notification can.
+      std::map<unsigned, gen_t> remote_trigger_gens;
+      // trigger notifications that arrived out of order, buffered until the
+      //  generations below them show up.  The scalable path discards instead
+      //  (NOTIFICATION_PROTOCOL rule 4); the legacy path keeps buffering.
+      std::map<gen_t, gen_t> held_triggers;
+    };
+    // non-null iff this is a reduction barrier (redop_id != 0)
+    std::unique_ptr<LegacyReductionState> legacy;
+
+    // ---- messages RECORDED under 'mutex' and emitted AFTER it (S2) ---------
+    // The emit phase reads ONLY this struct and immutable members - never
+    //  'cur_plan' (S3).  That is what makes rule 6's "forward before
+    //  forgetting" work without any extra effort: every target was resolved
+    //  inside the critical section, before anything could replace the child
+    //  list.
+    struct PendingReport {
+      gen_t gen = 0;
+      NodeID to = -1;         // -1 => this slot holds no report
+      int64_t val = 0;        // CUMULATIVE subtree total (rule 7)
+      bool is_direct = false; // rule 3: straight to the owner
+      bool poisoned = false;  // Q4, sticky per generation
+      // the encoded (node,count) map of section 11.1, EMPTY unless this node
+      //  is in eager-flush mode.  A default-constructed vector allocates
+      //  nothing, so a steady-state report still costs no allocation.
+      std::vector<unsigned char> flush_map;
+    };
+
+    // NOTIFICATION_PROTOCOL action T, the notification half.  EVERY field is
+    //  materialised inside the critical section (S3), including the target set,
+    //  which is a snapshot of 'sub_set' taken BEFORE the shrink is applied -
+    //  rule 1's "any shrink must be published to the PRE-SHRINK set".  That is
+    //  the one thing in this protocol that reordering cannot fix, so it is
+    //  handled by snapshotting rather than by ordering.
+    struct PendingNotify {
+      bool valid = false;
+      MulticastTargetSet targets; // the PRE-SHRINK subscriber set
+      gen_t wm = 0;
+      gen_t prev = 0;
+      uint64_t set_ver = 0;
+      std::vector<gen_t> poison;            // poisoned generations in (prev, wm]
+      std::vector<unsigned char> departing; // encoded R; empty if set_ver is
+                                            //  unchanged, in which case no
+                                            //  recipient will apply membership
+      bool shrink_hint = true;              // rule 8's advisory byte
+    };
+
+    // one child of the NEW tree, with its own sub-subtree payload
+    struct PendingPlan {
+      NodeID to = -1;
+      std::vector<unsigned char> payload;
+    };
+
+    // one generation's flush fan-out.  Rule 8 enters eager flush for EVERY open
+    //  generation at or after the altered one, so a single (generation, targets)
+    //  pair is no longer enough.
+    struct PendingFlush {
+      gen_t gen = 0;
+      std::vector<NodeID> to;
+    };
+
+    // rule 8 - the alteration travelling to the owner
+    struct PendingAlter {
+      gen_t gen = 0;
+      int delta = 0;
+      Barrier::timestamp_t ts = 0;
+      Barrier::timestamp_t prev_ts = 0;
+    };
+
+    // rule 8.1 - the bypassed arrival travelling to the owner
+    struct PendingTsArrival {
+      gen_t gen = 0;
+      int64_t val = 0; // CUMULATIVE for this gate (rule 7)
+      Barrier::timestamp_t ts = 0;
+      Barrier::timestamp_t local_ts = 0;
+      bool poisoned = false; // Q4, sticky per generation
+    };
+
+    struct PendingSends {
+      // The first - and, on every hot path, only - report.  Kept scalar so a
+      //  steady-state arrival allocates nothing at all.
+      PendingReport report;
+      // Rule 6 flushes EVERY open generation, so one report is not enough: a
+      //  node may be holding arrivals for several generations at once.
+      //  Generations after the first spill into here, which stays empty on the
+      //  arrival and report paths.
+      std::vector<PendingReport> more_reports;
+
+      // one entry per generation entering eager flush; empty in steady state,
+      //  so a default-constructed vector allocates nothing
+      std::vector<PendingFlush> flushes;
+
+      // rule 8: at most ONE alteration and at most ONE bypassed arrival per
+      //  action, so these stay scalar
+      bool has_alter = false;
+      PendingAlter alter;
+      bool has_ts_arrival = false;
+      PendingTsArrival ts_arrival;
+
+      // rule 6 step (a): the invalidation being forwarded down the tree BEING
+      //  RETIRED.  0 => nothing to forward.
+      uint32_t fwd_inval_epoch = 0;
+      std::vector<NodeID> inval_to;
+
+      // rule 5: the new plan being passed on to this node's children in the NEW
+      //  tree.  0 => nothing to forward.
+      uint32_t fwd_plan_epoch = 0;
+      std::vector<PendingPlan> plan_to;
+
+      // ---- NOTIFICATION_PROTOCOL --------------------------------------------
+      // action T's notification half, owner only.  At most one per section,
+      //  because a trigger drains one contiguous run of generations and
+      //  coalescing them into a single delta is explicitly supported.
+      PendingNotify notify;
+
+      // the pull (rule 5's 'subscribe'), always unicast to the owner.  At most
+      //  one per section - rule 7.
+      bool has_subscribe = false;
+      gen_t subscribe_lk = 0;   // what I already know: bounds the reply's delta
+      gen_t subscribe_need = 0; // what I am waiting for: LEGACY path only
+
+      // rule 8's departure intent, unicast to the owner.  At most one per
+      //  section - the eligibility test latches 'depart_outstanding'.
+      bool has_depart = false;
+    };
+
+    // ---- IMPLEMENTATION_PLAN section 5 - instrument from day one -----------
+    //
+    // The specs abstract K, J, the shrink policy and the plan-rebuild trigger
+    //  as NONDETERMINISM precisely so that no choice of constant can be wrong,
+    //  which is the same reason none of them can be validated by a model.
+    //  Only measurement can tune them, so these are the four quantities
+    //  IMPLEMENTATION_PLAN section 5 asks to have counted from the start.
+    //
+    // Every field is written ONLY under 'mutex', beside the state it describes,
+    //  so it costs one non-atomic increment on a path that is already locked.
+    //  Nothing branches on any of them - they are diagnostics.
+    struct BarrierCounters {
+      // --- NODE SIDE, rule 8.  'leave_rejoin_cycles' near zero is the
+      //     expectation that validates K = 8; a rising count is exactly what
+      //     doubles K, so the counter and the adaptation share one signal.
+      uint64_t departs_sent = 0;
+      uint64_t departs_suppressed = 0; // rule 8's hint said it would be declined
+      uint64_t leave_rejoin_cycles = 0;
+      uint64_t churn_backoffs = 0; // rejoins inside DEPART_CHURN_WINDOW
+
+      // --- OWNER SIDE.  'subscribe_fan_in' is the last unaggregated O(N) path
+      //     in the design, so it is the one to watch for the escape hatch.
+      uint64_t subscribe_fan_in = 0;
+      uint64_t departs_received = 0;
+      uint64_t shrinks_applied = 0;
+      uint64_t shrinks_declined = 0; // the cost test said the removal loses
+      uint64_t nodes_removed = 0;
+
+      // --- ARRIVAL, the deviation path (ARRIVAL_PROTOCOL section 11.1).  An
+      //     eager-flush report is the only O(subtree) payload in the protocol.
+      uint64_t flush_episodes = 0;
+      uint64_t flush_report_bytes = 0;
+      size_t flush_report_bytes_max = 0;
+
+      // --- OWNER, plan lifecycle (ARRIVAL_PROTOCOL sections 11.2 and 11.3).
+      //     'agg_peak_entries' is the memory bound D9 exists to protect: the
+      //     aggregation structure is a LOCAL of the trigger path, and this is
+      //     the number that would show it silently growing if it ever stopped
+      //     being one.
+      uint64_t plan_rebuilds = 0;
+      size_t agg_peak_entries = 0;
+
+      // --- RULE 10, the pinned-edge machinery (SCALE_TEST_PLAN section 1).
+      //     Each is the exercise-proof for a verified rule: a scale run where
+      //     one of these never moves has NOT tested that rule, no matter how
+      //     green it is.  The park/dead/retro/stale counters are the race
+      //     windows - they cannot be forced deterministically from the
+      //     application, only made probable (churn phases, many seeds).
+      uint64_t plans_parked = 0;          // rule 5 deferral engaged
+      uint64_t parked_plans_applied = 0;  // ...and resolved by an invalidation
+      uint64_t dead_plans_discarded = 0;  // rule 10.2/10.3 guard fired
+      uint64_t retro_flushes_sent = 0;    // rule 10.4 late case 3
+      uint64_t stale_edge_forwards = 0;   // rule 10.5 receiver-side forward
+      uint64_t report_edges_pinned = 0;   // rule 10.1, per (generation) pin
+      uint64_t pin_conflicts_avoided = 0; // pinned target differed from current parent
+      uint64_t gap_pulls = 0;             // NOTIFICATION rule 4 gap -> pull
+
+      // has anything at all happened worth reporting?
+      bool any(void) const;
+    };
+    BarrierCounters counters;
+
+    // IMPLEMENTATION_PLAN section 5 - THE WAY OUT.  The counters above are
+    //  written under 'mutex' on paths that already hold it and nothing branches
+    //  on them, so without a reader they are write-only.  Two exist:
+    //
+    //   * dump_counters(), called when the barrier slot is recycled and
+    //     when it is destroyed, which logs one line per barrier that actually
+    //     used the deviation or hysteresis paths (log level 'info', category
+    //     'barrier'); and
+    //   * get_counters(), for a debugger or a test that wants the numbers
+    //     directly.  Caller must hold 'mutex' if the barrier is live.
+    const BarrierCounters &get_counters(void) const { return counters; }
+
+    // Silent unless something was counted.  Called where the barrier is
+    //  quiescent (slot re-initialisation and destruction), so it takes no lock
+    //  of its own; any other caller must hold 'mutex'.
+    void dump_counters(const char *why) const;
+
+#ifdef DEBUG_REALM
+    // DEBUG ONLY - fail loudly on a '..._locked' helper called without the
+    //  lock.  If 'mutex' can be taken here then NOBODY held it, and in
+    //  particular this thread did not, which is the bug.  Failing to take it is
+    //  INCONCLUSIVE (another thread may hold it), so this never fires falsely.
+    void assert_locked(const char *who) const;
+#define REALM_BARRIER_ASSERT_LOCKED() this->assert_locked(__func__)
+#else
+#define REALM_BARRIER_ASSERT_LOCKED()                                                    \
+  do {                                                                                   \
+  } while(0)
+#endif
+
+    // ---- scalable arrival helpers.  ALL of these require 'mutex' -----------
+
+    // find or create the record for 'gen'
+    Generation *get_generation_locked(gen_t gen);
+
+    // ARRIVAL_PROTOCOL rule 1, BOTH halves: this node's local arrival count
+    //  equals the quota its plan predicts AND every child the plan predicts has
+    //  reported at least once.
+    bool plan_satisfied_locked(const Generation &g) const;
+
+    // where a report from this node goes (section 8.1: the parent is stored)
+    NodeID report_target_locked(void) const;
+
+    // has the plan this node holds been retired without a replacement having
+    //  arrived yet?  See should_report_locked() for why this matters.
+    bool plan_retired_locked(void) const;
+
+    // is this node reporting eagerly for 'g' rather than aggregating under a
+    //  valid plan?  The union of rules 2/4 (the per-generation flag), rule 3
+    //  (no plan record at all), rule 6's retired-but-not-yet-replaced state and
+    //  rule 8.3 (this node's arrivals bypass the tree, so its quota is
+    //  unreachable).  It is also exactly the condition under which a report
+    //  carries the (node,count) map of section 11.1.
+    bool flush_mode_locked(gen_t gen, const Generation &g) const;
+
+    // the forwarding decision of action A step 5 / action R step 6
+    bool should_report_locked(gen_t gen, const Generation &g) const;
+
+    // record the cumulative report this node owes its parent, and remember we
+    //  have now passed that much on (reported_up)
+    void record_report_locked(Generation &g, gen_t gen, PendingSends &sends);
+
+    // BarrierArrive's 'held' set: report EVERY open generation this node is
+    //  sitting on, whatever mode it is in.  Used by rules 5 and 6.
+    void report_held_locked(PendingSends &sends);
+
+    // ARRIVAL_PROTOCOL rule 4 - enter eager-flush mode for one generation.
+    //  The shared core of rules 2, 3, 4 and 8; IDEMPOTENT.
+    void enter_flush_locked(Generation &g, gen_t gen, PendingSends &sends);
+
+    // ARRIVAL_PROTOCOL rule 8.3 - enter eager flush for EVERY open generation
+    //  at or after 'from_gen'.  Generations this node has no record for yet are
+    //  covered by ts_floor rather than by a flag, exactly as rule 6's
+    //  quantifier is covered by plan_retired_locked() - see flush_mode_locked.
+    void enter_flush_from_locked(gen_t from_gen, PendingSends &sends);
+
+    // ARRIVAL_PROTOCOL rule 8 - the timestamp this node's arrivals for 'gen'
+    //  must carry (the model's myTs[n][g]): the greatest ts_floor entry with
+    //  key <= gen, or 0 if this node has never altered this barrier.
+    Barrier::timestamp_t ts_floor_locked(gen_t gen) const;
+
+    // OWNER ONLY - expected(gen).  See alter_floor / alter_steps.
+    int64_t expected_locked(gen_t gen) const;
+
+    // OWNER ONLY - is every timestamp in this gate applied?  EXACT SET
+    //  MEMBERSHIP: never a "<= highest applied" comparison.
+    bool ts_gate_open_locked(const Generation::TsKey &gate) const;
+
+    // OWNER ONLY - credit 'count' arrivals to a generation, on whichever
+    //  accumulator that generation's path uses
+    void credit_arrivals_locked(Generation &g, int64_t count) const;
+
+    // OWNER ONLY - action TS.  Accept one cumulative bypassed-arrival report
+    //  and credit it if its gate is open (park it in place if not).
+    void apply_ts_arrival_locked(NodeID from, Generation &g,
+                                 const Generation::TsKey &gate, int64_t val);
+
+    // OWNER ONLY - a timestamp has just been applied, so every parked stream
+    //  gated on it may now be counted
+    void open_ts_gates_locked(Barrier::timestamp_t ts);
+
+    // OWNER ONLY - ARRIVAL_PROTOCOL rule 9.  Retire the current plan: send the
+    //  invalidation down the tree being retired and retire this node's own
+    //  epoch, which leaves every node in it eagerly reporting until a new plan
+    //  is built.  IDEMPOTENT - a plan already retired is left alone.
+    void retire_plan_locked(PendingSends &sends);
+
+    // OWNER ONLY - action RA.  Apply one alteration persistently, open the
+    //  gates it holds shut, and release any alteration held behind it.
+    void apply_alter_locked(gen_t alter_gen, int delta, Barrier::timestamp_t ts,
+                            Barrier::timestamp_t prev_ts, PendingSends &sends);
+
+    // ARRIVAL_PROTOCOL section 8.8 - retention.  Fold the alteration steps at
+    //  or below the watermark into the floor and drop the ts_floor breakpoints
+    //  no arrival can name any more.
+    void prune_alter_state_locked(gen_t watermark);
+
+    // ARRIVAL_PROTOCOL rule 5 - install a plan record decoded from a 'newplan'
+    //  payload and record the fan-out to this node's children in the new tree.
+    //  Reports held work FIRST, while the OLD plan is still in place, because
+    //  that is who owes the old parent (BarrierArrive evaluates Send() in the
+    //  unprimed state).
+    void apply_plan_locked(uint32_t epoch, const void *data, size_t datalen,
+                           NodeID parent, PendingSends &sends);
+
+    // ARRIVAL_PROTOCOL section 11.1 - the (node,count) map this node speaks
+    //  for: its own local arrivals merged with every child's last flush map.
+    //  Merging is per-node REPLACE-IF-HIGHER, never addition: each entry is
+    //  that node's own cumulative local total, so a node that appears under
+    //  two children (its old parent and its new one, mid-switch) must be
+    //  counted ONCE, at its highest observed value.  Summing would over-count
+    //  and an over-count is what makes a plan deadlock - see
+    //  build_new_plan_locked().
+    void merge_counts_locked(const Generation &g, std::map<NodeID, int64_t> &out) const;
+
+    // ARRIVAL_PROTOCOL section 11.2 and 11.4 - OWNER ONLY.  Turn the merged
+    //  node->count map into a tree plus quotas, install the owner's own
+    //  record, and record the invalidate/newplan fan-out.  'agg' is a local of
+    //  the caller and is not retained (section 11.3).
+    //
+    // 'tree_arrivals' is the number of arrivals the gathered generation took
+    //  THROUGH THE TREE (its expected count less the arrivals that bypassed
+    //  it).  Section 11.2 reads the merged maps as "the participant set", which
+    //  they only are when every participant was eager and therefore carried a
+    //  map; comparing their sum against this says whether that was the case.
+    void build_new_plan_locked(const std::map<NodeID, int64_t> &agg,
+                               int64_t tree_arrivals, PendingSends &sends);
+
+    // owner only: has 'g' accounted for every arrival it is waiting for?
+    bool generation_complete_locked(gen_t gen, const Generation &g) const;
+
+    // ---- NOTIFICATION_PROTOCOL helpers.  ALL of these require 'mutex' ------
+
+    // decision Q3 - record one poisoned generation and PUBLISH it.  Idempotent.
+    //  Past POISONED_GENERATION_LIMIT this logs fatal and aborts: there is no
+    //  representation that stays lock-free past the cap.
+    void add_poison_locked(gen_t gen);
+
+    // Advance the watermark to 'wm', publishing the poison for the range FIRST
+    //  (section 3.5), then drain and free every generation record at or below
+    //  it, sorting the waiters by whether their generation was poisoned.
+    //  Signals external waiters inside the section, as the three existing
+    //  signal sites do.
+    void publish_watermark_locked(gen_t wm, const gen_t *poison, size_t num_poisoned,
+                                  EventWaiter::EventWaiterList &clean,
+                                  EventWaiter::EventWaiterList &poisoned);
+
+    // the model's 'waiting[n] # {}': does this node still hold an untriggered
+    //  waiter?  Used by rule 6's re-subscribe test.  No new member is needed.
+    bool has_waiters_locked(void) const;
+
+    // the generation to put in a subscribe's 'subscribe_gen' field
+    gen_t subscribe_need_locked(void) const;
+
+    // NOTIFICATION_PROTOCOL action C step 4 - the CONSULTATION-driven pull.
+    //  Deliberately NOT gated on 'pull_outstanding': the model's Consult has no
+    //  such guard (BarrierNotify:122-126), because 'member' going to PENDING is
+    //  what suppresses a duplicate.  Does nothing if this node is the owner or
+    //  already believes itself covered.
+    void consult_subscribe_locked(PendingSends &sends);
+
+    // NOTIFICATION_PROTOCOL action N step 5 / action RP - the RECOVERY pull,
+    //  rule 7 gated.  If a pull is already outstanding this remembers the
+    //  request in 'pull_deferred' rather than dropping it.
+    void record_pull_locked(PendingSends &sends);
+
+    // ---- NOTIFICATION_PROTOCOL rule 8 helpers.  ALL require 'mutex' --------
+
+    // action C step 3 - THE CONSULTATION SIGNAL.  Resets the idle counter and
+    //  retires any departure intent this node was holding.  Called from
+    //  add_waiter, subscribe and (through subscribe) external_wait /
+    //  external_timedwait.  NEVER from has_triggered().
+    void note_consultation_locked(void);
+
+    // this node is going from "not a member" back to wanting in.  If it had
+    //  asked to leave, that is a leave->rejoin cycle; inside
+    //  DEPART_CHURN_WINDOW generations it is CHURN and doubles K.
+    void note_rejoin_locked(void);
+
+    // action N step 6 / action RP - the departure eligibility test, evaluated
+    //  where the watermark moves.  Records the unicast intent in 'sends'.
+    void consider_departure_locked(PendingSends &sends);
+
+    // OWNER ONLY - rule 3's COST TEST.  Would dropping 'departing' from
+    //  'sub_set' actually reduce the cost of a notification?  Removals are
+    //  discretionary precisely so this can say no: dropping scattered nodes
+    //  from an ALL_NODES encoding turns a 1-byte target set into a per-hop
+    //  bitmap, and that bitmap rides EVERY hop of the forwarding tree.
+    bool shrink_pays_locked(const MulticastTargetSet &departing) const;
+
+    // owner only: drain every contiguous generation that is now complete.
+    //  Returns the highest generation triggered (0 if none) and records the
+    //  waiters and remote notifications to be emitted AFTER the unlock.  A
+    //  plan switch due at the new watermark + 1 is built and recorded here
+    //  too, because this is the last moment the drained generation's
+    //  aggregation maps still exist (section 11.3).
+    //
+    // BarrierArrive's 'Trigger' and BarrierNotify's 'Trigger' are ONE critical
+    //  section here (tla/STATE_AND_LOCKING.md section 3.4 action T): they are
+    //  the same real-world event, they share the watermark, and the
+    //  notification's 'prev' must be the pre-trigger watermark of the same
+    //  contiguous chain.  Splitting them leaves a window in which the watermark
+    //  has advanced but no notification describes it.
+    gen_t check_triggers_locked(EventWaiter::EventWaiterList &local_notifications,
+                                EventWaiter::EventWaiterList &poisoned_notifications,
+                                std::vector<RemoteNotification> &remote_notifications,
+                                gen_t &oldest_previous, PendingSends &sends);
+
+    // 'mutex' must NOT be held (S2/S3)
+    void emit_pending_sends(const PendingSends &sends);
+    void emit_report(const PendingReport &r);
+
+    // 'mutex' must NOT be held.  Waiters woken with the wrong poison status is
+    //  one of the three unsafe imprecisions this protocol exists to prevent, so
+    //  the two lists are kept apart all the way to the trigger call.
+    static void deliver_waiters(EventWaiter::EventWaiterList &clean,
+                                EventWaiter::EventWaiterList &poisoned,
+                                TimeLimit work_until);
+
+    // 'mutex' must NOT be held: the emit phase reads only its arguments and
+    //  immutable members (S2/S3)
+    void emit_trigger_notifications(gen_t trigger_gen,
+                                    const std::vector<RemoteNotification> &rns,
+                                    gen_t oldest_previous, const void *final_values_copy,
+                                    size_t sizeof_lhs);
+
+    // caller MUST hold 'mutex'
+    LegacyReductionState &legacy_state(void)
+    {
+      if(!legacy) {
+        legacy.reset(new LegacyReductionState);
+      }
+      return *legacy;
+    }
   };
 }; // namespace Realm
 

--- a/src/realm/barrier_impl.h
+++ b/src/realm/barrier_impl.h
@@ -807,6 +807,12 @@ namespace Realm {
     //  the churn window's origin, and it is not evidence the node actually left
     //  - the owner may have declined.
     gen_t last_depart_wm = 0;
+    // a rejoin whose churn judgment is waiting on the subscribe REPLY.  A
+    //  departed node receives no notifications, so its own watermark FROZE at
+    //  the depart point; judging a voluntary-consult rejoin with the local
+    //  clock would call EVERY such rejoin churn, however long the node was
+    //  really gone.  The reply's watermark is the honest clock (action RP).
+    bool rejoin_judge_pending = false;
     // K, doubled on observed churn and capped at DEPART_K_MAX
     unsigned depart_K = DEPART_K_INITIAL;
     // one request per idle episode.  Cleared when this node next consults
@@ -1381,9 +1387,18 @@ namespace Realm {
     void note_consultation_locked(void);
 
     // this node is going from "not a member" back to wanting in.  If it had
-    //  asked to leave, that is a leave->rejoin cycle; inside
-    //  DEPART_CHURN_WINDOW generations it is CHURN and doubles K.
+    //  asked to leave, that is a leave->rejoin cycle; one that lands inside
+    //  DEPART_CHURN_WINDOW generations is CHURN and doubles K - measured on an
+    //  honest clock, which is what splits these three.  The rule-6 sites call
+    //  note_rejoin_locked() and judge immediately: their local watermark is
+    //  current, because the node learned of its removal from the removal
+    //  notification itself.  The voluntary-consult site (action C) calls
+    //  note_rejoin_deferred_locked(): a departed node's watermark froze at the
+    //  depart point, so the judgment waits for the subscribe reply's watermark
+    //  (action RP), which is what judge_rejoin_locked() consumes.
     void note_rejoin_locked(void);
+    void note_rejoin_deferred_locked(void);
+    void judge_rejoin_locked(gen_t now_wm);
 
     // action N step 6 / action RP - the departure eligibility test, evaluated
     //  where the watermark moves.  Records the unicast intent in 'sends'.

--- a/src/realm/barrier_impl.inl
+++ b/src/realm/barrier_impl.inl
@@ -28,8 +28,6 @@ namespace Realm {
 
 namespace Realm {
 
-  TYPE_IS_SERIALIZABLE(Realm::RemoteNotification);
-
   ////////////////////////////////////////////////////////////////////////
   //
   // class BarrierImpl
@@ -57,38 +55,6 @@ namespace Realm {
     Barrier b = id.convert<Barrier>();
     b.timestamp = timestamp;
     return b;
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-  //
-  // struct BarrierTriggerPayload
-  //
-
-  template <typename S>
-  bool serdez(S &ser, const BarrierTriggerPayload &notification)
-  {
-    bool success = false;
-    success = (ser & notification.remotes) && (ser & notification.reduction);
-    return success;
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-  //
-  // struct BarrierTriggerMessageArgs
-  //
-
-  template <typename S>
-  bool serdez(S &ser, const BarrierTriggerMessageArgs &args)
-  {
-    bool success = false;
-
-    success = (ser & args.internal.trigger_gen) && (ser & args.internal.previous_gen) &&
-              (ser & args.internal.first_generation) && (ser & args.internal.redop_id) &&
-              (ser & args.internal.migration_target) &&
-              (ser & args.internal.base_arrival_count) &&
-              (ser & args.internal.broadcast_index);
-
-    return success;
   }
 
 }; // namespace Realm

--- a/src/realm/runtime_impl.cc
+++ b/src/realm/runtime_impl.cc
@@ -761,6 +761,7 @@ namespace Realm {
     config_map.insert({"ib_regmem", &reg_ib_mem_size});
     config_map.insert({"report_sparsity_leaks", &report_sparsity_leaks});
     config_map.insert({"barrier_broadcast_radix", &barrier_broadcast_radix});
+    config_map.insert({"barrier_plan_radix", &barrier_plan_radix});
     config_map.insert({"diskmem", &disk_mem_size});
     config_map.insert({"dma_multi_field", &dma_multi_field});
 
@@ -800,7 +801,8 @@ namespace Realm {
         .add_option_int("-ll:util_bgwork", util_bgwork_timeslice)
         .add_option_int("-ll:ext_sysmem", use_ext_sysmem)
         .add_option_bool("-ll:report_sparsity_leaks", report_sparsity_leaks)
-        .add_option_int("-ll:barrier_radix", barrier_broadcast_radix);
+        .add_option_int("-ll:barrier_radix", barrier_broadcast_radix)
+        .add_option_int("-ll:barrier_plan_radix", barrier_plan_radix);
 
     // config for RuntimeImpl
     // low-level runtime parameters

--- a/src/realm/runtime_impl.h
+++ b/src/realm/runtime_impl.h
@@ -185,6 +185,12 @@ namespace Realm {
 
     // barriers
     int barrier_broadcast_radix = 4;
+    // fan-out of a constructed ARRIVAL plan (distinct from the multicast
+    //  broadcast radix above).  8 keeps a few-thousand-node barrier at depth 4;
+    //  a small value (2) makes relay trees - and with them the rule-10 race
+    //  windows - reachable at single-digit rank counts for testing
+    //  (tla/SCALE_TEST_PLAN.md).
+    int barrier_plan_radix = 8;
 
     // topology of the host
     const HardwareTopology *host_topology = nullptr;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -276,6 +276,9 @@ add_integration_test(ctxswitch "${REALM_TEST_DIR}/ctxswitch.cc")
 add_integration_test(barrier_reduce "${REALM_TEST_DIR}/barrier_reduce.cc")
 # barrier_arrivals.cc existed but was never registered, so it was neither built nor run.
 add_integration_test(barrier_arrivals "${REALM_TEST_DIR}/barrier_arrivals.cc")
+# the deviation driver (tla/SCALE_TEST_PLAN.md) - forces the protocol cases the
+#  other barrier tests never reach, and destroys its barriers so counters dump
+add_integration_test(barrier_scale_test "${REALM_TEST_DIR}/barrier_scale_test.cc")
 add_integration_test(taskreg "${REALM_TEST_DIR}/taskreg.cc")
 add_integration_test(idcheck "${REALM_TEST_DIR}/idcheck.cc")
 add_integration_test(inst_reuse "${REALM_TEST_DIR}/inst_reuse.cc")

--- a/tests/barrier_scale_test.cc
+++ b/tests/barrier_scale_test.cc
@@ -61,12 +61,17 @@ enum Phase
   P_SPLITWAIT,  // notification: waiters disjoint from arrivers + far-future
   P_POISON,     // Q4: poisoned arrival poisons exactly its generation
   P_CHAOS,      // everything above, seeded random
+  P_STEP,       // ONE persistent pattern shift at mid-phase: the realistic
+                //  Legion case.  Every post-shift generation deviates from the
+                //  stale plan the SAME way, so this is the probe for whether
+                //  the owner can ever re-learn a plan whose deviation is
+                //  discovered mid-generation (the partial-evidence question).
   P_NUM_PHASES
 };
 
-static const char *phase_names[P_NUM_PHASES] = {"steady",   "over",   "outsider",
-                                                "runahead", "churn",  "alter",
-                                                "split",    "poison", "chaos"};
+static const char *phase_names[P_NUM_PHASES] = {"steady", "over",  "outsider", "runahead",
+                                                "churn",  "alter", "split",    "poison",
+                                                "chaos",  "step"};
 
 namespace TestConfig {
   int gens = 32; // generations per phase
@@ -99,7 +104,7 @@ static uint64_t mix(uint64_t a, uint64_t b, uint64_t c)
 // r is ALWAYS nranks (the create-time expected count), except in P_ALTER where
 // the alteration adds one from its generation onward - through the API, which
 // is the point.
-static int arrivals_for(int phase, int seed, int nranks, int g, int r)
+static int arrivals_for(int phase, int seed, int nranks, int gens, int g, int r)
 {
   if(nranks == 1) {
     return 1; // every deviation needs a second rank; degenerate to steady
@@ -155,6 +160,20 @@ static int arrivals_for(int phase, int seed, int nranks, int g, int r)
     int base = nranks / arrivers;
     int extra = nranks % arrivers;
     return base + ((r < extra) ? 1 : 0);
+  }
+  case P_STEP:
+  {
+    // pattern A (everyone 1) for the first half; pattern B (rank 0 silent,
+    //  rank 1 doubled) for the second - constant within each half, total
+    //  conserved.  A healthy plan lifecycle re-learns ONCE at the shift and
+    //  aggregates thereafter; a broken one declines and stays eager forever.
+    if(g < gens / 2)
+      return 1;
+    if(r == 0)
+      return 0;
+    if(r == 1)
+      return 2;
+    return 1;
   }
   case P_CHAOS:
   {
@@ -212,7 +231,7 @@ static void worker_task(const void *args, size_t arglen, const void *userdata,
   for(int g = 0; g < G; g++) {
     wait_handles.push_back(ab);
 
-    int count = arrivals_for(wa.phase, wa.seed, N, g, R);
+    int count = arrivals_for(wa.phase, wa.seed, N, G, g, R);
     if(i_alter && (g == alter_at)) {
       // the contract: hold an unissued arrival from the pre-alteration count
       //  while altering, then use the returned (timestamped) handle

--- a/tests/barrier_scale_test.cc
+++ b/tests/barrier_scale_test.cc
@@ -74,10 +74,10 @@ static const char *phase_names[P_NUM_PHASES] = {"steady", "over",  "outsider", "
                                                 "chaos",  "step"};
 
 namespace TestConfig {
-  int gens = 32; // generations per phase
-  int seed = 12345;
+  int gens = 32;       // generations per phase
   int runahead = 4;    // max generations arrivals may lead waits (P_RUNAHEAD)
   int phase_mask = -1; // bitmask of phases to run, -1 = all
+  int seed = 12345;
 }; // namespace TestConfig
 
 struct WorkerArgs {

--- a/tests/barrier_scale_test.cc
+++ b/tests/barrier_scale_test.cc
@@ -1,0 +1,353 @@
+/*
+ * Copyright 2026 Stanford University, NVIDIA Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// The DEVIATION DRIVER for the scalable-barrier protocols
+// (tla/SCALE_TEST_PLAN.md).  The existing barrier tests exercise steady state
+// only - none of the deviation machinery (ARRIVAL_PROTOCOL rules 2/3/5/8/10)
+// ever executes under them, which the counters prove.  Each phase here forces
+// one protocol case; the exercise-proof is the counter dump each barrier
+// emits when it is destroyed (build with -DREALM_LOG_LEVEL=INFO and run with
+// -level barrier=2 to see it) plus the protocol's own info-level logs.
+//
+// Every rank computes the same seeded schedule, so the expected arrival total
+// per generation is known everywhere and conservation is maintained by
+// construction: a phase never changes the total (except ALTER, which changes
+// it through the API whose persistence it is testing).
+//
+// The oracle here is local (v1): in-order exactly-once wakes per rank, poison
+// observed exactly where scripted, and phase completion (a hang is caught by
+// the ctest timeout).  The cross-rank no-early-trigger ledger of
+// SCALE_TEST_PLAN.md section 2 is a follow-up.
+
+#include <assert.h>
+
+#include "realm.h"
+#include "osdep.h"
+#include "realm/cmdline.h"
+#include "realm/network.h"
+
+using namespace Realm;
+
+Logger log_app("app");
+
+enum
+{
+  MAIN_TASK = Processor::TASK_ID_FIRST_AVAILABLE + 0,
+  WORKER_TASK,
+};
+
+enum Phase
+{
+  P_STEADY = 0, // rule 1: plan learned once, then pure aggregation
+  P_OVER,       // rule 2: rotating over-arrival (+1 / -1 elsewhere)
+  P_OUTSIDER,   // rule 3: rotating outsider (a rank with 0 gets 1)
+  P_RUNAHEAD,   // rule 10.1/10.4: arrivals sprint ahead of waits
+  P_CHURN,      // rules 5/10.2/10.3: pattern rotates EVERY generation
+  P_ALTER,      // rules 8/9: persistent count change mid-phase
+  P_SPLITWAIT,  // notification: waiters disjoint from arrivers + far-future
+  P_POISON,     // Q4: poisoned arrival poisons exactly its generation
+  P_CHAOS,      // everything above, seeded random
+  P_NUM_PHASES
+};
+
+static const char *phase_names[P_NUM_PHASES] = {"steady",   "over",   "outsider",
+                                                "runahead", "churn",  "alter",
+                                                "split",    "poison", "chaos"};
+
+namespace TestConfig {
+  int gens = 32; // generations per phase
+  int seed = 12345;
+  int runahead = 4;    // max generations arrivals may lead waits (P_RUNAHEAD)
+  int phase_mask = -1; // bitmask of phases to run, -1 = all
+}; // namespace TestConfig
+
+struct WorkerArgs {
+  Barrier barrier;
+  int phase;
+  int rank; // this worker's index == address space
+  int nranks;
+  int gens;
+  int seed;
+};
+
+// deterministic per-(seed, phase, gen) mix - every rank computes the same value
+static uint64_t mix(uint64_t a, uint64_t b, uint64_t c)
+{
+  uint64_t x = a * 0x9E3779B97F4A7C15ull + b * 0xBF58476D1CE4E5B9ull +
+               c * 0x94D049BB133111EBull + 0x2545F4914F6CDD1Dull;
+  x ^= x >> 30;
+  x *= 0xBF58476D1CE4E5B9ull;
+  x ^= x >> 27;
+  return x;
+}
+
+// How many arrivals rank r owes for generation g of this phase.  The sum over
+// r is ALWAYS nranks (the create-time expected count), except in P_ALTER where
+// the alteration adds one from its generation onward - through the API, which
+// is the point.
+static int arrivals_for(int phase, int seed, int nranks, int g, int r)
+{
+  if(nranks == 1) {
+    return 1; // every deviation needs a second rank; degenerate to steady
+  }
+  switch(phase) {
+  case P_OVER:
+  {
+    // odd generations: one rank +1, its neighbour -1
+    if(g % 2 == 0)
+      return 1;
+    int over = (int)(mix(seed, phase, g) % nranks);
+    int under = (over + 1) % nranks;
+    if(r == over)
+      return 2;
+    if(r == under)
+      return 0;
+    return 1;
+  }
+  case P_OUTSIDER:
+  {
+    // rank (g%nranks) is silent for a WINDOW of generations, then returns as
+    //  an outsider while its neighbour goes quiet - the plan learned during
+    //  the window did not predict it
+    int quiet = (g / 4) % nranks;    // rotates every 4 generations
+    int loud = (quiet + 1) % nranks; // carries the quiet rank's arrival
+    if(r == quiet)
+      return 0;
+    if(r == loud)
+      return 2;
+    return 1;
+  }
+  case P_CHURN:
+  {
+    // a random pair swaps roles EVERY generation: constant plan rebuilds,
+    //  which is what makes the park/dead-plan race windows probable
+    int a = (int)(mix(seed, phase * 977, g) % nranks);
+    int b = (a + 1 + (int)(mix(seed, phase, g * 31) % (nranks - 1))) % nranks;
+    if(r == a)
+      return 2;
+    if(r == b)
+      return 0;
+    return 1;
+  }
+  case P_ALTER:
+    return 1; // the altering rank adds its extra arrival explicitly (below)
+  case P_SPLITWAIT:
+  {
+    // first half of the ranks carry all arrivals; second half only waits
+    int arrivers = (nranks + 1) / 2;
+    if(r >= arrivers)
+      return 0;
+    // distribute nranks arrivals over 'arrivers' ranks
+    int base = nranks / arrivers;
+    int extra = nranks % arrivers;
+    return base + ((r < extra) ? 1 : 0);
+  }
+  case P_CHAOS:
+  {
+    // random redistribution with the total conserved: walk the ranks with a
+    //  seeded shuffle of +1/-1 pairs
+    int v = 1;
+    uint64_t h = mix(seed, phase, g);
+    int plus = (int)(h % nranks);
+    int minus = (plus + 1 + (int)((h >> 16) % (nranks - 1))) % nranks;
+    if(r == plus)
+      v += 1;
+    if(r == minus)
+      v -= 1;
+    return v;
+  }
+  case P_STEADY:
+  case P_RUNAHEAD:
+  case P_POISON:
+  default:
+    return 1;
+  }
+}
+
+static bool poisoned_gen(int phase, int gens, int g)
+{
+  // one poisoned generation, mid-phase
+  return (phase == P_POISON) && (g == gens / 2);
+}
+
+static void worker_task(const void *args, size_t arglen, const void *userdata,
+                        size_t userlen, Processor p)
+{
+  const WorkerArgs wa = *(const WorkerArgs *)args;
+  const int N = wa.nranks, G = wa.gens, R = wa.rank;
+
+  // two independent walks over the generation chain: 'ab' is where arrivals
+  //  are issued, 'wb' where waits happen.  In P_RUNAHEAD 'ab' leads 'wb' by a
+  //  rank-staggered lag, which is what creates run-ahead: arrivals on
+  //  generations the previous plan is still current for.
+  Barrier ab = wa.barrier;
+  int lag = 0;
+  if(wa.phase == P_RUNAHEAD && N > 1) {
+    lag = 1 + (R % TestConfig::runahead);
+  }
+
+  // P_ALTER: rank 0 alters +1 at the midpoint and owes one extra arrival per
+  //  generation from then on - the PERSISTENCE is the thing under test
+  //  (event.h:271, the pre-existing bug C6 fixed).
+  const int alter_at = G / 2;
+  const bool i_alter = (wa.phase == P_ALTER) && (R == 0) && (N > 1);
+
+  // arrivals first walk
+  std::vector<Barrier> wait_handles;
+  wait_handles.reserve(G);
+  for(int g = 0; g < G; g++) {
+    wait_handles.push_back(ab);
+
+    int count = arrivals_for(wa.phase, wa.seed, N, g, R);
+    if(i_alter && (g == alter_at)) {
+      // the contract: hold an unissued arrival from the pre-alteration count
+      //  while altering, then use the returned (timestamped) handle
+      assert(count > 0);
+      ab = ab.alter_arrival_count(1);
+      wait_handles.back() = ab; // wait on the timestamped branch too
+    }
+    if(i_alter && (g >= alter_at)) {
+      count += 1; // persistent: one extra every generation from the alteration on
+    }
+
+    if(poisoned_gen(wa.phase, G, g) && (R == (g % N)) && (count > 0)) {
+      // one arrival rides a poisoned precondition; Q4 says the generation is
+      //  poisoned for every waiter
+      UserEvent ue = UserEvent::create_user_event();
+      ab.arrive(1, ue);
+      ue.cancel(); // poisons the precondition
+      count -= 1;
+    }
+    if(count > 0) {
+      ab.arrive(count);
+    }
+
+    // waits: everyone waits every generation, except the split phase (only
+    //  the non-arrivers wait) and run-ahead (waits lag behind arrivals)
+    bool do_wait = true;
+    if(wa.phase == P_SPLITWAIT && N > 1) {
+      do_wait = (R >= (N + 1) / 2);
+    }
+    if(do_wait && (g >= lag)) {
+      const int wg = g - lag;
+      bool poisoned = false;
+      wait_handles[wg].wait_faultaware(poisoned);
+      const bool expect = poisoned_gen(wa.phase, G, wg);
+      if(poisoned != expect) {
+        log_app.fatal() << "poison mismatch: phase=" << phase_names[wa.phase]
+                        << " rank=" << R << " gen=" << wg << " got=" << poisoned
+                        << " want=" << expect;
+        abort();
+      }
+    }
+
+    ab = ab.advance_barrier();
+    assert(ab.exists());
+  }
+
+  // drain the lagged waits
+  if(lag > 0) {
+    for(int wg = G - lag; wg < G; wg++) {
+      bool poisoned = false;
+      wait_handles[wg].wait_faultaware(poisoned);
+      assert(poisoned == poisoned_gen(wa.phase, G, wg));
+    }
+  }
+
+  // P_SPLITWAIT far-future check: the last rank ALSO waits on the final
+  //  generation up front next phase - modelled here simply by re-waiting the
+  //  last handle (already triggered: exercises the has_triggered fast path)
+  bool p2 = false;
+  wait_handles[G - 1].wait_faultaware(p2);
+  assert(p2 == poisoned_gen(wa.phase, G, G - 1));
+}
+
+static void main_task(const void *args, size_t arglen, const void *userdata,
+                      size_t userlen, Processor p)
+{
+  // one worker processor per address space
+  std::map<AddressSpace, Processor> per_space;
+  Machine::ProcessorQuery pq =
+      Machine::ProcessorQuery(Machine::get_machine()).only_kind(Processor::LOC_PROC);
+  for(Machine::ProcessorQuery::iterator it = pq.begin(); it != pq.end(); ++it) {
+    AddressSpace s = (*it).address_space();
+    if(per_space.find(s) == per_space.end()) {
+      per_space[s] = *it;
+    }
+  }
+  const int N = (int)per_space.size();
+  log_app.print() << "barrier_scale_test: ranks=" << N << " gens=" << TestConfig::gens
+                  << " seed=" << TestConfig::seed;
+
+  for(int phase = 0; phase < P_NUM_PHASES; phase++) {
+    if((TestConfig::phase_mask >= 0) && !((TestConfig::phase_mask >> phase) & 1)) {
+      continue;
+    }
+    // expected per generation == N by construction of arrivals_for()
+    Barrier b = Barrier::create_barrier(N);
+
+    std::vector<Event> done;
+    int rank = 0;
+    for(std::map<AddressSpace, Processor>::iterator it = per_space.begin();
+        it != per_space.end(); ++it, ++rank) {
+      WorkerArgs wa;
+      wa.barrier = b;
+      wa.phase = phase;
+      wa.rank = rank;
+      wa.nranks = N;
+      wa.gens = TestConfig::gens;
+      wa.seed = TestConfig::seed;
+      done.push_back(it->second.spawn(WORKER_TASK, &wa, sizeof(wa)));
+    }
+    Event::merge_events(done).wait();
+
+    // destruction is what fires the owner-side counter dump ("destroyed") -
+    //  the exercise-proof of SCALE_TEST_PLAN section 1
+    b.destroy_barrier();
+    log_app.print() << "phase " << phase_names[phase] << ": PASS";
+  }
+}
+
+int main(int argc, char **argv)
+{
+  Runtime rt;
+  rt.init(&argc, (char ***)&argv);
+
+  CommandLineParser cp;
+  cp.add_option_int("-gens", TestConfig::gens);
+  cp.add_option_int("-seed", TestConfig::seed);
+  cp.add_option_int("-runahead", TestConfig::runahead);
+  cp.add_option_int("-phases", TestConfig::phase_mask);
+  bool ok = cp.parse_command_line(argc, const_cast<const char **>(argv));
+  assert(ok);
+
+  Processor p = Machine::ProcessorQuery(Machine::get_machine())
+                    .only_kind(Processor::LOC_PROC)
+                    .first();
+  assert(p.exists());
+
+  Processor::register_task_by_kind(Processor::LOC_PROC, false /*!global*/, MAIN_TASK,
+                                   CodeDescriptor(main_task), ProfilingRequestSet())
+      .external_wait();
+  Processor::register_task_by_kind(Processor::LOC_PROC, false /*!global*/, WORKER_TASK,
+                                   CodeDescriptor(worker_task), ProfilingRequestSet())
+      .external_wait();
+
+  Event e = rt.collective_spawn(p, MAIN_TASK, 0, 0);
+  rt.shutdown(e);
+  return rt.wait_for_shutdown();
+}

--- a/tests/barrier_scale_test.cc
+++ b/tests/barrier_scale_test.cc
@@ -66,12 +66,26 @@ enum Phase
                 //  stale plan the SAME way, so this is the probe for whether
                 //  the owner can ever re-learn a plan whose deviation is
                 //  discovered mid-generation (the partial-evidence question).
+  P_DEPART,     // notification rules 3/6 + the K-doubling adaptation.  The
+                //  upper half of the ranks keeps ARRIVING every generation but
+                //  stops CONSULTING (waiting) except at widely spaced
+                //  checkpoints, so the delivered-generation watermark crosses
+                //  the departure threshold MID-WINDOW and they ask to leave
+                //  the subscriber set while triggers are still flowing - the
+                //  lower half waits every generation, so the owner always has
+                //  a next trigger at which to weigh (and grant) the shrink.
+                //  This is what the split phase cannot do: there the departs
+                //  are products of the FINAL triggers' notification burst, so
+                //  they always arrive after the last trigger and die with the
+                //  barrier, never weighed.  Needs -gens >= 384 for the full
+                //  cycle count; shorter runs exercise a prefix (>= 128 gets
+                //  the churn arm), and the default 32 degenerates to steady.
   P_NUM_PHASES
 };
 
 static const char *phase_names[P_NUM_PHASES] = {"steady", "over",  "outsider", "runahead",
                                                 "churn",  "alter", "split",    "poison",
-                                                "chaos",  "step"};
+                                                "chaos",  "step",  "depart"};
 
 namespace TestConfig {
   int gens = 32;       // generations per phase
@@ -192,6 +206,7 @@ static int arrivals_for(int phase, int seed, int nranks, int gens, int g, int r)
   case P_STEADY:
   case P_RUNAHEAD:
   case P_POISON:
+  case P_DEPART: // deviation is in the WAIT schedule, not the arrivals
   default:
     return 1;
   }
@@ -256,10 +271,46 @@ static void worker_task(const void *args, size_t arglen, const void *userdata,
     }
 
     // waits: everyone waits every generation, except the split phase (only
-    //  the non-arrivers wait) and run-ahead (waits lag behind arrivals)
+    //  the non-arrivers wait), run-ahead (waits lag behind arrivals), and
+    //  depart (the upper half waits only at checkpoints)
     bool do_wait = true;
     if(wa.phase == P_SPLITWAIT && N > 1) {
       do_wait = (R >= (N + 1) / 2);
+    }
+    if(wa.phase == P_DEPART && N > 1 && (R >= (N + 1) / 2)) {
+      // Checkpoint waits only.  Between checkpoints this rank arrives blind,
+      //  so its watermark delta since the last consultation crosses the
+      //  departure eligibility threshold - DEPART_K_INITIAL(8) plus a
+      //  node_id%DEPART_STAGGER_J(32) stagger, so at most 39 - somewhere
+      //  mid-window, and it asks to leave.  The two window sizes bracket
+      //  DEPART_CHURN_WINDOW(64): with W=128 the rejoin at the next
+      //  checkpoint lands MORE than 64 generations after the depart, the
+      //  cycle is clean, K stays 8, and it repeats every window; with W=64
+      //  the rejoin is churn, K doubles until the threshold outgrows the
+      //  window, and the rank correctly stops asking.  (Constants from
+      //  barrier_impl.h, restated here because that header is not public.)
+      const int W = ((R % 2) == 0) ? 64 : 128;
+      do_wait = ((g % W) == (W - 1));
+      if(do_wait) {
+        // let the trigger frontier - paced by the lower half's every-generation
+        //  waits - run well PAST this rank's depart point before it consults
+        //  again.  All this rank's arrivals for the window are already issued,
+        //  so the frontier does not need it; without the pause the next waiter
+        //  registers within a generation or two of the departure in OWNER-clock
+        //  terms and even the honest judge calls every rejoin churn.  A
+        //  departed node cannot poll for the frontier instead: it receives no
+        //  notifications, so its local knowledge is frozen until it consults.
+        //
+        // The two arms gate EACH OTHER: the frontier can only pass a sleeping
+        //  rank's last issued arrival, so it advances one 64-generation
+        //  churn-arm window per churn-arm sleep and stalls exactly at those
+        //  64-multiple checkpoints.  The clean arm must therefore sleep past
+        //  TWO churn-arm epochs, or its rejoin lands on a stall point exactly
+        //  64 generations after its depart - the churn boundary - instead of
+        //  the full 128 its window implies.  Oversleeping costs nothing but
+        //  wall clock: the frontier caps at this rank's own issued arrivals.
+        usleep(((R % 2) == 0) ? 100000 : 250000);
+      }
     }
     if(do_wait && (g >= lag)) {
       const int wg = g - lag;

--- a/tests/barrier_scale_test.cc
+++ b/tests/barrier_scale_test.cc
@@ -40,6 +40,10 @@
 #include "realm/cmdline.h"
 #include "realm/network.h"
 
+#ifdef __linux__
+#include <unistd.h>
+#endif
+
 using namespace Realm;
 
 Logger log_app("app");
@@ -218,6 +222,32 @@ static bool poisoned_gen(int phase, int gens, int g)
   return (phase == P_POISON) && (g == gens / 2);
 }
 
+// T3 soak instrumentation (SCALE_TEST_PLAN sections 4/5): resident-set samples
+//  from rank 0, cheap enough to leave on unconditionally.  A leak in
+//  per-generation state shows as MONOTONE GROWTH across a 1e5-generation
+//  phase; the expectation is a flat line after the first sample (the
+//  generation records, flush maps and aggregation structures all drain as
+//  generations trigger - agg_peak_entries is the counter-side view of the
+//  same bound).
+static long rss_mb(void)
+{
+#ifdef __linux__
+  FILE *f = fopen("/proc/self/statm", "r");
+  if(f == NULL) {
+    return -1;
+  }
+  long total = 0, resident = 0;
+  int n = fscanf(f, "%ld %ld", &total, &resident);
+  fclose(f);
+  if(n != 2) {
+    return -1;
+  }
+  return (resident * sysconf(_SC_PAGESIZE)) >> 20;
+#else
+  return -1; // sampled on the cluster; not meaningful elsewhere
+#endif
+}
+
 static void worker_task(const void *args, size_t arglen, const void *userdata,
                         size_t userlen, Processor p)
 {
@@ -245,6 +275,14 @@ static void worker_task(const void *args, size_t arglen, const void *userdata,
   wait_handles.reserve(G);
   for(int g = 0; g < G; g++) {
     wait_handles.push_back(ab);
+
+    if((R == 0) && ((g % 8192) == 0)) {
+      const long mb = rss_mb();
+      if(mb >= 0) {
+        log_app.print() << "rss_mb: phase=" << phase_names[wa.phase] << " gen=" << g
+                        << " mb=" << mb;
+      }
+    }
 
     int count = arrivals_for(wa.phase, wa.seed, N, G, g, R);
     if(i_alter && (g == alter_at)) {
@@ -335,6 +373,14 @@ static void worker_task(const void *args, size_t arglen, const void *userdata,
       bool poisoned = false;
       wait_handles[wg].wait_faultaware(poisoned);
       assert(poisoned == poisoned_gen(wa.phase, G, wg));
+    }
+  }
+
+  if(R == 0) {
+    const long mb = rss_mb();
+    if(mb >= 0) {
+      log_app.print() << "rss_mb: phase=" << phase_names[wa.phase] << " gen=" << G
+                      << " mb=" << mb;
     }
   }
 

--- a/tla/.gitignore
+++ b/tla/.gitignore
@@ -1,0 +1,9 @@
+# TLC working directories and downloaded tooling
+states/
+jtmp/
+tla2tools.jar
+tools/
+*.log
+*.out
+*.old
+*_TTrace_*.tla

--- a/tla/.gitignore
+++ b/tla/.gitignore
@@ -1,3 +1,18 @@
+# Copyright 2026 Stanford University, NVIDIA Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # TLC working directories and downloaded tooling
 states/
 jtmp/

--- a/tla/README.md
+++ b/tla/README.md
@@ -1,0 +1,13 @@
+# Formal Specifications for Realm Protocols
+
+TLA+ models, model-checking scenarios, and design documents for Realm's
+distributed protocols. One subdirectory per protocol family:
+
+| Directory | Protocols |
+|---|---|
+| [`barrier/`](barrier/README.md) | Scalable barrier arrival (`BarrierArrive.tla`) and notification (`BarrierNotify.tla`) — see `barrier/README.md` for the documents, the scenario suite, and the mutation battery |
+
+The working convention, earned the hard way in the barrier effort (details in
+`barrier/README.md`): a protocol rule counts as verified only when a scenario
+catches its removal, every property is validated in both directions, and the
+battery re-runs whenever a rule changes.

--- a/tla/README.md
+++ b/tla/README.md
@@ -1,3 +1,20 @@
+<!--
+Copyright 2026 Stanford University, NVIDIA Corporation
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Formal Specifications for Realm Protocols
 
 TLA+ models, model-checking scenarios, and design documents for Realm's

--- a/tla/barrier/ARRIVAL_PROTOCOL.md
+++ b/tla/barrier/ARRIVAL_PROTOCOL.md
@@ -863,6 +863,50 @@ are already specified and verified (§5 rules 5 and 6); only the payload is new.
 
 ---
 
+### 11.5 The gathering generation (added after scale testing; NOT modelled)
+
+Scale testing (the `P_STEP` probe, 8 ranks, depth-3 trees) found that §11.1's
+gathering is **structurally incomplete for any deviation discovered
+mid-generation**: traffic that flowed before the flush reached its senders is
+bare rule-1 counts, so the owner's evidence can never be complete, every
+generation of a *persistent* pattern shift declines identically, and the
+barrier stays eager forever (measured: 1 rebuild, 66 declines, permanent
+flushing over 128 generations).
+
+Four mechanisms close it, all in the implementation only — the plan lifecycle
+remains the unmodelled stage, and these are performance mechanisms whose
+failure modes are bandwidth, not correctness:
+
+1. **On a partial-evidence decline, the owner declares the next generation a
+   gathering generation** — fully eager from its first arrival, so its
+   evidence completes by construction and the rebuild at its trigger succeeds.
+   Cost: one eager generation per pattern shift.
+2. **The declaration rides the trigger notification** (`gather_gen` on
+   `BarrierNotifyMessage`), applied by the receiver in the same critical
+   section that wakes its waiters. It must: a separate flush message down a
+   multi-hop tree loses the wake→arrive race on nearly every generation
+   (measured: `gathered=7 of 8` declines, forever).
+3. **The identical-plan skip**: a rebuild that reproduces the current plan
+   (64-bit hash — storing the plan itself is the O(N²) blow-up D9 forbids) is
+   not installed, saving an invalidate+newplan broadcast that buys nothing.
+4. **Gathering backoff**: identical outcomes double a suppression window
+   (cap 32), so an *alternating* pattern — where no single plan fits — decays
+   to the pre-gathering behaviour instead of gathering forever. A rebuild that
+   produces a *different* plan resets the backoff, so genuine shifts still
+   converge immediately.
+
+Measured on the probes (8 ranks, radix 2, 128 generations): a persistent shift
+converges in two eager generations (flush episodes 526 → 42); the adversarial
+alternating pattern's rebuild storm is capped (65 → 19 and decaying); steady
+state is untouched except for one **startup transient**: the first plan's
+broadcast races the first trigger notification, a rank that wakes first is
+still legitimately an outsider, and its case-3 signal costs one tree-wide
+flush and one identical-skip (occasionally one decline + one gathering).
+Traced, bounded, self-quieting — and *cheaper* than before these mechanisms,
+which is when the same race silently installed a redundant plan with a fresh
+epoch. Expect `identical_plans_skipped >= 1` per barrier as the normal
+signature.
+
 ## 12. Atomicity
 
 **Neither this model nor `BarrierNotify.tla` represents concurrency.** Every

--- a/tla/barrier/ARRIVAL_PROTOCOL.md
+++ b/tla/barrier/ARRIVAL_PROTOCOL.md
@@ -958,3 +958,60 @@ path — see the notification document's rule 8.
 The previous implementation attempt did not fail on protocol logic; it failed on
 a deferred handler path that reached a null runtime. A correct protocol applied
 non-atomically is still broken, and neither model can catch it.
+
+## 13. Quota-gated forwarding
+
+**Motivation (measured, SCALE_TEST_PLAN.md §7):** with the local-quota gate,
+a relay forwards every child report that arrives after its own quota lands, so
+steady-state owner fan-in is ≈N−1 messages per generation under synchronized
+arrivals — at every plan radix — and that incast is what trips the transport's
+episodic multi-millisecond stalls at ≥128 ranks.
+
+**The rule (BarrierArrive rule 1, revised):** in planned, non-flushing mode, a
+relay reports only when its cumulative subtree total **reaches or exceeds**
+(`>=`, never `=` — MCGateJump) the plan's **subtree quota** — its own quota
+plus its descendants', computable at install time from the plan payload since
+the tree shape is a deterministic function of the (node, quota) vector. One
+report per edge per steady generation; the owner receives radix messages.
+
+**The valves (rule 6) — how a gated holder is guaranteed to be released when
+counts route around it.** Each is certified by a scenario that deadlocks
+without exactly it:
+
+| Valve | Where | Catches | Scenario |
+|---|---|---|---|
+| receipt: sender not an owner-child of the current plan | owner report handler | a retired relay's forward, a planless direct pin | MCGateAhead |
+| receipt: value exceeds sender's subtree quota | owner report handler | over-arrival straddling a gated relay | MCGateOver |
+| switch audit: re-judge accepted values against the NEW plan (value-exceeds and orphaned-sender tests) | owner, at plan install | values accepted legally under plan k−1 made deviant by plan k | MCGateMove, MCGateDemote |
+| install re-fan: re-announce every open flushed generation to the NEW children | every plan install (newplan and parked) | flush fans are kid-list snapshots; later-gained children never heard | MCGateDemote, MCGatePark |
+| stale-edge signal: the stale-edge forwarder also sends a count-free flush to the owner | any relay | mis-pinned counts hiding value-legal inside a legitimate chain | MCGatePark |
+
+The response to every symptom is the same: the owner flushes the generation
+down the current tree, and flush (per-generation, cleared only by trigger)
+un-gates every holder. All feed-forward; no timers.
+
+**Subsumption (mask-probed):** under these valves the case-3 flush signals —
+immediate and retroactive (rules 3 and 10.4) — are no longer load-bearing for
+*safety*: no scenario strands without them. They remain in the protocol
+because their flush traffic is the plan-learning evidence (§11). Their battery
+rows are documented-benign.
+
+**Model fidelity note (§8 addendum):** landing this rule required correcting
+`ParentOf` to read the sender's own epoch's plan — the implementation's
+`report_target_locked()` reads `cur_plan.parent`, an explicit field of the
+record the node installed, and can never re-aim to the owner because some
+*other* node's record went planless. The old global derivation manufactured a
+phantom strand (MCDouble under the gate) that the implementation cannot
+exhibit.
+
+**Implementation mapping:**
+- `should_report_locked`: the planned branch tests `subtree_known >= subtree_quota`
+  (computed at `apply_plan_locked` from the plan payload).
+- owner's `handle_remote_report`: the receipt valve (non-kid ∨ value-exceeds
+  ⇒ `enter_flush_locked` + fan), alongside the existing `is_direct` handling.
+- `build_new_plan_locked`/install: the switch audit over `child_acc`, and the
+  flush re-fan over open flushed generations.
+- stale-edge branch of `handle_remote_report`: add the count-free flush to the
+  owner beside the existing immediate forward.
+- Counters: `reports_gated`, `gate_releases` join the exercise-proof table;
+  the acceptance metric is owner `reports_received`/generation ≈ plan radix.

--- a/tla/barrier/ARRIVAL_PROTOCOL.md
+++ b/tla/barrier/ARRIVAL_PROTOCOL.md
@@ -1,0 +1,899 @@
+# Realm Scalable Barriers — Arrival Protocol
+
+**Status: design frozen, formally verified.** Revised after the pinned-edge
+rework (see rule 10) — the spec grew five rules, and one rule this document
+previously required (install-clears-flush) is now a **caught mutation**. This document is the normative
+description of the barrier *arrival* protocol. `BarrierArrive.tla` in this directory
+is the formal specification; where this prose and the spec disagree, **the spec
+wins** — it is the artifact that was model-checked.
+
+This document is written for an agent or engineer implementing the protocol in
+C++. It covers what the protocol is, why each rule exists, exactly where each
+rule lives in the TLA+ source, what was verified and how, and — importantly —
+the places where the model is deliberately not the implementation.
+
+---
+
+## 1. Scope
+
+**In scope:** how arrivals at many nodes are aggregated up to the barrier owner
+so the owner can decide a generation has triggered, including adaptation when
+the arrival pattern changes from one generation to the next, and
+`alter_arrival_count`, which changes how many arrivals the owner is waiting for.
+
+**Out of scope, deliberately not modelled:**
+
+| Excluded | Reason |
+|---|---|
+| Message duplication | The transport is reliable (user decision) |
+| Reduction barriers | Not in the first implementation (user decision) |
+| Node failure | No fault model in this design |
+| Subscription / trigger-notification tree | A separate protocol; needs its own spec |
+| Resource reclamation | `destroy_barrier` is the cleanup point (user decision) |
+
+The exclusions are recorded in the spec header at `BarrierArrive.tla:35-37`.
+
+Negative alterations and the terminal-negative case (`event.h:293-297`) are
+modelled only in so far as the delta is a constant in `AlterOps`; the scenario
+uses a positive delta. See §8.6.
+
+---
+
+## 2. The problem this solves
+
+A barrier generation triggers when the owner has accounted for every arrival.
+The naive approach — every node reports every arrival directly to the owner — is
+O(N) messages at one node. The scalable approach aggregates through a tree.
+
+The tree cannot be static, because Realm does not know in advance which nodes
+will arrive on a barrier or how many times. So the owner *learns* an arrival
+plan from observed traffic and pushes it out; nodes then aggregate along it.
+
+The hazard is **silence**. A node that is aggregating stays quiet until its
+subtree is complete. If the actual arrival pattern deviates from the plan — a
+node arrives that the plan did not expect, or a node arrives more times than
+predicted — then some node waits for a completion condition that will never be
+met, and the generation never triggers. The previous design (see
+`../../src/realm/SCALABLE_BARRIERS_IMPLEMENTATION_PLAN.md`) died on exactly this;
+TLC found a terminal deadlock in the model of it (`BarrierArrival.tla`).
+
+This protocol's entire job is to guarantee that **every arrival eventually
+reaches the owner, without timers, polling, or background sweeps.** Every action
+is caused by an arrival or by the receipt of a message — the protocol is
+feed-forward.
+
+---
+
+## 3. Per-node state
+
+From `BarrierArrive.tla:67-86`. Model variables are global functions over nodes; in
+the implementation each node holds its own slice.
+
+| Model variable | Per-node meaning | Suggested C++ home |
+|---|---|---|
+| `localTotal[n][g]` | arrivals issued *at this node* for generation `g` | per-generation counter |
+| `childAcc[n][c][g]` | highest cumulative value accepted from child `c` for `g` | small map keyed by child |
+| `reportedUp[n][g]` | cumulative value last sent to the parent for `g` | per-generation counter |
+| `flushing[n][g]` | eager-flush mode, **per generation** | per-generation flag |
+| `curPlan[n]` | this node's own plan record: `quota`, `inplan`, `kids` | plan struct |
+| `myEpoch[n]` | which plan index `curPlan` is | integer |
+| `invalEpoch[n]` | highest plan index invalidated here | integer |
+| `deferEpoch[n]` | a parked new plan, 0 = none | integer |
+
+| `myTs[n][g]` | timestamp this node's arrivals for `g` carry, 0 = none | per-generation field |
+
+Owner-only: `ownerAcc[g]` (accepted total per generation), `watermark` (highest
+contiguous triggered generation), `triggered[g]`, plus the alteration state
+`expected[g]` (the count currently being waited for), `appliedTs` (alterations
+applied) and `tsAcc[g]` (timestamped arrivals counted).
+
+Two derived quantities are used constantly (`BarrierArrive.tla:143-145`):
+
+```tla
+SubtreeKnown(n, g) == localTotal[n][g] + (sum over children of childAcc[n][c][g])
+Unreported(n, g)   == SubtreeKnown(n, g) - reportedUp[n][g]
+Holding(n, g)      == Unreported(n, g) > 0
+```
+
+`Holding` is the danger condition: this node knows about arrivals it has not
+passed on. Every liveness argument in the protocol is about making sure a
+holding node is always reachable by something that will make it speak.
+
+### Membership rule
+
+**Only nodes with a non-zero expected contribution are in a plan at all.** A node
+whose predicted arrival count is zero is not in the tree — it is not a leaf, not
+a relay, not anything. It is in eager-flush mode permanently, by virtue of
+`curPlan[n].inplan = FALSE`.
+
+This is a load-bearing simplification (it was a user design decision, and it
+removes a whole class of "waiting on a child that will never speak" states). The
+model encodes it as the `NoPlan == [quota |-> 0, inplan |-> FALSE, kids |-> {}]`
+record used in every scenario file, e.g. `MCSeven.tla:48`.
+
+---
+
+## 4. Messages
+
+`BarrierArrive.tla:114-124`.
+
+| Kind | Fields | Purpose |
+|---|---|---|
+| `report` | `from, to, gen, val` | cumulative subtree total, sent to parent |
+| `direct` | `from, to, gen, val` | same, but sent straight to the owner by a node outside the plan |
+| `flush` | `from, to, gen` | "enter eager-flush mode for this generation" |
+| `invalidate` | `from, to, epoch` | "the plan you hold is being retired" |
+| `newplan` | `from, to, epoch` | "install plan `epoch`" |
+| `alter` | `from, to, gen, delta, ts` | `alter_arrival_count` — persistent change to the expected count |
+| `tsdirect` | `from, to, gen, ts, val` | an arrival carrying a causal timestamp, sent straight to the owner; `val` is cumulative |
+
+`msgs` is a **set**, not a queue — TLC therefore explores every delivery
+reordering. Reports are **cumulative, not incremental**: `val` is the running
+subtree total, so a later report replaces an earlier one rather than adding to
+it. This is what makes duplicate and out-of-order delivery harmless.
+
+---
+
+## 5. The protocol rules
+
+Ten rules. Each one has a mutation in the battery that a validated check
+catches, so none of them is decorative. Rule 10 is a bundle of five, added
+after the pinned-edge rework; its history is instructive and is told inline.
+
+### Rule 1 — Steady state: report on match, otherwise stay silent
+
+`BarrierArrive.tla:216-230` (arrival path), `BarrierArrive.tla:246-251` (report path),
+predicate at `BarrierArrive.tla:163-166`.
+
+A node forwards its cumulative subtree total when its local arrival count equals
+the quota its plan predicts. Below quota it stays silent. This is the aggregation
+that makes the protocol scalable.
+
+> **There is NO child-wait, and an earlier version of this document was wrong to
+> say there was.** It claimed a relay must also wait for every predicted child,
+> called that a correctness requirement, and warned against removing it.
+>
+> It is an optimisation at best. Reports are cumulative and **replace**, so a
+> forward that omits an absent child is superseded the moment that child
+> reports; and `Trigger` demands exact equality with the expected count, so a
+> temporarily-low total simply does not fire.
+>
+> Seven scenarios agree, including `MCChain` and `MCDeepSwitch`, both built
+> specifically to contain the relay-below-relay structure the old claim named.
+> **No scenario in the suite had that structure when the claim was recorded** —
+> MCLarge and MCSeven are both owner → relay → leaf.
+>
+> Removing it also matters: the child-wait is the only reason a relay cares
+> *which* child reports to it, and therefore the only reason a re-parented
+> generation can strand. It is what forced flush mode to be sticky. See rule 5.
+
+### Rule 2 — Over-arrival at a predicted node triggers eager flush
+
+`BarrierArrive.tla:217-222`.
+
+If a node in the plan receives more arrivals than its quota, its plan is wrong
+and waiting is unsafe. It:
+
+1. sets `flushing[n][g] = TRUE`,
+2. reports its cumulative total upward immediately,
+3. fans a `flush` announcement out to its children.
+
+From then on, for that generation, every arrival reports immediately.
+
+### Rule 3 — Arrival at a node outside the plan reports directly to the owner
+
+`BarrierArrive.tla:212-216`, owner-side handling at `BarrierArrive.tla:254-255,262-264`.
+
+A node not in the plan has no parent and no completion condition to wait for, so
+it cannot aggregate. It sends a `direct` report to the owner. The owner, on
+receiving a `direct`, enters flush mode for that generation and fans a `flush`
+out through its children.
+
+### Rule 4 — Flush is per generation and idempotent
+
+`BarrierArrive.tla:284-295`.
+
+A node receiving `flush` for a generation it is already flushing just drops the
+message (this is what terminates the fan-out). Otherwise it sets the flag,
+re-fans to its children, and — critically — **immediately reports anything it is
+currently holding** for that generation.
+
+Flush mode is per generation. The next generation starts back in planned mode.
+
+### Rule 5 — Pattern change: invalidate the old tree, broadcast the new plan, defer on overlap
+
+`BarrierArrive.tla:304-330` (owner initiates), `:332-368` (invalidation),
+`:370-401` (new plan).
+
+When the owner triggers generation `g` and a new plan starts at `g+1`, it sends
+**both** broadcasts at once:
+
+- `invalidate` down the tree being retired, carrying the retiring epoch;
+- `newplan` down the *new* tree, carrying the new epoch.
+
+These race. The resolution is entirely local, with no global knowledge:
+
+> **A node that receives `newplan` while it is still an un-invalidated member of
+> the retiring plan PARKS it** (`deferEpoch`). When the `invalidate` arrives, it
+> does its invalidation work and *then* applies and forwards the parked plan.
+
+The condition is `curPlan[m.to].inplan /\ (invalEpoch[m.to] < myEpoch[m.to])` at
+`BarrierArrive.tla:375`. A node's own membership is the flag, and it is
+self-clearing — if the invalidation already passed, the node looks like it was
+never in the old plan and the new plan installs immediately.
+
+This is the piece that motivated the whole verification effort. **It is
+verified**: disabling the deferral is the first mutation in the battery and TLC
+reports `Invariant ReachableWhileHolding is violated` in ~46 seconds.
+
+### Rule 6 — On invalidation: forward first, flush *every* open generation, then switch
+
+`BarrierArrive.tla:338-366`.
+
+Order matters, and both halves are separately verified:
+
+- **Forward before forgetting.** The node re-sends `invalidate` to the children
+  in its *current* (old) list *before* replacing that list. Dropping the child
+  list first strands the entire subtree — a mutation TLC catches.
+- **Report held work for every open generation, not just the switch
+  generation** — `held == { g \in Gens : ~triggered[g] /\ Unreported(...) > 0 }`
+  (`BarrierArrive.tla:412`), unconditional on the flushing flag.
+- **The flushing flag itself is also set** for open generations with state
+  (`:452-456`) — but honesty requires recording that under the final protocol
+  this half is **no longer independently caught**: narrowing it to the switch
+  generation passes MCStrand2, MCStale and MCPark. The rule-10 machinery
+  subsumes it — held work goes out unconditionally at the invalidation, a
+  planless node is eager for everything, and any straddling-generation holder
+  under a live plan is unstuck by the owner's deviation fan, which conservation
+  guarantees will fire. Retained as defense-in-depth: over-flushing is always
+  safe, and the flag is what carries `saw_direct` onto held reports in the
+  implementation.
+- **A plan install NEVER clears flush** (`BarrierArrive.tla:454-456` sets it,
+  RecvNewPlan leaves it unchanged). An earlier revision of this document said
+  the opposite — that installing a plan returns open generations to planned
+  mode — and that rule is now a **caught mutation** (`MCStale`, deadlock): the
+  owner's deviation flush and the `newplan` race, and when the install wins the
+  flush is lost and the generation strands behind a quota the new plan cannot
+  meet.
+
+  A flushed generation stays eager **until it triggers**. That is naturally
+  bounded — the flag lives on the generation record and dies with it, and new
+  generations start planned under whatever plan the node holds — so nothing is
+  sticky across the barrier's future. The unbounded-stickiness scare that
+  motivated install-clears-flush was partly a modelling artifact: the model
+  pre-enumerates all generations, so flagging them all at an invalidation
+  looked like eager-forever when it never was.
+
+### Rule 7 — Cumulative totals only increase; non-increasing reports are stale
+
+`BarrierArrive.tla:242` (guard), `:269-280` (`DropStale`), `:258-261` (owner update).
+
+A report whose `val` does not exceed the stored `childAcc` for that child and
+generation is stale and is discarded. The owner's accumulator **replaces** the
+child's previous contribution rather than adding to it:
+
+```tla
+ownerAcc' = [ownerAcc EXCEPT ![m.gen] = @ - childAcc[Owner][m.from][m.gen] + m.val]
+```
+
+Accepting stale reports lets the owner's count go *down*, which is a mutation
+TLC catches. Implementations must not treat reports as increments.
+
+### Rule 8 — `alter_arrival_count`: timestamped arrivals bypass the tree
+
+`BarrierArrive.tla:403-441` (issue), `:443-457` (owner applies), `:459-471` (the gate),
+arrival path at `:198-202`.
+
+`alter_arrival_count` changes how many arrivals the owner is waiting for. Unlike
+every other deviation in this protocol that is a **counting** problem, not a
+routing one, and getting it wrong is a *safety* failure — `event.h:303-306` names
+the symptom as "a barrier that triggered too early."
+
+The ordering is already solved and does **not** need message ordering. A negative
+delta (an arrival) names the positive adjustment it depends on, and the owner
+holds it until that adjustment lands — `barrier_impl.h:144-146` plus the
+per-generation `pending` map at `:188-199`. The model encodes that buffer as a
+guard (`m.ts \in appliedTs`), which is why it needs no ordering assumption.
+
+What tree aggregation breaks is different: **a relay collapses its subtree into a
+single integer, which erases the timestamps.** Three rules follow.
+
+1. **An arrival carrying a timestamp bypasses the tree** and is reported to the
+   owner carrying that node's **cumulative** count of bypassed arrivals — the
+   same replace-if-higher shape as every other report in the protocol
+   (`:201`, `TsIssued` at `:107`). Alterations are rare relative to arrivals, so
+   the direct traffic is negligible, and no report ever has to carry a set of
+   timestamps, which is where the previous design's causal-DAG machinery came
+   from.
+
+   **Every accumulator in this protocol is cumulative, replace-if-higher, and
+   counts in one direction.** The owner's timestamped total is a sum of per-node
+   cumulative values (`TsTotal`, `:112`), exactly like `childAcc`. Do not
+   introduce an incrementing counter alongside them, and do not carry the legacy
+   path's count-down convention (`base_arrival_count + unguarded_delta == 0`)
+   into the scalable path.
+2. **The owner may not count a timestamped arrival until every alteration it
+   witnessed has been applied.** This is the existing `pending` map.
+3. **Issuing an alteration puts the node into eager flush** for every affected
+   open generation. This one is easy to miss: a node that bypasses the tree can
+   never satisfy its own plan quota via `localTotal`, so as a *relay* it would go
+   silent and strand its children. Removing it is a caught mutation (deadlock).
+
+The safety argument for why the owner cannot trigger on a stale count lives in
+the **API contract, not the protocol**: `event.h:290-292` requires the caller to
+still hold an unissued arrival from the pre-alteration count, and that reserved
+arrival is what holds the generation open until the alteration lands. The model
+encodes it as the guard at `:411`, and removing it is caught by `TriggerCorrect`.
+
+> **The current implementation does not match this contract and must be fixed.**
+> `event.h:271` says the delta is persistent across all future generations, and
+> that is what Legion expects. The code applies it to a single generation: the
+> delta lands in `Generation::unguarded_delta` (`barrier_impl.h:192`), the
+> trigger test is `base_arrival_count + unguarded_delta == 0`
+> (`barrier_impl.cc:847`), and `base_arrival_count` is never modified by an
+> alteration. Each generation gets a fresh `Generation`, so nothing carries
+> forward. There is no test anywhere in the repo that calls the API, which is why
+> this went unnoticed.
+
+### Rule 9 — A negative alteration is an arrival that also invalidates the plan
+
+Not modelled (see §8.6); recorded here as a design decision.
+
+A negative delta behaves as an **arrival** — it reduces the remaining count the
+same way — and additionally **invalidates the current arrival plan**, because
+lowering a node's expected contribution makes at least one quota in the plan
+unreachable, and a node waiting on an unreachable quota is exactly the silence
+failure this protocol exists to prevent.
+
+Two guards:
+
+- The barrier's base arrival count reaching **zero is an error**. A barrier with
+  no expected arrivals is meaningless, which is also what makes `0` a safe
+  "not yet known" sentinel for `base_arrival_count` (§3).
+- The terminal-negative case of `event.h:293-297` needs no arrival on the
+  returned handle, so it is the one branch whose safety argument does *not* rest
+  on a reserved arrival. It has no coverage — see §8.6.
+
+### Rule 10 — Plan changes race with everything: the pinned-edge rules
+
+Added after `MCDeepSwitch` (three plans over a relay chain) violated
+`NoOverCount` — a **safety** failure, the owner counting more arrivals than
+issued — in a spec whose battery was all-green. Five sub-rules; every one is a
+caught mutation, and four candidate fixes died to counterexamples on the way.
+The unifying observation: **a re-routed generation loses either a count (it
+arrives twice) or a signal (it arrives with nobody told), and both are fatal.**
+
+1. **Pinned report edges** (`TargetOf`/`Pin`, `BarrierArrive.tla:187-195`; pinned
+   at every touch, e.g. `:278,318,351,471`). A node's report target for
+   generation `g` is fixed at its first touch of `g`; later plan changes do
+   not re-aim it. Without this the owner double-counts: reports are cumulative
+   and can never be retracted, so a contribution folded into an old parent's
+   aggregate plus the same node's post-switch report arrive under two sender
+   keys and are summed. Caught by `MCDouble` — `NoOverCount`.
+   *Cycle-freedom assumption:* pinned edges from different plans must not form
+   a cycle. The implementation guarantees this by building every plan tree in
+   ascending node id with the owner at the root, so every report edge strictly
+   decreases.
+
+2. **The live guard** (`live == dk > m.epoch`, `:407`). A parked plan is
+   applied only if strictly newer than the invalidation delivering it —
+   otherwise it is being delivered by its own death notice: installing it
+   re-enters planned mode with the plan's only invalidation already consumed,
+   and forwarding it strands every descendant, who never see that invalidation
+   at all. A dead parked plan is DISCARDED: not installed, not forwarded.
+   Caught by `MCStrand2`.
+
+3. **The install guard** (`invalEpoch >= m.epoch` in RecvNewPlan's discard
+   condition, `:489`). Same principle at the second door: messages reorder, so
+   a `newplan` can arrive after both of its own broadcast's invalidations have
+   overtaken it, and a plan whose retirement this node has witnessed is dead
+   on arrival. One principle, two doors: **a plan with epoch `e` is
+   installable only if `e > myEpoch` and `e > invalEpoch`.** Caught by
+   `MCStrand2`.
+
+4. **A planless node becomes an outsider** (`:464-467`), and **case 3
+   delivers late**. A node invalidated with no live replacement clears its
+   plan record, so later run-ahead arrivals fire case 3 natively — and for
+   arrivals it already made, it sends a **count-free flush signal to the
+   owner** (`:432-436`): case 3 delivered retroactively. In `Arrive`, case 3
+   **outranks the flushing flag** — the count still follows the pinned edge;
+   only the signal goes to the owner, because a cumulative value sent off-pin
+   double-counts. All three are caught by `MCStale`.
+
+5. **Stale-edge forwarding** (`:302`). A report arriving from a node not in
+   the receiver's child list is forwarded at once rather than held behind the
+   receiver's quota — the pinned edge is the only route that contribution has.
+   Caught by `MCDouble`, `MCStrand` and `MCStrand2` (deadlock). *This rule
+   evaded five scenarios and looked deletable; it is load-bearing. Pinning is
+   what creates legitimate non-child reports, so a rule that was decorative in
+   the unpinned protocol became essential — the child-wait lesson, reversed.*
+
+The recurring failure shape, named for whoever extends this: **the count and
+the signal must never travel separately.** Four of the five bugs were a count
+arriving with its signal lost — folded into an aggregate, cleared by an
+install, suppressed by a branch priority. The implementation's `is_direct`
+flag (the signal riding the count's own message) is immune to this class by
+construction, which is why the C++ port of rule 10 was three edits, not five.
+
+---
+
+## 6. Safety properties
+
+`BarrierArrive.tla:487-527`. All six are checked as invariants in every scenario
+config.
+
+| Property | Line | Meaning |
+|---|---|---|
+| `TypeOK` | 493 | well-formedness; also bounds-checks counters |
+| `TriggerInOrder` | 499 | generations trigger in order, no gaps |
+| `TriggerCorrect` | 505 | a triggered generation has accounted for *exactly* every arrival |
+| `NoOverCount` | 507 | the owner never counts more than were issued |
+| `ReachableWhileHolding` | 519 | **the liveness-critical one** — see below |
+| `BoundedRetention` | 527 | at most one parked plan per node; retained state is bounded |
+| `ExpectedSane` | 513 | scenario sanity: the owner's expected count never exceeds what will be issued |
+
+`TriggerCorrect` is also the check that owns `alter_arrival_count`. `Total(g)`
+(`:99`) is ground truth — the pattern's base arrivals plus the deltas of every
+alteration actually issued — and is independent of what the owner currently
+believes `expected` to be. A trigger against a stale count violates it at once.
+
+### `ReachableWhileHolding` — read this before changing anything
+
+```tla
+ReachableWhileHolding ==
+    \A n \in Nodes, g \in Gens :
+        (~triggered[g] /\ Holding(n, g) /\ n # Owner) =>
+            \/ flushing[n][g]
+            \/ ~curPlan[n].inplan
+            \/ (n \in Reachable)
+```
+
+"No node may sit on unreported work with nothing that will ever collect it."
+This is a *safety* encoding of the liveness property that actually matters, and
+it is the check that catches every one of the seven mutations.
+
+Two subtleties, both of which were bugs in earlier versions of this check:
+
+1. **`KidsOf(n) == curPlan[n].kids`** (`BarrierArrive.tla:127`) — a node's children
+   come from its **own** plan record. An earlier version derived them from other
+   nodes' beliefs about who their parent was (`{m : plan[m].parent = n}`), which
+   let the check conclude a node was reachable when nobody would ever forward to
+   it. That single defect hid a real race through three attempts. The comment at
+   `BarrierArrive.tla:124-126` marks this.
+
+2. **`Reachable` is seeded from in-flight messages, not just the owner**
+   (`BarrierArrive.tla:137-139`). A parent that has forwarded an invalidation has
+   discharged its duty and may drop the child, so the child is briefly in no tree
+   while the message is on the wire. Crediting only messages addressed to the
+   *holder* is not enough either — an invalidation travelling toward an
+   **ancestor** will reach the whole subtree under it. Both narrower versions
+   fire on perfectly healthy states.
+
+### Why `Done` exists
+
+`BarrierArrive.tla:473`:
+
+```tla
+Done == (\A g \in Gens : triggered[g]) /\ UNCHANGED vars
+```
+
+A completed run stutters, so TLC's deadlock detection does not mistake
+"finished" for "stuck". Any remaining state with no successor is a genuine
+deadlock. **Deadlock checking must stay ON** in every config — it is doing real
+work here.
+
+> A `EventuallyTriggers` temporal property was tried and **abandoned**. It never
+> fired, even on a state space containing a genuinely stuck state. Every earlier
+> claim of "liveness caught it" was false. Deadlock detection plus
+> `ReachableWhileHolding` is what actually works. Do not reintroduce the temporal
+> property without validating it fires on a known-broken spec first.
+
+---
+
+## 7. What was verified
+
+### Scenarios
+
+| Module | Config | Nodes | Gens | Plans | Arrivals | Distinct states | Purpose |
+|---|---|---|---|---|---|---|---|
+All state counts below are on the **final spec** (post rule 10) unless marked.
+
+| Module | Config | Nodes | Gens | Plans | Distinct states | Purpose |
+|---|---|---|---|---|---|---|
+| `MCOver.tla` | `Over.cfg` | 5 | 2 | 1 | 10,591 | rule 2 in isolation (no outsider to mask it) |
+| `MCOverSwitch.tla` | `OverSwitch.cfg` | 3 | 2 | 2 | 14,582 | **over-arrival × plan switch** — closes the gap the unaffordable trio left |
+| `MCDeviate.tla` | `Deviate.cfg` | 5 | 2 | 1 | 814,685 | rule 3, outsider |
+| `MCDouble.tla` | `Double.cfg` | 4 | 2 | 2 | 41,154 | **the double-count, minimal** — re-parented node with a child of its own |
+| `MCStale.tla` | `Stale.cfg` | 4 | 2 | 2 | 7,826 | **run-ahead outsider + over-predicting quota** — found five bugs in candidate fixes |
+| `MCStrand.tla` | `Strand.cfg` | 4 | 2 | 2 | 3,936 | single-switch stranding (control: passes, one switch is not enough) |
+| `MCStrand2.tla` | `Strand2.cfg` | 4 | 3 | 3 | 20,034,804 | **two successive switches + run-ahead + relay chain** — the strand, minimal |
+| `MCChain.tla` | `Chain.cfg` | 5 | 2 | 1 | 435,848 | relay below a relay |
+| `MCAlter.tla` | `Alter.cfg` | 4 | 2 | 1 | 71,124 | `alter_arrival_count` — altering node is a *relay*, not a leaf |
+| `MCDeepSwitch.tla` | `DeepSwitch.cfg` | 5 | 4 | 3 | **unaffordable** | found the `NoOverCount` violation that forced rule 10; outgrew the machine after the fix |
+| `MCLarge.tla` | `Large.cfg` | 6 | 3 | 3 | **unaffordable** — >27M, growing | superseded by MCStrand2 + MCOverSwitch |
+| `MCLate.tla`, `MCSeven.tla`, `MCBig*.tla` | — | — | — | — | **unaffordable** | historical; retained as records |
+
+The suite philosophy changed with rule 10 and it matters: **the load-bearing
+scenarios are now the minimal ones.** `MCStale` — four nodes, ~8k states —
+found five distinct bugs in candidate fixes that 20M-state scenarios never
+reached, because it was built from a failing *trace*, not from topology
+intuition. When a big scenario fails, distil the trace into a minimal scenario
+first; iterate there; keep the big one only as breadth.
+
+**`MCDeepSwitch` and `MCChain` are the primary evidence now.** `MCSeven` was,
+until removing the child-wait roughly tripled its state space and put it out of
+reach (abandoned past 28M distinct states with the queue still growing). It is
+retained but no longer runnable on the current spec.
+
+That is a smaller loss than it sounds: `MCSeven` never actually contained a
+relay below a relay — like `MCLarge` it is owner → relay → leaf — so the two
+purpose-built scenarios cover structure it never had, at a few percent of the
+cost. Its topology is still documented in `MCSeven.tla:12-24`:
+
+```
+  plan 1 (gen 1)        plan 2 (gen 2)        plan 3 (gen 3)
+    0                     0                     0
+    |- 1  q1              |- 2  q1              |- 1  q1
+    |  |- 3  q2           |  |- 5  q1           |  |- 6  q1
+    |- 2  q1
+       |- 4  q1
+
+  g1  matches plan 1                       -> steady state
+  g2  DISAGREES with plan 2: node 2 over-arrives (case 2) and node 6
+      arrives while in no plan (case 3)
+  g3  matches plan 3, except node 3 runs ahead while still on plan 1,
+      where its quota of 2 keeps it silent - so reaching it needs an
+      invalidation across two pattern changes and two hops.
+```
+
+That was its baseline on the pre-correction spec: 9,793,928 distinct states,
+~15 minutes. It does not finish on the current one.
+
+**The state space is driven by total arrivals and tree depth, not by node count
+alone** — each `arrive()` is its own action, and each level of depth adds another
+layer of forwarding interleavings. The jump from `MCLarge` (6 nodes, 11 arrivals,
+1.56M states) to `MCSeven` (7 nodes, 12 arrivals, >28M and unfinished) is an
+order of magnitude for one extra node and one extra arrival. `MCBig3`, at 16
+arrivals, is far out of reach. If you want to scale past 6 nodes you need a state
+constraint or symmetry reduction, and both need care not to hide the very
+interleavings that matter.
+
+### Mutation battery
+
+The full battery on the **final spec** — every mutation paired with a scenario
+that can actually catch it, which took three rounds of re-pairing to get right
+(see the masking note below; two "NOT CAUGHT" verdicts were mis-pairings, found
+by asking what structure the mutation strands and building it).
+
+| Mutation | Scenario | Caught by |
+|---|---|---|
+| no deferral: install a new plan before being invalidated | **`MCPark`** | `ReachableWhileHolding` |
+| forget the child list *before* forwarding the invalidation | **`MCPark`** | `ReachableWhileHolding` |
+| accept stale reports (running total may go down) | `MCDouble` | `TriggerCorrect` |
+| case 3 sends its count but no flush signal | `MCStale` | deadlock |
+| no eager flush on over-arrival | `MCOver` | deadlock |
+| no pinning: reports follow the current plan | `MCDouble` | `NoOverCount` |
+| no live guard (rule 10.2) | `MCStrand2` | `ReachableWhileHolding` |
+| no install guard (rule 10.3) | `MCStrand2` | `ReachableWhileHolding` |
+| no planless-outsider (rule 10.4) | `MCStale` | deadlock |
+| no retroactive case 3 (rule 10.4) | `MCStale` | deadlock |
+| case 3 loses priority to the flushing flag (rule 10.4) | `MCStale` | deadlock |
+| a plan install clears flush (rule 5) | `MCStale` | deadlock |
+| no stale-edge forwarding (rule 10.5) | `MCDouble`, `MCStrand`, `MCStrand2` | deadlock |
+| flush only the switch generation at invalidate | — | **not caught — subsumed, see rule 6** |
+
+Why `MCPark` exists: the deferral's real job is **routing the invalidation down
+the old tree** — a node that installs early forwards it down its *new* kid
+list, so old-only descendants never receive it. Only a descendant holding
+*below quota* exposes that; every earlier scenario's descendants met their
+quotas, which is why MCStrand2 could not catch it.
+
+Alteration rules (rules 8/9), re-verified on the final spec — all caught on
+`MCAlter`: ts-arrival counted without its alteration (`TriggerCorrect`),
+ts-arrivals aggregating through the tree (`TriggerCorrect`), no eager flush on
+alter (deadlock), no reserved-arrival guard (`TriggerCorrect`).
+
+> **Two lessons from getting this wrong.**
+>
+> **Masking.** "No eager flush on over-arrival" comes back NOT CAUGHT on any
+> scenario containing an outsider or a run-ahead — their case-3 signals make
+> the owner flush anyway, covering for the missing one (`MCSeven`, `MCChain`,
+> and later `MCOverSwitch` all mask it). It is caught on `MCOver`, which has no
+> outsider for exactly this reason. **A battery reporting "all caught" proves
+> nothing unless each rule has a scenario that could have caught it** — and a
+> NOT CAUGHT is a mis-pairing until the structure the mutation strands has been
+> deliberately built and still fails to catch it.
+>
+> **Structure.** The child-wait was recorded as verified when no scenario in the
+> suite contained the structure it supposedly protected. Adding `MCChain` and
+> `MCDeepSwitch` showed it was never a rule at all.
+
+And on `MCAlter`, all caught:
+
+| Mutation | Caught by |
+|---|---|
+| owner counts a timestamped arrival without applying its alteration | `TriggerCorrect` |
+| timestamped arrivals aggregate through the tree (timestamp erased) | `TriggerCorrect` |
+| altering node does not enter eager flush (stops relaying) | deadlock |
+| no reserved-arrival contract guard | `TriggerCorrect` |
+
+The alteration extension was **conservative** when it landed: with
+`AlterOps = {}` all four then-existing scenarios reproduced their exact prior
+counts (`MCSeven` 9,793,928, `MCLarge` 338,390, `MCDeviate` 73,168, `MCOver`
+3,784). Those figures predate the rule-1 correction, which changed every count —
+see the table above for current values.
+
+**Methodology note for whoever maintains this:** a scenario earns trust only when
+it kills every mutation, and a property earns trust only when validated in *both*
+directions — silent on a known-healthy spec, firing on a known-broken one. Six
+separate verification-apparatus bugs were found in this effort, several of which
+produced false "verified" results. An uncaught mutation is a scenario defect
+until proven otherwise, not a protocol result.
+
+---
+
+## 8. Fidelity notes — where the model is not the implementation
+
+Read this section carefully. These are the gaps between `BarrierArrive.tla` and a
+real C++ implementation, and each one is an implementation obligation that the
+model does not force on you.
+
+### 8.1 Report addressing is a global lookup in the model
+
+`ParentOf(n)` at `BarrierArrive.tla:153-155` finds the parent by searching all nodes
+for one that lists `n` as a child, falling back to `Owner`. That is a modelling
+convenience — a real node stores its parent locally in its plan record.
+
+Two consequences:
+
+- The fallback-to-`Owner` branch corresponds to "I am in no plan, so I report
+  direct to the owner" (rule 3). Implementations get this from the plan record.
+- During a switch, two nodes can transiently both list `n` as a child (an old
+  parent that has not switched and a new parent that has). The model's `CHOOSE`
+  picks one arbitrarily. A real implementation sends to whatever its own plan
+  record says.
+
+### 8.2 A receiver must accept reports from nodes it does not list as children
+
+The model handles this — `childAcc[m.to][m.from][m.gen]` is defined over *all*
+nodes, so `RecvReport` accepts from anyone. **The implementation must do the same
+explicitly.** A node whose parent has already switched plans and dropped it will
+still send to that old parent; if the old parent rejects reports from unknown
+children, the count is lost. This is easy to get wrong because it looks like a
+defensive check worth adding.
+
+### 8.3 `ReportWith` at `BarrierArrive.tla:147-149` is dead code
+
+Defined but never referenced — superseded by `Send` at `:157-159`. It was left in
+place so the verified artifact stays byte-identical to what was checked. Ignore
+it; do not implement it.
+
+### 8.4 A set-of-messages model deduplicates silently
+
+Not a live issue — recorded because it cost a spurious deadlock trace and the
+shape recurs. `msgs` is a **set**, so any message with no varying field collapses
+with an identical one. An earlier draft had timestamped arrivals reported
+individually, and two arrivals from the same node for the same generation merged
+into one element; the owner undercounted and TLC reported a deadlock that looked
+like a protocol defect.
+
+Making those reports cumulative fixed it as a side effect, because cumulative
+values differ. **If you add a message kind to either spec, check it carries
+something that varies per instance.**
+
+### 8.5 The model constrains the application contract, and that can hide a rule
+
+`Alter` is guarded by `unissued[a.node][a.gen] > 0` — the reserved-arrival
+requirement. An earlier version *also* forbade a node from arriving while it held
+an unissued alteration. That is stronger than the API, which permits arriving on
+the pre-alteration handle, and it silently **subsumed** the reserved-arrival
+guard, so removing that guard came back NOT CAUGHT.
+
+Generalised: an over-constrained model does not fail loudly, it makes a real rule
+look unnecessary. If a mutation you expect to be caught is not, suspect the
+scenario before concluding the rule is redundant.
+
+### 8.6 Negative alterations are not exercised
+
+`AlterOps` carries an arbitrary integer delta, but the scenario uses `+1`. The
+terminal-negative case of `event.h:293-297` — a negative alteration driving the
+remaining count to exactly zero, which needs no arrival on the returned handle —
+has **no coverage**. It is the one branch of the contract with a different safety
+argument, so it deserves its own scenario before that path is implemented.
+
+### 8.7 The plan is a given, not a computed thing — see §11
+
+The model takes `Plans` and `PlanStart` as constants. **How the owner constructs a
+new plan from observed arrivals is not modelled and not verified.** The design
+intent (from the earlier discussion) is: during eager-flush mode every report
+carries where the arrival occurred, the owner aggregates those into a new plan,
+distributes it, and then forgets the aggregation structure — it must not persist,
+or O(N) barriers with the same pattern cost O(N²) memory.
+
+**§11 specifies that construction.** What the model verifies is the other half:
+whatever plan the owner produces, the switch to it is safe. Construction itself
+needs no model — it is a local computation at the owner — but it does need the
+wire formats and the memory bound in §11.
+
+### 8.8 Retained state and cleanup
+
+`BoundedRetention` only checks the parked-plan slot. The broader constraint,
+agreed with the user: a node may forget retained per-generation state once every
+possible impacted generation has triggered, and `destroy_barrier` is an
+acceptable place to require full cleanup. Unbounded lifetime is not acceptable.
+
+---
+
+## 9. Reproducing the results
+
+TLA+ tools are at `tools/tla2tools.jar` (TLA+ 2.19, gitignored). Java is not on
+the default PATH on this machine:
+
+```sh
+cd tla/barrier
+java -Xmx6g -XX:+UseParallelGC \
+    -Djava.io.tmpdir=jtmp -cp tools/tla2tools.jar tlc2.TLC \
+    -workers 8 -config DeepSwitch.cfg MCDeepSwitch.tla
+```
+
+Expect `Model checking completed. No error has been found.` and 311,772 distinct
+states. Swap for any other pair from the table in §7 — but **not**
+`Seven.cfg`/`MCSeven.tla`, which no longer completes on this spec.
+
+To classify a run's verdict, grep for the verdict line rather than tailing
+output — TLC prints violations as `Error: Invariant <name> is violated.` A
+harness that only looks for the bare string `Invariant ... is violated` will
+miss the `Error:` prefix, which is exactly the reporting bug that made the first
+battery report an unhelpful fallback verdict for all seven mutations.
+
+### Other files in this directory
+
+- `BarrierArrival.tla` + `MCPlanned.tla` + `DeadlockNoFlush.cfg` — the model of
+  the **old, abandoned** protocol, in which TLC proved a terminal deadlock.
+  Kept as the record of why the redesign happened. Its liveness-property
+  results were later shown to be unreliable (the property never fired); the
+  deadlock proof is the citable result.
+- `MCSeven.tla`, `MCLarge.tla`, `MCLate.tla` — early scenarios that outgrew
+  practical checking as the spec gained rules; retained as records, superseded
+  by the minimal suite (see README.md).
+
+---
+
+## 10. Implementation checklist
+
+Derived from the rules above; each maps to a verified property.
+
+- [ ] Reports carry **cumulative** subtree totals; receivers replace, never add.
+- [ ] Reject reports that do not strictly increase the stored per-child value.
+- [ ] Accept reports from nodes not in the current child list (§8.2).
+- [ ] A relay forwards when local count == quota. **No child-wait** — do not add
+      one (rule 1).
+- [ ] A plan install **never clears flush**; a flushed generation stays eager
+      until it triggers (rule 5 — a caught mutation, do not "restore" clearing).
+- [ ] Nodes with zero predicted arrivals are not in the tree and flush always.
+- [ ] Over-arrival ⇒ set flush, report immediately, fan flush to children.
+- [ ] Outsider arrival ⇒ `direct` to owner; owner flushes and fans out.
+- [ ] Flush is per generation, idempotent, and reports held work on entry.
+- [ ] On `newplan` while an un-invalidated member of the old plan ⇒ **park it**.
+- [ ] On `invalidate`: forward to old children **first**, then flush **every**
+      open generation with state, then apply any parked plan — **only if the
+      parked plan's epoch exceeds the invalidation's** (rule 10.2); a dead
+      parked plan is discarded, never installed or forwarded.
+- [ ] A `newplan` is dead on arrival if its retirement was already witnessed:
+      install only when `epoch > myEpoch` **and** `epoch > invalEpoch`
+      (rule 10.3).
+- [ ] A node's report target for a generation is **pinned at first touch** and
+      never re-aimed by a later plan (rule 10.1).
+- [ ] A report from a sender not in the current child list is **forwarded at
+      once**, never held behind the receiver's quota (rule 10.5).
+- [ ] A node left planless becomes an **outsider**; its post-invalidation
+      arrivals fire case 3, and its pre-invalidation arrivals are covered by a
+      count-free flush signal to the owner (rule 10.4). The **count follows the
+      pinned edge; only the signal goes to the owner** — a cumulative value
+      sent off-pin double-counts.
+- [ ] Plan trees are built in ascending node id, owner at the root, so pinned
+      report edges can never form a cycle (rule 10.1's assumption).
+- [ ] No timers, no polling, no background sweeps — every action is caused by an
+      arrival or a message receipt.
+- [ ] Per-generation state is reclaimable; `destroy_barrier` frees the rest.
+- [ ] An arrival carrying a causal timestamp **bypasses the tree** and reports to
+      the owner on its own.
+- [ ] The owner does not count a timestamped arrival until every alteration it
+      witnessed has been applied (the existing `pending` map).
+- [ ] Issuing an alteration puts the node into **eager flush** for every affected
+      open generation — otherwise it stops relaying for its children.
+
+- [ ] A negative alteration behaves as an arrival **and** invalidates the plan;
+      a base arrival count of zero is an error.
+- [ ] Every spec action is applied atomically with respect to barrier state (§12).
+
+If you change any of these, re-run the mutation battery. A rule with no mutation
+covering it is a rule nobody has actually verified.
+
+---
+
+## 11. The plan lifecycle
+
+The model treats plans as constants: reports carry a bare count
+(`BarrierArrive.tla:140,150,205`) and `newplan` carries only an epoch, with content
+read from `Plans[epoch]`. So the spec verifies **plan switching given that plans
+arrive**, and specifies neither what a plan message contains nor how one is
+built. This section fills that gap. None of it is model-checked; all of it is
+constrained by what the model *does* verify — that any plan is safe to adopt.
+
+### 11.1 Gathering
+
+An **eager-flush report carries per-node arrival counts**, not just a total: the
+set of nodes on which arrivals occurred and how many occurred on each. A single
+deviating arrival is one `(node, count)` pair; a node that had buffered arrivals
+before entering flush mode reports all of them.
+
+Relays merge these maps on the way up exactly as they merge counts today, with
+the same cumulative-replace semantics — a relay re-sends its whole subtree map,
+so a later report supersedes an earlier one and reordering stays harmless.
+
+Cost note: an eager-flush report is O(subtree) rather than O(1) and is re-sent on
+each child update. That is the deviation path, not steady state, but the node set
+should use the multicast codec's encodings rather than a naive list.
+
+### 11.2 Construction
+
+The owner accumulates the merged maps into one structure: node → arrival count.
+From that it has both the participant set and the expected count per node, which
+is exactly a plan — a tree shape over that node set, plus each node's quota.
+
+Only nodes with a non-zero count appear. That is the membership rule from §3, and
+it is what stops a relay ever waiting on a child that will never speak.
+
+### 11.3 Forgetting — the memory bound
+
+**The aggregation structure is transient.** It exists from the start of gathering
+until the new plan has been broadcast, and is then deleted. It must not persist:
+O(N) barriers each retaining an O(N) participant map is the O(N²) blow-up this
+design exists to avoid.
+
+What persists is only what each node holds of its own plan record — quota,
+in-plan flag, child list — which is O(fanout) per node.
+
+### 11.4 Distribution
+
+A `newplan` message must carry the recipient's own plan record, not just an
+epoch: its quota and its child list. Epoch numbering, deferral and invalidation
+are already specified and verified (§5 rules 5 and 6); only the payload is new.
+
+---
+
+## 12. Atomicity
+
+**Neither this model nor `BarrierNotify.tla` represents concurrency.** Every
+action in both is atomic. The implementation is not: multiple application tasks
+may invoke barrier APIs in parallel on the same node, and active messages from
+remote nodes are delivered asynchronously on handler threads at the same time.
+
+> **Every action in the specification must be applied atomically with respect to
+> that barrier's state.**
+
+"Action" means one whole numbered ACTION in the module — its guard evaluation and
+every primed-variable update together. Splitting one action across two critical
+sections is a defect even when each half is individually locked, because the
+model never exposes the intermediate state and so no invariant constrains it.
+
+Where this bites hardest — each of these reads several variables and writes
+several more:
+
+| Action | Reads and writes that must not tear |
+|---|---|
+| `Arrive` (`:191`) | `unissued`, `localTotal`, `flushing`, quota and child check, then the send |
+| `RecvReport` (`:240`) | staleness test, `childAcc`, recomputed subtree total, forward decision, `reportedUp` |
+| `RecvInvalidate` (`:332`) | child list read **before** it is replaced, every open generation flushed, parked plan applied |
+| `Trigger` (`:304`) | count comparison and the plan switch that follows it |
+| `Alter` (`:403`) | reserved-arrival guard, `unissued`, `myTs`, flush state, sends |
+
+One constraint pulls the other way and must be honoured: **`has_triggered` stays
+lock-free.** It may do a single atomic load of the watermark and nothing else. In
+particular the consultation signal for departure hysteresis must not be on that
+path — see the notification document's rule 8.
+
+The previous implementation attempt did not fail on protocol logic; it failed on
+a deferred handler path that reached a null runtime. A correct protocol applied
+non-atomically is still broken, and neither model can catch it.

--- a/tla/barrier/ARRIVAL_PROTOCOL.md
+++ b/tla/barrier/ARRIVAL_PROTOCOL.md
@@ -1,3 +1,20 @@
+<!--
+Copyright 2026 Stanford University, NVIDIA Corporation
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Realm Scalable Barriers — Arrival Protocol
 
 **Status: design frozen, formally verified.** Revised after the pinned-edge

--- a/tla/barrier/Alter.cfg
+++ b/tla/barrier/Alter.cfg
@@ -1,0 +1,21 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Nodes     <- MCNodes
+    Owner     <- MCOwner
+    MaxGen    <- MCMaxGen
+    Pattern   <- MCPattern
+    NumPlans  <- MCNumPlans
+    Plans     <- MCPlans
+    PlanStart <- MCPlanStart
+    BaseCount <- MCBaseCount
+    AlterOps  <- MCAlterOps
+
+INVARIANTS
+    TypeOK
+    TriggerInOrder
+    TriggerCorrect
+    NoOverCount
+    ReachableWhileHolding
+    BoundedRetention
+    ExpectedSane

--- a/tla/barrier/Alter.cfg
+++ b/tla/barrier/Alter.cfg
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 SPECIFICATION Spec
 
 CONSTANTS

--- a/tla/barrier/BarrierArrival.tla
+++ b/tla/barrier/BarrierArrival.tla
@@ -1,0 +1,655 @@
+-------------------------- MODULE BarrierArrival --------------------------
+(***************************************************************************)
+(* TLA+ model of the ARRIVAL half of the Realm scalable-barrier protocol    *)
+(* described in SCALABLE_BARRIERS_IMPLEMENTATION_PLAN.md.                   *)
+(*                                                                         *)
+(* Modelled: sections 10 (deterministic radix overlay), 11 (dynamic         *)
+(* arrival protocol: local accumulation, DIRTY propagation, COLLECT         *)
+(* rounds returning cumulative values with revisions), 12 (learned fast     *)
+(* path: per-source quota, per-relay expected child subtotals, silent       *)
+(* underfull children), 13 (mismatch detection and pull-based recovery),    *)
+(* 16.1 (freeze-on-first-use: a generation's mode is fixed when it starts), *)
+(* plus the EAGER FLUSH extension.                                          *)
+(*                                                                         *)
+(* Deliberately NOT modelled: the adjustment ledger / Lamport stamps /      *)
+(* causal DAG (section 15), the subscription and trigger-notification tree  *)
+(* (section 14), multicast encoding (section 7), plan learning/commit       *)
+(* traffic (the learned plan is supplied as a constant, which is exactly    *)
+(* the plan generation 0 would have learned), node failure (the plan        *)
+(* assumes reliable nodes and reliable transport).                          *)
+(*                                                                         *)
+(* See README.md for results, constants and the counterexample traces.      *)
+(***************************************************************************)
+EXTENDS Integers, FiniteSets
+
+CONSTANTS
+    N,              (* number of nodes                                      *)
+    R,              (* radix of the routing overlay                         *)
+    RootId,         (* node id of the logical root                          *)
+    G,              (* number of generations                                *)
+    Arr,            (* [Gens -> [Nodes -> Nat]] arrivals the app will issue  *)
+    Expected,       (* [Gens -> Nat] persistent expected count               *)
+    PlannedGens,    (* SUBSET Gens: generations frozen onto the fast path    *)
+    Quota,          (* [Nodes -> Nat] predicted local arrival count          *)
+    PlannedKids,    (* [Nodes -> SUBSET Nodes] predicted children            *)
+    PTotal,         (* [Nodes -> Nat] predicted subtree total                *)
+    EagerFlush,     (* BOOLEAN: enable the eager-flush extension             *)
+    MaxCopies,      (* per-message cap in the network bag (>= 1)             *)
+    MaxDups,        (* transport duplication budget                          *)
+    MaxRev          (* revision ceiling (a saturation detector, not a rule)  *)
+
+----------------------------------------------------------------------------
+(*                          Small helpers                                  *)
+----------------------------------------------------------------------------
+Min2(a, b) == IF a < b THEN a ELSE b
+
+(* Sum of f[x] over x in S.  S is always a small finite set here. *)
+SumF(S, f) ==
+    LET RECURSIVE H(_)
+        H(T) == IF T = {} THEN 0
+                ELSE LET x == CHOOSE y \in T : TRUE
+                     IN f[x] + H(T \ {x})
+    IN H(S)
+
+----------------------------------------------------------------------------
+(*             Section 10: deterministic owner-relative radix tree          *)
+(*                                                                         *)
+(* All protocol logic below is written in RELATIVE index space, where       *)
+(* index 0 is the logical root.  NodeIdOf / RelOf are the plan's mapping    *)
+(* back to absolute node ids; they are only exercised by an ASSUME.         *)
+----------------------------------------------------------------------------
+Nodes == 0 .. N - 1
+Gens  == 0 .. G - 1
+
+NodeIdOf(i) == (i + RootId) % N
+RelOf(x)    == (x - RootId + N) % N
+
+Parent(i) == (i - 1) \div R
+Kids(i)   == { i * R + k : k \in 1 .. R } \cap Nodes
+
+RECURSIVE SubtreeOf(_)
+SubtreeOf(n) == {n} \cup UNION { SubtreeOf(c) : c \in Kids(n) }
+
+(* A node participates in the learned plan iff it is the root or its
+   parent predicted it.  Nodes with no plan are dynamic (section 12/13). *)
+InPlan(n)      == (n = 0) \/ (n \in PlannedKids[Parent(n)])
+HasPlan(g, n)  == (g \in PlannedGens) /\ InPlan(n)
+
+ASSUME N \in Nat /\ N >= 2
+ASSUME R \in Nat /\ R >= 1
+ASSUME G \in Nat /\ G >= 1
+ASSUME RootId \in 0 .. N - 1
+ASSUME MaxCopies >= 1 /\ MaxDups >= 0 /\ MaxRev >= 1
+ASSUME EagerFlush \in BOOLEAN
+ASSUME PlannedGens \subseteq Gens
+(* the relative/absolute mapping is a bijection *)
+ASSUME \A i \in Nodes : RelOf(NodeIdOf(i)) = i
+(* the overlay is a tree with bounded degree, rooted at relative index 0 *)
+ASSUME \A i \in Nodes \ {0} : Parent(i) \in Nodes /\ i \in Kids(Parent(i))
+ASSUME \A i \in Nodes : Cardinality(Kids(i)) <= R
+(* the learned plan is a subtree of the overlay and its subtree totals add up *)
+ASSUME \A n \in Nodes : PlannedKids[n] \subseteq Kids(n)
+ASSUME \A n \in Nodes : PTotal[n] = Quota[n] + SumF(PlannedKids[n], PTotal)
+(* the application supplies exactly the expected count in every generation *)
+ASSUME \A g \in Gens : SumF(Nodes, Arr[g]) = Expected[g]
+
+----------------------------------------------------------------------------
+(*                            Messages                                     *)
+(*                                                                         *)
+(* Section 17.1.  All five message kinds share one record shape so that     *)
+(* the network bag has a uniform element type.                             *)
+(*   REP     child -> parent : cumulative value + revision (+ planned flag) *)
+(*   MM      child -> parent : plan mismatch signal (section 13.1)          *)
+(*   DIRTY   child -> parent : clean-to-dirty edge (section 11.1/11.2)      *)
+(*   COLLECT parent -> child : collection request (section 11.3 / 13.3)     *)
+(*   FLUSH   parent -> child : eager-flush mode propagation (extension)     *)
+----------------------------------------------------------------------------
+Mk(k, g, s, d, rv, v, p) ==
+    [kind |-> k, gen |-> g, src |-> s, dst |-> d, rev |-> rv, val |-> v, pc |-> p]
+
+Rep(g, s, rv, v, p) == Mk("REP",     g, s, Parent(s), rv, v, p)
+MMsg(g, s)          == Mk("MM",      g, s, Parent(s),  0, 0, FALSE)
+Dty(g, s)           == Mk("DIRTY",   g, s, Parent(s),  0, 0, FALSE)
+Col(g, s, d)        == Mk("COLLECT", g, s, d,          0, 0, FALSE)
+Flu(g, s, d)        == Mk("FLUSH",   g, s, d,          0, 0, FALSE)
+
+EmptyBag == [x \in {} |-> 0]
+Cnt(B, m)     == IF m \in DOMAIN B THEN B[m] ELSE 0
+AddSet(B, S)  == [ m \in (DOMAIN B) \cup S |->
+                     Min2(MaxCopies, Cnt(B, m) + (IF m \in S THEN 1 ELSE 0)) ]
+Del(B, m)     == IF Cnt(B, m) <= 1
+                 THEN [ x \in (DOMAIN B) \ {m} |-> B[x] ]
+                 ELSE [ B EXCEPT ![m] = @ - 1 ]
+
+----------------------------------------------------------------------------
+(*                            State                                        *)
+----------------------------------------------------------------------------
+VARIABLES
+    pending,         (* [g][n] arrivals the application has not issued yet   *)
+    local,           (* [g][n] locally accumulated arrivals (section 11.1)   *)
+    mode,            (* [g][n] in {"DYN","PLAN","REC","FLUSH"}               *)
+    acc,             (* [g][n][c] highest accepted [rev,val] from child c    *)
+    sentRev,         (* [g][n] revision of the last report sent upward       *)
+    sentVal,         (* [g][n] cumulative value of the last report sent up   *)
+    dirtySent,       (* [g][n] a DIRTY is outstanding for this dirty episode *)
+    dirtyKids,       (* [g][n] children known dirty and not yet collected    *)
+    awaiting,        (* [g][n] children this node's collect wave waits for   *)
+    owedReply,       (* [g][n] this node owes its parent a collect reply     *)
+    mmSeen,          (* [g][n] this node has already forwarded a mismatch    *)
+    collectPending,  (* [g] root has an unserviced dirty/mismatch signal     *)
+    triggered,       (* SUBSET Gens                                          *)
+    trigCount,       (* [g] number of times g triggered (must stay <= 1)     *)
+    trigTotal,       (* [g] root total observed at trigger time, -1 if none  *)
+    rootMsgs,        (* [g] arrival-protocol messages SENT to the root, i.e.
+                        the root's protocol fan-in (saturating at R+1; a
+                        transport duplicate is not a protocol message)       *)
+    fatal,           (* equal revision with conflicting content was seen     *)
+    msgs,            (* network bag: message -> number of copies in flight   *)
+    dups             (* transport duplications used so far                   *)
+
+vars == << pending, local, mode, acc, sentRev, sentVal, dirtySent, dirtyKids,
+           awaiting, owedReply, mmSeen, collectPending, triggered, trigCount,
+           trigTotal, rootMsgs, fatal, msgs, dups >>
+
+NoRep == [rev |-> -1, val |-> 0]
+
+(* cumulative subtree value currently held by n for generation g *)
+Subtot(g, n) ==
+    local[g][n] + SumF(Kids(n), [c \in Kids(n) |-> acc[g][n][c].val])
+
+(* arrivals the application has actually issued inside n's subtree so far *)
+IssuedIn(g, n) ==
+    SumF(SubtreeOf(n), [x \in SubtreeOf(n) |-> Arr[g][x] - pending[g][x]])
+
+TypeOK ==
+    /\ pending  \in [Gens -> [Nodes -> Nat]]
+    /\ local    \in [Gens -> [Nodes -> Nat]]
+    /\ mode     \in [Gens -> [Nodes -> {"DYN", "PLAN", "REC", "FLUSH"}]]
+    /\ \A g \in Gens, n \in Nodes :
+          /\ DOMAIN acc[g][n] = Kids(n)
+          /\ \A c \in Kids(n) : acc[g][n][c].rev \in (-1) .. MaxRev
+                                /\ acc[g][n][c].val \in Nat
+    /\ sentRev  \in [Gens -> [Nodes -> (-1) .. MaxRev]]
+    /\ sentVal  \in [Gens -> [Nodes -> Nat]]
+    /\ dirtySent \in [Gens -> [Nodes -> BOOLEAN]]
+    /\ \A g \in Gens, n \in Nodes : dirtyKids[g][n] \subseteq Kids(n)
+                                    /\ awaiting[g][n] \subseteq Kids(n)
+    /\ owedReply \in [Gens -> [Nodes -> BOOLEAN]]
+    /\ mmSeen    \in [Gens -> [Nodes -> BOOLEAN]]
+    /\ collectPending \in [Gens -> BOOLEAN]
+    /\ triggered \subseteq Gens
+    /\ trigCount \in [Gens -> Nat]
+    /\ fatal \in BOOLEAN
+    /\ dups \in 0 .. MaxDups
+    /\ \A m \in DOMAIN msgs :
+          /\ m.kind \in {"REP", "MM", "DIRTY", "COLLECT", "FLUSH"}
+          /\ m.gen \in Gens /\ m.src \in Nodes /\ m.dst \in Nodes
+          /\ msgs[m] \in 1 .. MaxCopies
+
+Init ==
+    /\ pending  = [g \in Gens |-> [n \in Nodes |-> Arr[g][n]]]
+    /\ local    = [g \in Gens |-> [n \in Nodes |-> 0]]
+    /\ mode     = [g \in Gens |-> [n \in Nodes |->
+                      IF HasPlan(g, n) THEN "PLAN" ELSE "DYN"]]
+    /\ acc      = [g \in Gens |-> [n \in Nodes |-> [c \in Kids(n) |-> NoRep]]]
+    /\ sentRev  = [g \in Gens |-> [n \in Nodes |-> -1]]
+    /\ sentVal  = [g \in Gens |-> [n \in Nodes |-> 0]]
+    /\ dirtySent = [g \in Gens |-> [n \in Nodes |-> FALSE]]
+    /\ dirtyKids = [g \in Gens |-> [n \in Nodes |-> {}]]
+    /\ awaiting  = [g \in Gens |-> [n \in Nodes |-> {}]]
+    /\ owedReply = [g \in Gens |-> [n \in Nodes |-> FALSE]]
+    /\ mmSeen    = [g \in Gens |-> [n \in Nodes |-> FALSE]]
+    /\ collectPending = [g \in Gens |-> FALSE]
+    /\ triggered = {}
+    /\ trigCount = [g \in Gens |-> 0]
+    /\ trigTotal = [g \in Gens |-> -1]
+    /\ rootMsgs  = [g \in Gens |-> 0]
+    /\ fatal     = FALSE
+    /\ msgs      = EmptyBag
+    /\ dups      = 0
+
+----------------------------------------------------------------------------
+(*                        Predicates over plan state                       *)
+----------------------------------------------------------------------------
+(* Section 12.2: every expected child produced exactly its predicted
+   subtotal, the local quota is met, and no unexpected child reported. *)
+PlannedSat(g, n) ==
+    /\ HasPlan(g, n)
+    /\ local[g][n] = Quota[n]
+    /\ \A c \in PlannedKids[n] : acc[g][n][c].val = PTotal[c]
+    /\ \A c \in Kids(n) \ PlannedKids[n] : acc[g][n][c].rev < 0
+
+(* Section 13.1: detectable deviations. *)
+MismatchCond(g, n) ==
+    /\ mode[g][n] = "PLAN"
+    /\ \/ local[g][n] > Quota[n]                          (* source over quota *)
+       \/ \E c \in Kids(n) \ PlannedKids[n] :             (* unexpected child  *)
+             acc[g][n][c].rev >= 0 \/ c \in dirtyKids[g][n]
+       \/ \E c \in PlannedKids[n] : acc[g][n][c].val > PTotal[c]  (* excess *)
+
+(* Eager flush propagates down the plan tree and down any dynamic branch
+   the node already knows about (section 13.3: "old active branches plus
+   new dynamic branches, not every machine node"). *)
+FlushTargets(g, n) == PlannedKids[n] \cup dirtyKids[g][n]
+
+RecMode == IF EagerFlush THEN "FLUSH" ELSE "REC"
+
+(* Root fan-in accounting (sections 6.6 and 23): count the arrival-protocol
+   messages a node sends to the logical root, at send time.  Counting at
+   delivery time would also count transport duplicates, which are not
+   protocol messages.
+   Only generations on the learned fast path are counted; the bound in 6.6
+   is claimed for a stable plan only, and not tracking the dynamic
+   generations keeps the state space smaller. *)
+SendsToRoot(n) == (n # 0) /\ (Parent(n) = 0)
+BumpSend(g, n, k) ==
+    IF SendsToRoot(n) /\ k /\ (g \in PlannedGens)
+    THEN [rootMsgs EXCEPT ![g] = Min2(@ + 1, R + 1)]
+    ELSE rootMsgs
+
+----------------------------------------------------------------------------
+(*                             Local actions                               *)
+----------------------------------------------------------------------------
+(* Section 11.1: arrive() accumulates locally, always. *)
+Arrive(n, g) ==
+    /\ pending[g][n] > 0
+    /\ pending' = [pending EXCEPT ![g][n] = @ - 1]
+    /\ local'   = [local   EXCEPT ![g][n] = @ + 1]
+    /\ UNCHANGED << mode, acc, sentRev, sentVal, dirtySent, dirtyKids,
+                    awaiting, owedReply, mmSeen, collectPending, triggered,
+                    trigCount, trigTotal, rootMsgs, fatal, msgs, dups >>
+
+(* Section 13.1/13.3: a node notices a deviation from the plan, leaves the
+   fast path, signals its parent, and -- with eager flush -- immediately
+   propagates FLUSH down its planned branches. *)
+EnterRecovery(n, g) ==
+    /\ MismatchCond(g, n)
+    /\ mode'   = [mode   EXCEPT ![g][n] = RecMode]
+    /\ mmSeen' = [mmSeen EXCEPT ![g][n] = TRUE]
+    /\ msgs'   = AddSet(msgs,
+                    (IF n # 0 /\ ~mmSeen[g][n] THEN {MMsg(g, n)} ELSE {})
+                    \cup (IF EagerFlush
+                          THEN { Flu(g, n, c) : c \in FlushTargets(g, n) }
+                          ELSE {}))
+    /\ collectPending' = IF n = 0
+                         THEN [collectPending EXCEPT ![g] = TRUE]
+                         ELSE collectPending
+    /\ rootMsgs' = BumpSend(g, n, ~mmSeen[g][n])
+    /\ UNCHANGED << pending, local, acc, sentRev, sentVal, dirtySent,
+                    dirtyKids, awaiting, owedReply, triggered, trigCount,
+                    trigTotal, fatal, dups >>
+
+(* Section 12.1/12.2 planned completion, and the push behaviour of a node
+   that has left the fast path (recovering node announces its overflow;
+   flushing node reports every arrival immediately). *)
+PushUp(n, g) ==
+    /\ n # 0
+    /\ Subtot(g, n) > sentVal[g][n]
+    /\ sentRev[g][n] < MaxRev
+    /\ \/ (mode[g][n] = "PLAN" /\ PlannedSat(g, n))
+       \/ mode[g][n] \in {"REC", "FLUSH"}
+    /\ msgs' = AddSet(msgs, { Rep(g, n, sentRev[g][n] + 1, Subtot(g, n),
+                                  mode[g][n] = "PLAN") })
+    /\ sentRev' = [sentRev EXCEPT ![g][n] = @ + 1]
+    /\ sentVal' = [sentVal EXCEPT ![g][n] = Subtot(g, n)]
+    /\ dirtySent' = [dirtySent EXCEPT ![g][n] = FALSE]
+    /\ rootMsgs' = BumpSend(g, n, TRUE)
+    /\ UNCHANGED << pending, local, mode, acc, dirtyKids, awaiting,
+                    owedReply, mmSeen, collectPending, triggered, trigCount,
+                    trigTotal, fatal, dups >>
+
+(* Section 11.1/11.2: one DIRTY per clean-to-dirty transition.  Only a
+   node running the DYNAMIC protocol does this.  A node on the learned
+   fast path stays silent until it reaches its quota (section 12.2). *)
+SendDirty(n, g) ==
+    /\ n # 0
+    /\ mode[g][n] = "DYN"
+    /\ ~dirtySent[g][n]
+    /\ (Subtot(g, n) > sentVal[g][n]) \/ (dirtyKids[g][n] # {})
+    /\ msgs' = AddSet(msgs, {Dty(g, n)})
+    /\ dirtySent' = [dirtySent EXCEPT ![g][n] = TRUE]
+    /\ rootMsgs' = BumpSend(g, n, TRUE)
+    /\ UNCHANGED << pending, local, mode, acc, sentRev, sentVal, dirtyKids,
+                    awaiting, owedReply, mmSeen, collectPending, triggered,
+                    trigCount, trigTotal, fatal, dups >>
+
+(* Section 11.3 step 3: a relay replies only after every child in its
+   snapshot has replied.  The reply is cumulative and carries a fresh
+   revision; it is sent even when the value did not change, otherwise the
+   collection wave could never complete. *)
+CompleteCollect(n, g) ==
+    /\ n # 0
+    /\ owedReply[g][n]
+    /\ awaiting[g][n] = {}
+    /\ sentRev[g][n] < MaxRev
+    /\ msgs' = AddSet(msgs, { Rep(g, n, sentRev[g][n] + 1, Subtot(g, n), FALSE) })
+    /\ sentRev' = [sentRev EXCEPT ![g][n] = @ + 1]
+    /\ sentVal' = [sentVal EXCEPT ![g][n] = Subtot(g, n)]
+    /\ owedReply' = [owedReply EXCEPT ![g][n] = FALSE]
+    /\ dirtySent' = [dirtySent EXCEPT ![g][n] = FALSE]
+    /\ rootMsgs' = BumpSend(g, n, TRUE)
+    /\ UNCHANGED << pending, local, mode, acc, dirtyKids, awaiting, mmSeen,
+                    collectPending, triggered, trigCount, trigTotal,
+                    fatal, dups >>
+
+(* Section 11.3: the root schedules a collection pass after a dirty
+   notification, and section 13.3 step 4: on mismatch it collects every
+   incomplete planned branch and every dynamic dirty branch.
+   NOTE: the root does NOT spin collection rounds -- section 11.3 says it
+   waits for another clean-to-dirty transition. *)
+LaunchCollect(g) ==
+    /\ collectPending[g]
+    /\ g \notin triggered
+    /\ LET tg == { c \in Kids(0) :
+                     \/ c \in dirtyKids[g][0]
+                     \/ /\ HasPlan(g, 0)
+                        /\ mode[g][0] # "PLAN"
+                        /\ c \in PlannedKids[0]
+                        /\ acc[g][0][c].val < PTotal[c] }
+       IN /\ tg # {}
+          /\ msgs' = AddSet(msgs, { Col(g, 0, c) : c \in tg })
+          /\ dirtyKids' = [dirtyKids EXCEPT ![g][0] = @ \ tg]
+    /\ collectPending' = [collectPending EXCEPT ![g] = FALSE]
+    /\ UNCHANGED << pending, local, mode, acc, sentRev, sentVal, dirtySent,
+                    awaiting, owedReply, mmSeen, triggered, trigCount,
+                    trigTotal, rootMsgs, fatal, dups >>
+
+(* Section 6.1: trigger exactly once, on an exact count, in order.  The
+   >= test (rather than =) is deliberate: it lets TriggerCorrect actually
+   detect a double-counted total instead of silently disabling the step. *)
+Trigger(g) ==
+    /\ g \notin triggered
+    /\ (g = 0) \/ ((g - 1) \in triggered)
+    /\ Subtot(g, 0) >= Expected[g]
+    /\ triggered' = triggered \cup {g}
+    /\ trigCount' = [trigCount EXCEPT ![g] = @ + 1]
+    /\ trigTotal' = [trigTotal EXCEPT ![g] = Subtot(g, 0)]
+    /\ UNCHANGED << pending, local, mode, acc, sentRev, sentVal, dirtySent,
+                    dirtyKids, awaiting, owedReply, mmSeen, collectPending,
+                    rootMsgs, fatal, msgs, dups >>
+
+----------------------------------------------------------------------------
+(*                         Message handlers                                *)
+----------------------------------------------------------------------------
+Consume(m, S) == AddSet(Del(msgs, m), S)
+
+(* Section 6.2: keep the highest accepted revision.  A higher revision
+   REPLACES; an equal revision with different content is fatal; a lower
+   revision is stale and ignored. *)
+RcvRep(m) ==
+    LET n == m.dst
+        g == m.gen
+        c == m.src
+        cur == acc[g][n][c]
+        newer == m.rev > cur.rev
+    IN /\ c \in Kids(n)
+       /\ acc' = IF newer
+                 THEN [acc EXCEPT ![g][n][c] = [rev |-> m.rev, val |-> m.val]]
+                 ELSE acc
+       /\ fatal' = fatal \/ (m.rev = cur.rev /\ m.val # cur.val)
+       (* the root owes nobody a reply, so it keeps no wave state *)
+       /\ awaiting' = IF newer /\ n # 0
+                      THEN [awaiting EXCEPT ![g][n] = @ \ {c}]
+                      ELSE awaiting
+       /\ msgs' = Del(msgs, m)
+       /\ UNCHANGED << pending, local, mode, sentRev, sentVal, dirtySent,
+                       dirtyKids, owedReply, mmSeen, collectPending,
+                       triggered, trigCount, trigTotal, rootMsgs, dups >>
+
+RcvMM(m) ==
+    LET n == m.dst
+        g == m.gen
+        c == m.src
+    IN /\ mode' = [mode EXCEPT ![g][n] =
+                     IF EagerFlush THEN "FLUSH"
+                     ELSE IF mode[g][n] = "PLAN" THEN "REC"
+                     ELSE mode[g][n]]
+       /\ mmSeen' = [mmSeen EXCEPT ![g][n] = TRUE]
+       /\ msgs' = Consume(m,
+                    (IF n # 0 /\ ~mmSeen[g][n] THEN {MMsg(g, n)} ELSE {})
+                    \cup (IF EagerFlush /\ mode[g][n] # "FLUSH"
+                          THEN { Flu(g, n, x) : x \in FlushTargets(g, n) \ {c} }
+                          ELSE {}))
+       /\ collectPending' = IF n = 0
+                            THEN [collectPending EXCEPT ![g] = TRUE]
+                            ELSE collectPending
+       /\ rootMsgs' = BumpSend(g, n, ~mmSeen[g][n])
+       /\ UNCHANGED << pending, local, acc, sentRev, sentVal, dirtySent,
+                       dirtyKids, awaiting, owedReply, triggered, trigCount,
+                       trigTotal, fatal, dups >>
+
+RcvDirty(m) ==
+    LET n == m.dst
+        g == m.gen
+        c == m.src
+    IN /\ c \in Kids(n)
+       /\ dirtyKids' = [dirtyKids EXCEPT ![g][n] = @ \cup {c}]
+       /\ collectPending' = IF n = 0
+                            THEN [collectPending EXCEPT ![g] = TRUE]
+                            ELSE collectPending
+       /\ msgs' = Del(msgs, m)
+       /\ UNCHANGED << pending, local, mode, acc, sentRev, sentVal, dirtySent,
+                       awaiting, owedReply, mmSeen, triggered, trigCount,
+                       trigTotal, rootMsgs, fatal, dups >>
+
+(* Section 11.3 step 2 / 13.3 step 4: snapshot the branches that still owe
+   something and recurse into them; the reply is owed until they answer. *)
+RcvCollect(m) ==
+    LET n == m.dst
+        g == m.gen
+        tg == { c \in Kids(n) :
+                  \/ c \in dirtyKids[g][n]
+                  \/ /\ HasPlan(g, n)
+                     /\ c \in PlannedKids[n]
+                     /\ acc[g][n][c].val < PTotal[c] }
+    IN /\ n # 0
+       /\ awaiting'  = [awaiting  EXCEPT ![g][n] = tg]
+       /\ owedReply' = [owedReply EXCEPT ![g][n] = TRUE]
+       /\ dirtyKids' = [dirtyKids EXCEPT ![g][n] = @ \ tg]
+       /\ msgs' = Consume(m, { Col(g, n, c) : c \in tg })
+       /\ UNCHANGED << pending, local, mode, acc, sentRev, sentVal, dirtySent,
+                       mmSeen, collectPending, triggered, trigCount,
+                       trigTotal, rootMsgs, fatal, dups >>
+
+(* EAGER FLUSH extension: switch this generation to flushing mode, which
+   makes the node self-announcing from now on, and pass the mode further
+   down the plan tree. *)
+RcvFlush(m) ==
+    LET n == m.dst
+        g == m.gen
+    IN /\ mode[g][n] # "FLUSH"
+       /\ mode' = [mode EXCEPT ![g][n] = "FLUSH"]
+       /\ msgs' = Consume(m, { Flu(g, n, c) : c \in FlushTargets(g, n) })
+       /\ UNCHANGED << pending, local, acc, sentRev, sentVal, dirtySent,
+                       dirtyKids, awaiting, owedReply, mmSeen, collectPending,
+                       triggered, trigCount, trigTotal, rootMsgs, fatal, dups >>
+
+RcvFlushDone(m) ==   (* already flushing: just consume the redundant copy *)
+    /\ mode[m.gen][m.dst] = "FLUSH"
+    /\ msgs' = Del(msgs, m)
+    /\ UNCHANGED << pending, local, mode, acc, sentRev, sentVal, dirtySent,
+                    dirtyKids, awaiting, owedReply, mmSeen, collectPending,
+                    triggered, trigCount, trigTotal, rootMsgs, fatal, dups >>
+
+Deliver(m) ==
+    /\ m \in DOMAIN msgs
+    /\ CASE m.kind = "REP"     -> RcvRep(m)
+         [] m.kind = "MM"      -> RcvMM(m)
+         [] m.kind = "DIRTY"   -> RcvDirty(m)
+         [] m.kind = "COLLECT" -> RcvCollect(m)
+         [] m.kind = "FLUSH"   -> RcvFlush(m) \/ RcvFlushDone(m)
+
+(* The transport is reliable but may duplicate (section 2 requires the
+   protocol to tolerate overlapping reports regardless).  Duplication is
+   an unfair action: liveness may never depend on it. *)
+DupMsg ==
+    /\ dups < MaxDups
+    /\ \E m \in DOMAIN msgs :
+          /\ Cnt(msgs, m) < MaxCopies
+          /\ msgs' = AddSet(msgs, {m})
+    /\ dups' = dups + 1
+    /\ UNCHANGED << pending, local, mode, acc, sentRev, sentVal, dirtySent,
+                    dirtyKids, awaiting, owedReply, mmSeen, collectPending,
+                    triggered, trigCount, trigTotal, rootMsgs, fatal >>
+
+----------------------------------------------------------------------------
+(*                          Next-state relation                            *)
+----------------------------------------------------------------------------
+LocalStep(n, g) ==
+    \/ Arrive(n, g)
+    \/ EnterRecovery(n, g)
+    \/ PushUp(n, g)
+    \/ SendDirty(n, g)
+    \/ CompleteCollect(n, g)
+
+DeliverFrom(s) == \E m \in DOMAIN msgs : m.src = s /\ Deliver(m)
+
+Next ==
+    \/ \E n \in Nodes, g \in Gens : LocalStep(n, g)
+    \/ \E g \in Gens : LaunchCollect(g) \/ Trigger(g)
+    \/ \E s \in Nodes : DeliverFrom(s)
+    \/ DupMsg
+
+----------------------------------------------------------------------------
+(*                        Fairness assumptions                             *)
+(*                                                                         *)
+(* These are the whole point of the exercise: the plan states no liveness   *)
+(* theory, so the assumptions under which the barrier makes progress have   *)
+(* to be written down here.                                                *)
+(*                                                                         *)
+(* FairLocal   -- every node eventually takes each of its enabled local     *)
+(*                steps for each generation: it eventually issues a         *)
+(*                pending arrive(), eventually notices a plan mismatch,     *)
+(*                eventually sends a report it is willing to send,          *)
+(*                eventually emits its clean-to-dirty DIRTY, and eventually *)
+(*                completes a collection wave whose children have answered. *)
+(*                (This is one WF per (node, generation) over the           *)
+(*                disjunction; sound because every local step of a fixed    *)
+(*                (n,g) can only occur finitely often, so a permanently     *)
+(*                enabled step cannot be starved by the others forever.)    *)
+(* FairDeliver -- weak fairness on message delivery, per sender.            *)
+(* FairCollect -- weak fairness on the root's collection scheduling.        *)
+(* FairTrigger -- weak fairness on the root publishing a trigger.           *)
+(*                                                                         *)
+(* Deliberately NOT assumed: fairness of DupMsg (duplication must never be  *)
+(* load-bearing), and any form of timeout / polling / re-collection that    *)
+(* is not caused by a protocol signal (section 11.3 forbids spinning        *)
+(* collection rounds).                                                      *)
+----------------------------------------------------------------------------
+FairLocal   == \A n \in Nodes, g \in Gens : WF_vars(LocalStep(n, g))
+FairDeliver == \A s \in Nodes : WF_vars(DeliverFrom(s))
+FairCollect == \A g \in Gens : WF_vars(LaunchCollect(g))
+FairTrigger == \A g \in Gens : WF_vars(Trigger(g))
+
+Fairness == FairLocal /\ FairDeliver /\ FairCollect /\ FairTrigger
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+----------------------------------------------------------------------------
+(*                        Safety invariants (section 6)                    *)
+----------------------------------------------------------------------------
+(* 6.1 (1): a generation triggers at most once. *)
+TriggerOnce == \A g \in Gens : trigCount[g] <= 1
+
+(* 6.1 (1)+(2): it triggers only on the exact expected count. *)
+TriggerCorrect == \A g \in triggered : trigTotal[g] = Expected[g]
+
+(* 6.1 (4): generations trigger in order. *)
+TriggerInOrder == \A g \in triggered : (g = 0) \/ ((g - 1) \in triggered)
+
+(* 6.2: the receiver stores a value that some sender actually sent, never a
+   sum of two reports; revisions never run ahead of the sender; an equal
+   revision with different content is fatal. *)
+NoDoubleCount ==
+    /\ ~fatal
+    /\ \A g \in Gens, n \in Nodes : \A c \in Kids(n) :
+          /\ acc[g][n][c].rev <= sentRev[g][c]
+          /\ acc[g][n][c].val <= sentVal[g][c]
+
+(* 6.2 / 6.3: no arrival is lost and none is counted twice.  Every node's
+   cumulative subtree value is bounded by the arrivals the application has
+   actually issued in that subtree. *)
+NoLostArrival ==
+    \A g \in Gens, n \in Nodes :
+        /\ Subtot(g, n) <= IssuedIn(g, n)
+        /\ sentVal[g][n] <= IssuedIn(g, n)
+
+(* 6.6 / 23: bounded root fan-in.
+   (a) the overlay itself never gives any node more than R children;
+   (b) at most R distinct children ever report to the root;
+   (c) "For a STABLE learned plan, the logical root receives at most the
+       configured radix's worth of arrival-plan completions" -- so the
+       message bound is claimed only for a generation on the learned fast
+       path in which nothing has yet deviated from the plan.  Section 6.6
+       explicitly exempts bootstrap and recovery from the per-generation
+       bound (they only have to keep each individual ROUND bounded, which
+       (a) gives us since the root only ever talks to Kids(0)). *)
+BoundedRootFanIn ==
+    /\ \A n \in Nodes : Cardinality(Kids(n)) <= R
+    /\ \A g \in Gens :
+          Cardinality({c \in Kids(0) : acc[g][0][c].rev >= 0}) <= R
+    /\ \A g \in Gens :
+          ((g \in PlannedGens) /\ (\A n \in Nodes : ~mmSeen[g][n]))
+             => (rootMsgs[g] <= R)
+
+(* Saturation detector: if this ever fails the MaxRev ceiling truncated
+   behaviours and the liveness result would be unsound. *)
+RevNotSaturated == \A g \in Gens, n \in Nodes : sentRev[g][n] < MaxRev
+
+Safety ==
+    /\ TypeOK
+    /\ TriggerOnce
+    /\ TriggerCorrect
+    /\ TriggerInOrder
+    /\ NoDoubleCount
+    /\ NoLostArrival
+    /\ BoundedRootFanIn
+    /\ RevNotSaturated
+
+(* 6.2, as an action property: a higher revision replaces and never lowers
+   the accepted value; a lower revision is ignored. *)
+MonotoneAccept ==
+    [][ \A g \in Gens, n \in Nodes : \A c \in Kids(n) :
+           /\ acc'[g][n][c].val >= acc[g][n][c].val
+           /\ acc'[g][n][c].rev >= acc[g][n][c].rev ]_vars
+
+----------------------------------------------------------------------------
+(*                              Liveness                                   *)
+----------------------------------------------------------------------------
+AllIssued    == \A g \in Gens, n \in Nodes : pending[g][n] = 0
+AllTriggered == triggered = Gens
+
+EventuallyTriggers == AllIssued ~> AllTriggered
+
+(* A terminal state in which some generation has not triggered.  Nothing is
+   enabled anywhere: every arrive() has been issued, the network is empty and
+   no node has any work left, yet the barrier has not fired.  Checking
+   NotStuck as an ordinary invariant produces a much shorter and more
+   readable counterexample than the liveness lasso does. *)
+Stuck    == (~AllTriggered) /\ (~ENABLED Next)
+NotStuck == ~Stuck
+
+----------------------------------------------------------------------------
+(* Trace alias.  NOT referenced by the .cfg files: the tla2tools 2.19 build
+   used for the recorded results does not accept the ALIAS keyword in a
+   configuration file, so traces are printed with the default (full state)
+   format.  Add "ALIAS Alias" to a .cfg if your tla2tools supports it.     *)
+----------------------------------------------------------------------------
+Alias ==
+    [ mode      |-> mode,
+      local     |-> local,
+      pend      |-> pending,
+      subtotal  |-> [g \in Gens |-> [n \in Nodes |-> Subtot(g, n)]],
+      accepted  |-> [g \in Gens |-> [n \in Nodes |->
+                        [c \in Kids(n) |-> acc[g][n][c]]]],
+      sent      |-> [g \in Gens |-> [n \in Nodes |->
+                        <<sentRev[g][n], sentVal[g][n]>>]],
+      dirtyK    |-> dirtyKids,
+      dirtyS    |-> dirtySent,
+      await     |-> awaiting,
+      owed      |-> owedReply,
+      collPend  |-> collectPending,
+      trig      |-> triggered,
+      inflight  |-> DOMAIN msgs ]
+
+============================================================================

--- a/tla/barrier/BarrierArrival.tla
+++ b/tla/barrier/BarrierArrival.tla
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 -------------------------- MODULE BarrierArrival --------------------------
 (***************************************************************************)
 (* TLA+ model of the ARRIVAL half of the Realm scalable-barrier protocol    *)

--- a/tla/barrier/BarrierArrive.tla
+++ b/tla/barrier/BarrierArrive.tla
@@ -24,15 +24,19 @@
 (*                                                                         *)
 (* THE PROTOCOL                                                             *)
 (*                                                                         *)
-(*  1. STEADY STATE.  A node forwards its cumulative subtree total when it  *)
-(*     matches the quota its plan predicts.  Below quota it stays SILENT.   *)
-(*     It does NOT additionally wait for its predicted children.  Reports   *)
-(*     are cumulative and REPLACE, so a forward that omits a child is       *)
-(*     superseded when that child reports, and Trigger demands exact        *)
-(*     equality so a low total simply does not fire.  An earlier draft had  *)
-(*     a child-wait and this file warned against removing it; seven         *)
-(*     scenarios say otherwise - see rule 4.  Only nodes with a non-zero    *)
-(*     expected contribution are in a plan at all.                          *)
+(*  1. STEADY STATE - QUOTA-GATED FORWARDING.  A node forwards its          *)
+(*     cumulative subtree total when it reaches (>=, never =) the SUBTREE   *)
+(*     quota its plan predicts; below it, it stays SILENT and aggregates.   *)
+(*     One report per edge per steady generation is the entire point: the   *)
+(*     ungated design's owner fan-in measured ~N-1 messages per generation  *)
+(*     under synchronized arrivals, at every radix (SCALE_TEST_PLAN.md      *)
+(*     section 7).  Reports remain cumulative and REPLACE, and Trigger      *)
+(*     demands exact equality, so a low total simply does not fire.         *)
+(*                                                                         *)
+(*     THE GATE IS ONLY SAFE BECAUSE OF ITS VALVES (rule 6): an earlier     *)
+(*     design gated on the LOCAL quota precisely because subtree-waiting    *)
+(*     strands when counts route around the waiter.  Six MCGate scenarios   *)
+(*     each deadlock with one valve removed.                                *)
 (*  2. OVER-ARRIVAL at a predicted node -> eager flush for that generation, *)
 (*     report at once, announce the mode to its children.                   *)
 (*  3. ARRIVAL AT A NODE OUTSIDE THE PLAN -> it cannot wait for a match, so *)
@@ -52,6 +56,29 @@
 (*     generation strands on a child that already reported elsewhere.       *)
 (*  5. A cumulative total only ever increases; a report that does not       *)
 (*     increase the stored value is stale and is discarded.                 *)
+(*  6. THE GATE'S VALVES - every way counts can route around a gated relay  *)
+(*     has a feed-forward detector whose response is the owner flushing the *)
+(*     generation down the current tree:                                    *)
+(*      - OWNER RECEIPT VALVE: a report from a sender the current plan does *)
+(*        not list as an owner child (MCGateAhead), or whose value exceeds  *)
+(*        the sender's predicted subtree quota (MCGateOver).                *)
+(*      - OWNER SWITCH AUDIT: installing plan k re-judges every accepted    *)
+(*        value against k's subtree quotas - a value accepted legally under *)
+(*        k-1 can be deviant under k (MCGateMove) or orphaned entirely      *)
+(*        (MCGateDemote).                                                   *)
+(*      - INSTALL RE-FAN: flush fans are kid-list snapshots, so a plan      *)
+(*        install re-announces every open flushed generation to the NEW     *)
+(*        children (MCGateDemote for newplan, MCGatePark for a parked       *)
+(*        install).                                                         *)
+(*      - STALE-EDGE SIGNAL: the relay that receives a report over a pinned *)
+(*        edge the current plan disowns is the one witness that counts are  *)
+(*        routing irregularly; it forwards AND signals the owner            *)
+(*        (MCGatePark).                                                     *)
+(*     Under these valves the case-3 flush signals (immediate and           *)
+(*     retroactive) are no longer load-bearing for safety - the mask probe  *)
+(*     found no scenario that strands without them - but they REMAIN in the *)
+(*     implementation: their flush traffic is the plan-learning evidence    *)
+(*     (ARRIVAL_PROTOCOL.md section 11).                                    *)
 (*                                                                         *)
 (* Feed forward throughout: every action is caused by an arrival or by the  *)
 (* receipt of a message.  No timers, no polling, no background sweep.       *)
@@ -193,10 +220,14 @@ ReportWith(n, g, v) ==
     IF n = Owner THEN {}
     ELSE {[ kind |-> "report", from |-> n, to |-> Owner, gen |-> g, val |-> v ]}
 
-\* NOTE: a report goes to the node's PARENT.  The parent is whoever currently
-\*  lists n as a child; modelled by addressing the report to that node.
-ParentOf(n) == IF \E p \in Nodes : n \in curPlan[p].kids
-                 THEN CHOOSE p \in Nodes : n \in curPlan[p].kids
+\* NOTE: a report goes to the node's PARENT - the explicit parent field of
+\*  the plan record THIS NODE installed (barrier_impl report_target_locked),
+\*  modelled as a lookup in this node's own epoch's static plan.  A planless
+\*  node has no parent and reports to the owner (case 3).  Never derived from
+\*  other nodes' records: the implementation cannot see those.
+ParentOf(n) == IF curPlan[n].inplan
+                    /\ \E p \in Nodes : n \in Plans[myEpoch[n]][p].kids
+                 THEN CHOOSE p \in Nodes : n \in Plans[myEpoch[n]][p].kids
                  ELSE Owner
 
 TargetOf(n, g) == IF reportTo[n][g] # NoTarget THEN reportTo[n][g] ELSE ParentOf(n)
@@ -214,6 +245,30 @@ FlushFan(n, g) == { [ kind |-> "flush", from |-> n, to |-> c, gen |-> g ] : c \i
 PlanSatisfied(n, g) ==
     /\ curPlan[n].inplan
     /\ localTotal[n][g] = curPlan[n].quota
+
+\* THE SUBTREE QUOTA - what the current plan predicts this node's whole
+\*  subtree contributes per generation.  The implementation computes it at
+\*  install time from the plan payload (tree shape is a deterministic
+\*  function of the (node, quota) vector), so it costs nothing on the wire.
+RECURSIVE SubQ(_, _)
+SubQ(e, n) == Plans[e][n].quota +
+              LET kids == Plans[e][n].kids
+              IN  IF kids = {} THEN 0
+                  ELSE SumFn(kids, [c \in kids |-> SubQ(e, c)])
+
+SubQCur(n) == SubQ(myEpoch[n], n)
+
+\* THE OWNER VALVE.  A gated relay can strand only when counts route AROUND
+\*  it, and every such routing produces exactly one of two owner-visible
+\*  symptoms: a report from a sender the current plan does not list as an
+\*  owner child (the sender pinned direct while planless, or a retired
+\*  relay's invalidation-time forward), or a child whose cumulative value
+\*  EXCEEDS its predicted subtree quota (a stowaway count folded into a
+\*  legitimate chain).  Either way the owner flushes the generation down the
+\*  current tree, which un-gates every holder.
+OwnerDeviant(m) == /\ m.to = Owner
+                   /\ \/ m.from \notin KidsOf(Owner)
+                      \/ m.val > SubQ(myEpoch[Owner], m.from)
 
 Init ==
     /\ unissued   = [n \in Nodes |-> [g \in Gens |-> Pattern[g][n]]]
@@ -284,11 +339,11 @@ Arrive(n, g) ==
                 /\ reportedUp' = [reportedUp EXCEPT ![n][g] = sub]
              \/ /\ ~flushing[n][g] /\ curPlan[n].inplan
                 /\ lt <= curPlan[n].quota
-                /\ \/ /\ lt = curPlan[n].quota                      \* case 1: matched
+                /\ \/ /\ sub >= SubQCur(n)                          \* case 1: subtree done
                       /\ msgs' = msgs \cup Send(n, g, sub)
                       /\ reportedUp' = [reportedUp EXCEPT ![n][g] = sub]
-                   \/ /\ ~( lt = curPlan[n].quota )
-                      /\ UNCHANGED << msgs, reportedUp >>            \* SILENCE
+                   \/ /\ sub < SubQCur(n)
+                      /\ UNCHANGED << msgs, reportedUp >>            \* SILENCE (the GATE)
                 /\ UNCHANGED flushing
     /\ reportTo' = Pin(reportTo, n, {g})
     /\ UNCHANGED << childAcc, curPlan, myEpoch, invalEpoch, deferEpoch,
@@ -316,10 +371,14 @@ RecvReport(m) ==
                       \*  nothing will ever make that quota relevant again.
                       \/ (m.from \notin KidsOf(m.to))
                       \/ /\ curPlan[m.to].inplan
-                         /\ localTotal[m.to][m.gen] = curPlan[m.to].quota
+                         /\ sub2 >= SubQCur(m.to)
        IN  /\ childAcc' = acc2
            /\ msgs' = (msgs \ {m}) \cup (IF fwd THEN Send(m.to, m.gen, sub2) ELSE {})
-                      \cup (IF (m.kind = "direct") /\ ~flushing[Owner][m.gen]
+                      \cup (IF (m.from \notin KidsOf(m.to)) /\ (m.to # Owner)
+                              THEN {[ kind |-> "flush", from |-> m.to, to |-> Owner,
+                                      gen |-> m.gen ]} ELSE {})
+                      \cup (IF ((m.kind = "direct") \/ OwnerDeviant(m))
+                              /\ ~flushing[Owner][m.gen]
                               THEN FlushFan(Owner, m.gen) ELSE {})
            /\ reportedUp' = IF fwd THEN [reportedUp EXCEPT ![m.to][m.gen] = sub2]
                                    ELSE reportedUp
@@ -327,7 +386,7 @@ RecvReport(m) ==
                             THEN [ownerAcc EXCEPT ![m.gen] =
                                     @ - childAcc[Owner][m.from][m.gen] + m.val]
                             ELSE ownerAcc
-           /\ flushing' = IF m.kind = "direct"
+           /\ flushing' = IF (m.kind = "direct") \/ OwnerDeviant(m)
                             THEN [flushing EXCEPT ![Owner][m.gen] = TRUE]
                             ELSE flushing
     /\ reportTo' = Pin(reportTo, m.to, {m.gen})
@@ -380,8 +439,16 @@ Trigger(g) ==
     /\ watermark' = g
     /\ LET switch == { k \in Epochs : (k > 1) /\ (PlanStart[k] = g + 1) }
        IN  IF switch = {}
-             THEN UNCHANGED << msgs, curPlan, myEpoch, invalEpoch, deferEpoch >>
+             THEN UNCHANGED << msgs, curPlan, myEpoch, invalEpoch, deferEpoch,
+                               flushing >>
              ELSE LET k == CHOOSE x \in switch : TRUE
+                      deviant == { h \in Gens :
+                                     /\ h > g
+                                     /\ \/ flushing[Owner][h]
+                                        \/ \E s \in Nodes \ {Owner} :
+                                             \/ childAcc[Owner][s][h] > SubQ(k, s)
+                                             \/ /\ childAcc[Owner][s][h] > 0
+                                                /\ s \notin Plans[k][Owner].kids }
                   IN  /\ msgs' = msgs
                                  \cup { [ kind |-> "invalidate", from |-> Owner,
                                           to |-> c, epoch |-> myEpoch[Owner] ] :
@@ -389,11 +456,18 @@ Trigger(g) ==
                                  \cup { [ kind |-> "newplan", from |-> Owner,
                                           to |-> c, epoch |-> k ] :
                                           c \in Plans[k][Owner].kids }
+                                 \cup UNION { { [ kind |-> "flush", from |-> Owner,
+                                                  to |-> c, gen |-> h ] :
+                                                  c \in Plans[k][Owner].kids } :
+                                                h \in deviant }
                       /\ curPlan'    = [curPlan    EXCEPT ![Owner] = Plans[k][Owner]]
                       /\ myEpoch'    = [myEpoch    EXCEPT ![Owner] = k]
                       /\ invalEpoch' = [invalEpoch EXCEPT ![Owner] = k - 1]
+                      /\ flushing'   = [flushing EXCEPT ![Owner] =
+                                          [h \in Gens |-> IF h \in deviant THEN TRUE
+                                                           ELSE flushing[Owner][h]]]
                       /\ UNCHANGED deferEpoch
-    /\ UNCHANGED << unissued, localTotal, reportedUp, childAcc, flushing, ownerAcc >>
+    /\ UNCHANGED << unissued, localTotal, reportedUp, childAcc, ownerAcc >>
     /\ UNCHANGED alterVars
     /\ UNCHANGED reportTo
 
@@ -429,6 +503,14 @@ RecvInvalidate(m) ==
                                          THEN { [ kind |-> "newplan", from |-> m.to,
                                                   to |-> c, epoch |-> dk ] :
                                                   c \in Plans[dk][m.to].kids }
+                                              \cup
+                                              UNION { { [ kind |-> "flush", from |-> m.to,
+                                                          to |-> c, gen |-> x ] :
+                                                          c \in Plans[dk][m.to].kids } :
+                                                        x \in { h \in Gens :
+                                                                  ~triggered[h]
+                                                                  /\ (flushing[m.to][h]
+                                                                       \/ SubtreeKnown(m.to, h) > 0) } }
                                          ELSE {})
                                  \* RETROACTIVE CASE 3.  A node that ran ahead
                                  \*  arrived believing itself a plan member, so
@@ -514,6 +596,12 @@ RecvNewPlan(m) ==
                                         \cup { [ kind |-> "newplan", from |-> m.to,
                                                  to |-> c, epoch |-> m.epoch ] :
                                                  c \in Plans[m.epoch][m.to].kids }
+                                        \cup UNION { { [ kind |-> "flush", from |-> m.to,
+                                                         to |-> c, gen |-> h ] :
+                                                         c \in Plans[m.epoch][m.to].kids } :
+                                                       h \in { x \in Gens :
+                                                                 ~triggered[x]
+                                                                 /\ flushing[m.to][x] } }
                                         \cup UNION { Send(m.to, g, SubtreeKnown(m.to, g)) :
                                                        g \in held }
                              /\ reportedUp' = [reportedUp EXCEPT ![m.to] =

--- a/tla/barrier/BarrierArrive.tla
+++ b/tla/barrier/BarrierArrive.tla
@@ -1,0 +1,657 @@
+------------------------------ MODULE BarrierArrive ------------------------------
+(***************************************************************************)
+(* Realm scalable barriers - arrival protocol, generalised to a SEQUENCE of *)
+(* arrival plans so that several pattern changes can be in flight at once.  *)
+(*                                                                         *)
+(* BarrierV2 checked a single pattern change.  Everything it verified holds *)
+(* here; this module adds epoch bookkeeping so a node can be two plans      *)
+(* behind, which is the case pipelining actually produces.                  *)
+(*                                                                         *)
+(* THE PROTOCOL                                                             *)
+(*                                                                         *)
+(*  1. STEADY STATE.  A node forwards its cumulative subtree total when it  *)
+(*     matches the quota its plan predicts.  Below quota it stays SILENT.   *)
+(*     It does NOT additionally wait for its predicted children.  Reports   *)
+(*     are cumulative and REPLACE, so a forward that omits a child is       *)
+(*     superseded when that child reports, and Trigger demands exact        *)
+(*     equality so a low total simply does not fire.  An earlier draft had  *)
+(*     a child-wait and this file warned against removing it; seven         *)
+(*     scenarios say otherwise - see rule 4.  Only nodes with a non-zero    *)
+(*     expected contribution are in a plan at all.                          *)
+(*  2. OVER-ARRIVAL at a predicted node -> eager flush for that generation, *)
+(*     report at once, announce the mode to its children.                   *)
+(*  3. ARRIVAL AT A NODE OUTSIDE THE PLAN -> it cannot wait for a match, so *)
+(*     it reports DIRECTLY to the owner, which flushes and announces.       *)
+(*  4. PATTERN CHANGE.  The owner sends an INVALIDATION down the tree being *)
+(*     retired and the NEW PLAN down the new tree.  A node that is still an *)
+(*     un-invalidated member of the retiring plan PARKS the new plan; the   *)
+(*     invalidation applies it on arrival.  That deferral is what keeps the *)
+(*     two broadcasts from racing without any global knowledge: a node's    *)
+(*     own membership is the flag, and it is self-clearing.                 *)
+(*     On invalidation a node FORWARDS FIRST, then flushes EVERY open       *)
+(*     generation, then switches.  Installing a plan RETURNS the node to    *)
+(*     planned mode.  Flush MUST NOT be sticky: generations are unbounded   *)
+(*     in the implementation, so a node that stayed eager after its first   *)
+(*     invalidation would aggregate nothing ever again.  That is only safe  *)
+(*     because rule 1 has no child-wait - with one, a re-parented           *)
+(*     generation strands on a child that already reported elsewhere.       *)
+(*  5. A cumulative total only ever increases; a report that does not       *)
+(*     increase the stored value is stale and is discarded.                 *)
+(*                                                                         *)
+(* Feed forward throughout: every action is caused by an arrival or by the  *)
+(* receipt of a message.  No timers, no polling, no background sweep.       *)
+(*                                                                         *)
+(* NOT MODELLED, deliberately: message duplication (the transport is        *)
+(* reliable), reduction barriers (not in the first implementation), node    *)
+(* failure, and the subscription/trigger-notification tree.                 *)
+(***************************************************************************)
+EXTENDS Integers, FiniteSets, TLC
+
+CONSTANTS
+    Nodes,          \* set of node ids
+    Owner,          \* the fixed logical root
+    MaxGen,         \* generations are 1..MaxGen
+    Pattern,        \* [Gens -> [Nodes -> Nat]] arrivals the APPLICATION issues
+    NumPlans,       \* how many successive arrival plans this run goes through
+    Plans,          \* [1..NumPlans -> [Nodes -> [quota, inplan, kids]]]
+    PlanStart,      \* [1..NumPlans -> Gens] first generation each plan applies to
+    BaseCount,      \* [Gens -> Nat] expected arrival count BEFORE any alteration
+    AlterOps        \* set of [node, gen, delta, ts] - ts distinct and positive
+
+Gens   == 1..MaxGen
+Gens0  == 0..MaxGen
+Epochs == 1..NumPlans
+
+RECURSIVE SumFn(_, _)
+SumFn(S, f) == IF S = {} THEN 0
+               ELSE LET x == CHOOSE y \in S : TRUE
+                    IN  f[x] + SumFn(S \ {x}, f)
+
+RECURSIVE SumDeltas(_)
+SumDeltas(S) == IF S = {} THEN 0
+                ELSE LET x == CHOOSE y \in S : TRUE
+                     IN  x.delta + SumDeltas(S \ {x})
+
+
+VARIABLES
+    unissued,     \* [Nodes -> [Gens -> Nat]]  arrivals not yet made
+    localTotal,   \* [Nodes -> [Gens -> Nat]]  arrivals accumulated here
+    reportedUp,   \* [Nodes -> [Gens -> Nat]]  cumulative total last sent to the parent
+    childAcc,     \* [Nodes -> [Nodes -> [Gens -> Nat]]] highest accepted per child
+    flushing,     \* [Nodes -> [Gens -> BOOLEAN]]
+    curPlan,      \* [Nodes -> plan record]    the plan this node currently holds
+    myEpoch,      \* [Nodes -> Epochs]         which plan index that is
+    invalEpoch,   \* [Nodes -> 0..NumPlans]    highest plan index invalidated here
+    deferEpoch,   \* [Nodes -> 0..NumPlans]    a parked new plan (0 = none)
+    ownerAcc,     \* [Gens -> Nat]             owner's accepted total per generation
+    watermark,    \* highest CONTIGUOUS triggered generation
+    triggered,    \* [Gens -> BOOLEAN]
+    msgs,         \* set of in-flight messages (a set, so delivery may reorder)
+    expected,     \* [Gens -> Nat]   owner's CURRENT expected count (alterations applied)
+    appliedTs,    \* SUBSET of alteration timestamps the owner has applied
+    unaltered,    \* SUBSET AlterOps  alterations not yet issued
+    myTs,         \* [Nodes -> [Gens -> Nat]] timestamp this node's arrivals carry
+    reportTo,     \* [Nodes -> [Gens -> Nodes \cup {NoTarget}]] PINNED report edge
+    tsAcc         \* [Gens -> Nat]   owner's count of TIMESTAMPED arrivals
+
+vars == << unissued, localTotal, reportedUp, childAcc, flushing, curPlan,
+           myEpoch, invalEpoch, deferEpoch, ownerAcc, watermark, triggered, msgs,
+           expected, appliedTs, unaltered, myTs, tsAcc, reportTo >>
+
+\* Everything alter_arrival_count adds.  Existing actions leave all of it alone,
+\*  so they gain a single conjunct rather than five entries in a frame list.
+alterVars == << expected, appliedTs, unaltered, myTs, tsAcc >>
+
+\* Ground truth for how many arrivals generation g will EVER see: the pattern's
+\*  base arrivals plus the deltas of every alteration ISSUED so far (they are
+\*  persistent, so an alteration at gen k counts for every g >= k).  An
+\*  alteration that has not been issued has not created its arrival yet.
+Total(g) == SumFn(Nodes, [n \in Nodes |-> Pattern[g][n]])
+            + SumDeltas({ a \in (AlterOps \ unaltered) : a.gen <= g })
+
+\* Arrivals this node has issued for g, and how many of those BYPASSED the tree.
+\*  A bypassed arrival never enters localTotal, so the difference is exact.
+AppliedDelta(n, g) ==
+    SumDeltas({ a \in (AlterOps \ unaltered) : (a.node = n) /\ (a.gen <= g) })
+Issued(n, g)   == Pattern[g][n] + AppliedDelta(n, g) - unissued[n][g]
+TsIssued(n, g) == Issued(n, g) - localTotal[n][g]
+
+\* The owner's timestamped total is a SUM OF CUMULATIVE PER-NODE VALUES, exactly
+\*  like the tree's childAcc.  One direction, one semantics: every accumulator
+\*  in the protocol is replace-if-higher and counts up.
+TsTotal(g) == SumFn(Nodes, [n \in Nodes |-> tsAcc[n][g]])
+
+Msgs ==
+    [ kind : {"report","direct"}, from : Nodes, to : Nodes, gen : Gens, val : 0..64 ]
+    \cup [ kind : {"flush"},      from : Nodes, to : Nodes, gen : Gens ]
+    \cup [ kind : {"invalidate"}, from : Nodes, to : Nodes, epoch : 0..NumPlans ]
+    \cup [ kind : {"newplan"},    from : Nodes, to : Nodes, epoch : Epochs ]
+    \cup [ kind : {"alter"},      from : Nodes, to : Nodes, gen : Gens,
+                                  delta : 0..8, ts : 1..8 ]
+    \cup [ kind : {"tsdirect"},   from : Nodes, to : Nodes, gen : Gens, ts : 1..8,
+                                  val : 0..64 ]
+
+(***************************************************************************)
+(* THE PINNED REPORT EDGE.  A node's report target for a generation is      *)
+(* fixed the FIRST time it touches that generation and a later plan change  *)
+(* does not move it.                                                        *)
+(*                                                                         *)
+(* Without this the owner DOUBLE COUNTS.  Reports are cumulative and only   *)
+(* ever increase, so a contribution already folded into an old parent's     *)
+(* subtree total can never be retracted; if the child is then re-parented   *)
+(* and reports again down a different chain, the owner - which sums per     *)
+(* SENDER - counts it twice.  NoOverCount catches it.                       *)
+(*                                                                         *)
+(* Pinning makes each node's contribution flow up exactly ONE chain per     *)
+(* generation.  It assumes the pinned edges cannot form a cycle; the        *)
+(* implementation gets that from building plan trees in ascending node id   *)
+(* with the owner at the root, so every report edge strictly decreases.     *)
+(***************************************************************************)
+\* an INTEGER sentinel: TLC cannot evaluate an unbounded CHOOSE, and a string
+\*  sentinel makes the # test compare mixed types and throw
+NoTarget == -1
+
+\* A node's children come from ITS OWN plan record - never inferred from what
+\*  other nodes believe their parent to be.  Mixing those lets a reachability
+\*  check conclude a node is reachable when nobody would ever forward to it.
+KidsOf(n) == curPlan[n].kids
+
+RECURSIVE Grow(_)
+Grow(S) == LET S2 == S \cup UNION { KidsOf(n) : n \in S }
+           IN  IF S2 = S THEN S ELSE Grow(S2)
+
+\* Nodes an announcement can still get to.  Seeded from the owner AND from the
+\*  target of every announcement already on the wire: a parent that has
+\*  forwarded and dropped a child leaves that child in no tree at all, and an
+\*  invalidation still travelling toward an ANCESTOR will reach the whole
+\*  subtree under it.  Crediting only messages addressed to the holder itself
+\*  makes this fire on perfectly healthy in-flight states.
+Announced == { m.to : m \in { x \in msgs :
+                 x.kind \in {"invalidate","flush","newplan"} } }
+Reachable == Grow({Owner} \cup Announced)
+
+SubtreeKnown(n, g) == localTotal[n][g] + SumFn(Nodes, [c \in Nodes |-> childAcc[n][c][g]])
+Unreported(n, g)   == SubtreeKnown(n, g) - reportedUp[n][g]
+Holding(n, g)      == Unreported(n, g) > 0
+
+ReportWith(n, g, v) ==
+    IF n = Owner THEN {}
+    ELSE {[ kind |-> "report", from |-> n, to |-> Owner, gen |-> g, val |-> v ]}
+
+\* NOTE: a report goes to the node's PARENT.  The parent is whoever currently
+\*  lists n as a child; modelled by addressing the report to that node.
+ParentOf(n) == IF \E p \in Nodes : n \in curPlan[p].kids
+                 THEN CHOOSE p \in Nodes : n \in curPlan[p].kids
+                 ELSE Owner
+
+TargetOf(n, g) == IF reportTo[n][g] # NoTarget THEN reportTo[n][g] ELSE ParentOf(n)
+
+Send(n, g, v) ==
+    IF n = Owner THEN {}
+    ELSE {[ kind |-> "report", from |-> n, to |-> TargetOf(n, g), gen |-> g, val |-> v ]}
+
+\* pin n's edge for every generation in S that is not pinned yet
+Pin(f, n, S) == [f EXCEPT ![n] = [g \in Gens |-> IF g \in S THEN TargetOf(n, g)
+                                                            ELSE f[n][g]]]
+
+FlushFan(n, g) == { [ kind |-> "flush", from |-> n, to |-> c, gen |-> g ] : c \in KidsOf(n) }
+
+PlanSatisfied(n, g) ==
+    /\ curPlan[n].inplan
+    /\ localTotal[n][g] = curPlan[n].quota
+
+Init ==
+    /\ unissued   = [n \in Nodes |-> [g \in Gens |-> Pattern[g][n]]]
+    /\ localTotal = [n \in Nodes |-> [g \in Gens |-> 0]]
+    /\ reportedUp = [n \in Nodes |-> [g \in Gens |-> 0]]
+    /\ childAcc   = [n \in Nodes |-> [c \in Nodes |-> [g \in Gens |-> 0]]]
+    /\ flushing   = [n \in Nodes |-> [g \in Gens |-> FALSE]]
+    /\ curPlan    = Plans[1]
+    /\ myEpoch    = [n \in Nodes |-> 1]
+    /\ invalEpoch = [n \in Nodes |-> 0]
+    /\ deferEpoch = [n \in Nodes |-> 0]
+    /\ ownerAcc   = [g \in Gens |-> 0]
+    /\ watermark  = 0
+    /\ triggered  = [g \in Gens |-> FALSE]
+    /\ msgs       = {}
+    /\ expected   = BaseCount
+    /\ appliedTs  = {}
+    /\ unaltered  = AlterOps
+    /\ myTs       = [n \in Nodes |-> [g \in Gens |-> 0]]
+    /\ reportTo   = [n \in Nodes |-> [g \in Gens |-> NoTarget]]
+    /\ tsAcc      = [n \in Nodes |-> [g \in Gens |-> 0]]
+
+(***************************************************************************)
+(* ACTION 1 - the application issues an arrival.                           *)
+(***************************************************************************)
+Arrive(n, g) ==
+    /\ unissued[n][g] > 0
+    /\ unissued' = [unissued EXCEPT ![n][g] = @ - 1]
+    /\ \/ \* This node has issued an alteration covering g, so its arrivals carry
+          \*  a causal timestamp.  Tree aggregation collapses arrivals into a
+          \*  single integer and would ERASE that timestamp, so a timestamped
+          \*  arrival BYPASSES THE TREE and is reported to the owner on its own.
+          /\ myTs[n][g] > 0
+          /\ msgs' = msgs \cup
+               {[ kind |-> "tsdirect", from |-> n, to |-> Owner,
+                  gen |-> g, ts |-> myTs[n][g], val |-> TsIssued(n, g) + 1 ]}
+          /\ UNCHANGED << localTotal, reportedUp, flushing >>
+       \/ /\ myTs[n][g] = 0
+          /\ localTotal' = [localTotal EXCEPT ![n][g] = @ + 1]
+          /\ LET lt  == localTotal[n][g] + 1
+                 sub == lt + SumFn(Nodes, [c \in Nodes |-> childAcc[n][c][g]])
+             IN
+             \* CASE 3 TAKES PRIORITY OVER THE FLUSHING FLAG.  An outsider's
+             \*  arrival must SIGNAL, not merely report: a node that went
+             \*  planless has flushing set, and if that branch wins, its count
+             \*  reaches the owner as ordinary traffic - a count without a
+             \*  signal - and nothing ever tells the owner the plan
+             \*  mis-predicts this generation.
+             \*
+             \*  The COUNT still follows the pinned edge (Send): a cumulative
+             \*  value sent straight to the owner would double-count whenever
+             \*  an earlier report from this node is already folded into some
+             \*  relay's aggregate.  The SIGNAL is count-free: a flush to the
+             \*  owner, idempotent there, fanned down the current tree.
+             \/ /\ ~curPlan[n].inplan                                \* case 3
+                /\ msgs' = msgs \cup Send(n, g, sub)
+                           \cup {[ kind |-> "flush", from |-> n, to |-> Owner, gen |-> g ]}
+                /\ reportedUp' = [reportedUp EXCEPT ![n][g] = sub]
+                /\ UNCHANGED flushing
+             \/ /\ flushing[n][g] /\ curPlan[n].inplan              \* already eager
+                /\ msgs' = msgs \cup Send(n, g, sub)
+                /\ reportedUp' = [reportedUp EXCEPT ![n][g] = sub]
+                /\ UNCHANGED flushing
+             \/ /\ ~flushing[n][g] /\ curPlan[n].inplan
+                /\ lt > curPlan[n].quota                            \* case 2: over-arrival
+                /\ flushing' = [flushing EXCEPT ![n][g] = TRUE]
+                /\ msgs' = msgs \cup Send(n, g, sub) \cup FlushFan(n, g)
+                /\ reportedUp' = [reportedUp EXCEPT ![n][g] = sub]
+             \/ /\ ~flushing[n][g] /\ curPlan[n].inplan
+                /\ lt <= curPlan[n].quota
+                /\ \/ /\ lt = curPlan[n].quota                      \* case 1: matched
+                      /\ msgs' = msgs \cup Send(n, g, sub)
+                      /\ reportedUp' = [reportedUp EXCEPT ![n][g] = sub]
+                   \/ /\ ~( lt = curPlan[n].quota )
+                      /\ UNCHANGED << msgs, reportedUp >>            \* SILENCE
+                /\ UNCHANGED flushing
+    /\ reportTo' = Pin(reportTo, n, {g})
+    /\ UNCHANGED << childAcc, curPlan, myEpoch, invalEpoch, deferEpoch,
+                    ownerAcc, watermark, triggered >>
+    /\ UNCHANGED alterVars
+
+(***************************************************************************)
+(* ACTION 2 - a cumulative report arrives.  Higher REPLACES; equal or lower *)
+(* is stale and discarded.  Accepting it may be what completes this relay.  *)
+(***************************************************************************)
+RecvReport(m) ==
+    /\ m \in msgs /\ m.kind \in {"report","direct"}
+    /\ m.val > childAcc[m.to][m.from][m.gen]
+    /\ LET acc2 == [childAcc EXCEPT ![m.to][m.from][m.gen] = m.val]
+           sub2 == localTotal[m.to][m.gen]
+                   + SumFn(Nodes, [c \in Nodes |-> acc2[m.to][c][m.gen]])
+           fwd  == /\ m.to # Owner
+                   /\ sub2 > reportedUp[m.to][m.gen]
+                   /\ \/ flushing[m.to][m.gen]
+                      \* A STALE EDGE.  The sender pinned this edge for this
+                      \*  generation and a plan change has since moved it out of
+                      \*  our child list.  We are still the only route its
+                      \*  contribution has, so it must be passed on AT ONCE -
+                      \*  holding it behind our own quota strands it, because
+                      \*  nothing will ever make that quota relevant again.
+                      \/ (m.from \notin KidsOf(m.to))
+                      \/ /\ curPlan[m.to].inplan
+                         /\ localTotal[m.to][m.gen] = curPlan[m.to].quota
+       IN  /\ childAcc' = acc2
+           /\ msgs' = (msgs \ {m}) \cup (IF fwd THEN Send(m.to, m.gen, sub2) ELSE {})
+                      \cup (IF (m.kind = "direct") /\ ~flushing[Owner][m.gen]
+                              THEN FlushFan(Owner, m.gen) ELSE {})
+           /\ reportedUp' = IF fwd THEN [reportedUp EXCEPT ![m.to][m.gen] = sub2]
+                                   ELSE reportedUp
+           /\ ownerAcc' = IF m.to = Owner
+                            THEN [ownerAcc EXCEPT ![m.gen] =
+                                    @ - childAcc[Owner][m.from][m.gen] + m.val]
+                            ELSE ownerAcc
+           /\ flushing' = IF m.kind = "direct"
+                            THEN [flushing EXCEPT ![Owner][m.gen] = TRUE]
+                            ELSE flushing
+    /\ reportTo' = Pin(reportTo, m.to, {m.gen})
+    /\ UNCHANGED << unissued, localTotal, curPlan, myEpoch, invalEpoch,
+                    deferEpoch, watermark, triggered >>
+    /\ UNCHANGED alterVars
+
+DropStale ==
+    \E m \in msgs :
+        /\ \/ /\ m.kind \in {"report","direct"}
+              /\ m.val <= childAcc[m.to][m.from][m.gen]
+           \/ /\ m.kind = "tsdirect"
+              /\ m.ts \in appliedTs
+              /\ m.val <= tsAcc[m.from][m.gen]
+        /\ msgs' = msgs \ {m}
+        /\ UNCHANGED << unissued, localTotal, reportedUp, childAcc, flushing, curPlan,
+                        myEpoch, invalEpoch, deferEpoch, ownerAcc, watermark, triggered >>
+        /\ UNCHANGED alterVars
+    /\ UNCHANGED reportTo
+
+(***************************************************************************)
+(* ACTION 3 - a flush announcement arrives.  Idempotent per generation.     *)
+(***************************************************************************)
+RecvFlush(m) ==
+    /\ m \in msgs /\ m.kind = "flush"
+    /\ IF flushing[m.to][m.gen]
+         THEN /\ msgs' = msgs \ {m}
+              /\ UNCHANGED << flushing, reportedUp >>
+         ELSE /\ flushing' = [flushing EXCEPT ![m.to][m.gen] = TRUE]
+              /\ msgs' = (msgs \ {m}) \cup FlushFan(m.to, m.gen)
+                         \cup (IF Unreported(m.to, m.gen) > 0
+                                 THEN Send(m.to, m.gen, SubtreeKnown(m.to, m.gen)) ELSE {})
+              /\ reportedUp' = [reportedUp EXCEPT ![m.to][m.gen] =
+                                  IF Unreported(m.to, m.gen) > 0
+                                    THEN SubtreeKnown(m.to, m.gen) ELSE @]
+    /\ reportTo' = Pin(reportTo, m.to, {m.gen})
+    /\ UNCHANGED << unissued, localTotal, childAcc, curPlan, myEpoch, invalEpoch,
+                    deferEpoch, ownerAcc, watermark, triggered >>
+    /\ UNCHANGED alterVars
+
+(***************************************************************************)
+(* ACTION 4 - the owner triggers a generation, in order, and switches plans *)
+(* when the next plan's start generation has arrived.                       *)
+(***************************************************************************)
+Trigger(g) ==
+    /\ ~triggered[g]
+    /\ g = watermark + 1
+    /\ ownerAcc[g] + localTotal[Owner][g] + TsTotal(g) = expected[g]
+    /\ triggered' = [triggered EXCEPT ![g] = TRUE]
+    /\ watermark' = g
+    /\ LET switch == { k \in Epochs : (k > 1) /\ (PlanStart[k] = g + 1) }
+       IN  IF switch = {}
+             THEN UNCHANGED << msgs, curPlan, myEpoch, invalEpoch, deferEpoch >>
+             ELSE LET k == CHOOSE x \in switch : TRUE
+                  IN  /\ msgs' = msgs
+                                 \cup { [ kind |-> "invalidate", from |-> Owner,
+                                          to |-> c, epoch |-> myEpoch[Owner] ] :
+                                          c \in curPlan[Owner].kids }
+                                 \cup { [ kind |-> "newplan", from |-> Owner,
+                                          to |-> c, epoch |-> k ] :
+                                          c \in Plans[k][Owner].kids }
+                      /\ curPlan'    = [curPlan    EXCEPT ![Owner] = Plans[k][Owner]]
+                      /\ myEpoch'    = [myEpoch    EXCEPT ![Owner] = k]
+                      /\ invalEpoch' = [invalEpoch EXCEPT ![Owner] = k - 1]
+                      /\ UNCHANGED deferEpoch
+    /\ UNCHANGED << unissued, localTotal, reportedUp, childAcc, flushing, ownerAcc >>
+    /\ UNCHANGED alterVars
+    /\ UNCHANGED reportTo
+
+(***************************************************************************)
+(* ACTION 5 - invalidation.  FORWARD FIRST through the tree being retired,  *)
+(* flush EVERY open generation, then apply any parked plan.                 *)
+(***************************************************************************)
+RecvInvalidate(m) ==
+    /\ m \in msgs /\ m.kind = "invalidate"
+    /\ IF invalEpoch[m.to] >= m.epoch
+         THEN /\ msgs' = msgs \ {m}
+              /\ UNCHANGED << reportedUp, flushing, curPlan, myEpoch,
+                              invalEpoch, deferEpoch >>
+         ELSE /\ LET kids == KidsOf(m.to)
+                      held == { g \in Gens : ~triggered[g] /\ Unreported(m.to, g) > 0 }
+                      dk   == deferEpoch[m.to]
+                      \* A PARKED PLAN DELIVERED BY ITS OWN DEATH NOTICE IS NOT
+                      \*  A PLAN.  This invalidation retires epoch m.epoch, so a
+                      \*  parked plan with dk <= m.epoch is already retired.
+                      \*  Installing it puts this node in planned mode on a dead
+                      \*  plan having just consumed the only invalidation that
+                      \*  will ever name it; forwarding it does the same to every
+                      \*  descendant, who additionally never see the invalidation
+                      \*  at all - the one node positioned to route it down the
+                      \*  dead plan's edges spent it in this very action.
+                      live == dk > m.epoch
+                  IN  /\ msgs' = (msgs \ {m})
+                                 \cup { [ kind |-> "invalidate", from |-> m.to,
+                                          to |-> c, epoch |-> m.epoch ] : c \in kids }
+                                 \cup UNION { Send(m.to, g, SubtreeKnown(m.to, g)) :
+                                                g \in held }
+                                 \cup (IF live
+                                         THEN { [ kind |-> "newplan", from |-> m.to,
+                                                  to |-> c, epoch |-> dk ] :
+                                                  c \in Plans[dk][m.to].kids }
+                                         ELSE {})
+                                 \* RETROACTIVE CASE 3.  A node that ran ahead
+                                 \*  arrived believing itself a plan member, so
+                                 \*  the outsider rule never fired - its count
+                                 \*  reached the owner, but a count is not a
+                                 \*  signal, and nothing tells the owner the
+                                 \*  plan mis-predicts this generation.  On
+                                 \*  learning it is planless, the node delivers
+                                 \*  case 3 late: a COUNT-FREE flush signal to
+                                 \*  the owner for each open generation it has
+                                 \*  arrivals on.  The owner fans the flush down
+                                 \*  the current tree, which is what unsticks
+                                 \*  contributions parked behind quotas the
+                                 \*  retired plan over-predicted.
+                                 \cup (IF ~live /\ (m.to # Owner)
+                                         THEN { [ kind |-> "flush", from |-> m.to,
+                                                  to |-> Owner, gen |-> g ] :
+                                                  g \in { h \in Gens :
+                                                            ~triggered[h]
+                                                            /\ localTotal[m.to][h] > 0 } }
+                                         ELSE {})
+                      /\ reportedUp' = [reportedUp EXCEPT ![m.to] =
+                                          [g \in Gens |-> IF g \in held
+                                                            THEN SubtreeKnown(m.to, g)
+                                                            ELSE reportedUp[m.to][g]]]
+                      \* FLUSH IS PER GENERATION AND OUTLIVES PLAN INSTALLS.
+                      \*  Set for every open generation this node has state on;
+                      \*  cleared only by that generation triggering.  A plan
+                      \*  install must NOT clear it: the owner's deviation
+                      \*  flush and the newplan RACE, and if the install wins
+                      \*  the flush is lost and the generation strands.
+                      \*  Generations with no activity are governed by the plan
+                      \*  record alone - planless nodes are outsiders (case 3),
+                      \*  planned nodes start planned - so nothing here is
+                      \*  sticky across future generations.
+                      /\ flushing' = [flushing EXCEPT ![m.to] =
+                                        [g \in Gens |->
+                                           IF ~triggered[g] /\ SubtreeKnown(m.to, g) > 0
+                                             THEN TRUE
+                                             ELSE flushing[m.to][g]]]
+                      \* A node left with no live plan IS AN OUTSIDER and must
+                      \*  say so in its plan record: keeping the retired record
+                      \*  (inplan = TRUE) makes later run-ahead arrivals report
+                      \*  as ordinary member traffic - a count without a signal
+                      \*  - instead of firing case 3.  The retroactive signal
+                      \*  above covers arrivals from BEFORE this invalidation;
+                      \*  becoming an outsider covers the ones after.
+                      /\ curPlan' = IF live THEN [curPlan EXCEPT ![m.to] = Plans[dk][m.to]]
+                                            ELSE [curPlan EXCEPT ![m.to] =
+                                                    [quota |-> 0, inplan |-> FALSE,
+                                                     kids |-> {}]]
+                      /\ myEpoch' = IF live THEN [myEpoch EXCEPT ![m.to] = dk] ELSE myEpoch
+                      /\ deferEpoch' = [deferEpoch EXCEPT ![m.to] = 0]
+              /\ invalEpoch' = [invalEpoch EXCEPT ![m.to] = m.epoch]
+    /\ reportTo' = Pin(reportTo, m.to,
+                        { g \in Gens : ~triggered[g] /\ Unreported(m.to, g) > 0 })
+    /\ UNCHANGED << unissued, localTotal, childAcc, ownerAcc, watermark, triggered >>
+    /\ UNCHANGED alterVars
+
+(***************************************************************************)
+(* ACTION 6 - the new plan.  PARK it while still an un-invalidated member   *)
+(* of the retiring plan; otherwise apply and pass it on.                    *)
+(***************************************************************************)
+RecvNewPlan(m) ==
+    /\ m \in msgs /\ m.kind = "newplan"
+    \* A plan whose RETIREMENT this node has already witnessed is dead on
+    \*  arrival, exactly as in RecvInvalidate's 'live' guard: messages reorder,
+    \*  so a newplan can arrive after both its own broadcast's invalidations
+    \*  have overtaken it.  Installing it would return this node to planned
+    \*  mode under a dead plan - having already consumed the only invalidation
+    \*  that will ever name it - and forwarding it would do the same to every
+    \*  descendant.  One principle, two doors: install only if
+    \*  m.epoch > myEpoch AND m.epoch > invalEpoch.
+    /\ IF (myEpoch[m.to] >= m.epoch) \/ (invalEpoch[m.to] >= m.epoch)
+         THEN /\ msgs' = msgs \ {m}
+              /\ UNCHANGED << reportedUp, curPlan, myEpoch, deferEpoch, flushing >>
+         ELSE IF curPlan[m.to].inplan /\ (invalEpoch[m.to] < myEpoch[m.to])
+                THEN /\ msgs' = msgs \ {m}
+                     /\ deferEpoch' = [deferEpoch EXCEPT ![m.to] = m.epoch]
+                     /\ UNCHANGED << reportedUp, curPlan, myEpoch, flushing >>
+                ELSE /\ LET held == { g \in Gens : ~triggered[g] /\ Unreported(m.to, g) > 0 }
+                         IN  /\ msgs' = (msgs \ {m})
+                                        \cup { [ kind |-> "newplan", from |-> m.to,
+                                                 to |-> c, epoch |-> m.epoch ] :
+                                                 c \in Plans[m.epoch][m.to].kids }
+                                        \cup UNION { Send(m.to, g, SubtreeKnown(m.to, g)) :
+                                                       g \in held }
+                             /\ reportedUp' = [reportedUp EXCEPT ![m.to] =
+                                                 [g \in Gens |-> IF g \in held
+                                                                   THEN SubtreeKnown(m.to, g)
+                                                                   ELSE reportedUp[m.to][g]]]
+                             /\ curPlan' = [curPlan EXCEPT ![m.to] = Plans[m.epoch][m.to]]
+                             /\ myEpoch' = [myEpoch EXCEPT ![m.to] = m.epoch]
+                             \* a plan install NEVER clears flush: a flushed
+                             \*  generation stays eager until it triggers (see
+                             \*  RecvInvalidate).  Planned mode is what governs
+                             \*  the generations that are NOT flushed.
+                             /\ UNCHANGED flushing
+                     /\ UNCHANGED deferEpoch
+    /\ reportTo' = Pin(reportTo, m.to,
+                        { g \in Gens : ~triggered[g] /\ Unreported(m.to, g) > 0 })
+    /\ UNCHANGED << unissued, localTotal, childAcc, invalEpoch,
+                    ownerAcc, watermark, triggered >>
+    /\ UNCHANGED alterVars
+
+(***************************************************************************)
+(* ACTION 7 - alter_arrival_count.  The change is PERSISTENT: it applies to *)
+(* this generation and every later one (event.h).  The call is nonblocking  *)
+(* and does no round trip, so the alteration travels to the owner while the *)
+(* application carries on.                                                  *)
+(***************************************************************************)
+Alter(a) ==
+    /\ a \in unaltered
+    /\ ~triggered[a.gen]
+    \* THE APPLICATION CONTRACT (event.h): before issuing an alteration the
+    \*  caller must still hold at least one unissued arrival from the
+    \*  pre-alteration count.  That RESERVED ARRIVAL is what stops the barrier
+    \*  triggering before the owner has learned of the alteration - the safety
+    \*  argument lives in the API contract, not in the protocol.
+    /\ unissued[a.node][a.gen] > 0
+    /\ unaltered' = unaltered \ {a}
+    \* PERSISTENT: the delta applies to this generation and every later one, and
+    \*  it is a promise of real arrivals still to be issued by this node.
+    /\ unissued' = [unissued EXCEPT ![a.node] =
+                      [g \in Gens |-> IF g >= a.gen THEN unissued[a.node][g] + a.delta
+                                                    ELSE unissued[a.node][g]]]
+    /\ myTs' = [myTs EXCEPT ![a.node] =
+                  [g \in Gens |-> IF g >= a.gen THEN a.ts ELSE myTs[a.node][g]]]
+    \* Altering the count makes this node's plan quota wrong, and because its own
+    \*  arrivals now bypass the tree its localTotal can never reach that quota -
+    \*  so as a RELAY it would go silent and strand its children.  Enter EAGER
+    \*  FLUSH for every affected open generation, exactly as an over-arrival
+    \*  does, and announce it downward.
+    /\ LET aff  == { g \in Gens : (g >= a.gen) /\ ~triggered[g] }
+           held == { g \in Gens : (g >= a.gen) /\ ~triggered[g]
+                                 /\ Unreported(a.node, g) > 0 }
+       IN  /\ flushing' = [flushing EXCEPT ![a.node] =
+                             [g \in Gens |-> IF g \in aff THEN TRUE
+                                                          ELSE flushing[a.node][g]]]
+           /\ reportedUp' = [reportedUp EXCEPT ![a.node] =
+                               [g \in Gens |-> IF g \in held THEN SubtreeKnown(a.node, g)
+                                                            ELSE reportedUp[a.node][g]]]
+           /\ msgs' = msgs
+                      \cup {[ kind |-> "alter", from |-> a.node, to |-> Owner,
+                              gen |-> a.gen, delta |-> a.delta, ts |-> a.ts ]}
+                      \cup UNION { FlushFan(a.node, g) : g \in aff }
+                      \cup UNION { Send(a.node, g, SubtreeKnown(a.node, g)) : g \in held }
+    /\ UNCHANGED << localTotal, childAcc, curPlan,
+                    myEpoch, invalEpoch, deferEpoch, ownerAcc, watermark, triggered,
+                    expected, appliedTs, tsAcc >>
+    /\ UNCHANGED reportTo
+
+RecvAlter(m) ==
+    /\ m \in msgs /\ m.kind = "alter"
+    /\ expected' = [g \in Gens |-> IF g >= m.gen THEN expected[g] + m.delta
+                                                 ELSE expected[g]]
+    /\ appliedTs' = appliedTs \cup {m.ts}
+    /\ msgs' = msgs \ {m}
+    /\ UNCHANGED << unissued, localTotal, reportedUp, childAcc, flushing, curPlan,
+                    myEpoch, invalEpoch, deferEpoch, ownerAcc, watermark, triggered,
+                    unaltered, myTs, tsAcc >>
+    /\ UNCHANGED reportTo
+
+(***************************************************************************)
+(* ACTION 8 - a timestamped arrival reaches the owner.  THE GATE: it cannot *)
+(* be counted until every alteration it witnessed has been applied.  This   *)
+(* is barrier_impl.h's per-generation `pending` map keyed by timestamp,     *)
+(* modelled as a disabled action - so it needs no message ordering.         *)
+(***************************************************************************)
+RecvTsDirect(m) ==
+    /\ m \in msgs /\ m.kind = "tsdirect"
+    /\ m.ts \in appliedTs
+    /\ m.val > tsAcc[m.from][m.gen]
+    /\ tsAcc' = [tsAcc EXCEPT ![m.from][m.gen] = m.val]
+    /\ msgs' = msgs \ {m}
+    /\ UNCHANGED << unissued, localTotal, reportedUp, childAcc, flushing, curPlan,
+                    myEpoch, invalEpoch, deferEpoch, ownerAcc, watermark, triggered,
+                    expected, appliedTs, unaltered, myTs >>
+    /\ UNCHANGED reportTo
+
+(***************************************************************************)
+(* A COMPLETED run stutters, so "finished" is never mistaken for "stuck".   *)
+(* Any remaining state with no successor is a genuine deadlock.            *)
+(***************************************************************************)
+Done == (\A g \in Gens : triggered[g]) /\ UNCHANGED vars
+
+Next ==
+    \/ Done
+    \/ DropStale
+    \/ \E n \in Nodes, g \in Gens : Arrive(n, g)
+    \/ \E m \in msgs : RecvReport(m)
+    \/ \E m \in msgs : RecvFlush(m)
+    \/ \E m \in msgs : RecvInvalidate(m)
+    \/ \E m \in msgs : RecvNewPlan(m)
+    \/ \E g \in Gens : Trigger(g)
+    \/ \E a \in unaltered : Alter(a)
+    \/ \E m \in msgs : RecvAlter(m)
+    \/ \E m \in msgs : RecvTsDirect(m)
+
+Spec == Init /\ [][Next]_vars
+
+(***************************************************************************)
+(* SAFETY                                                                   *)
+(***************************************************************************)
+TypeOK == /\ watermark \in Gens0
+          /\ msgs \subseteq Msgs
+          /\ \A g \in Gens : ownerAcc[g] \in 0..64
+          /\ \A n \in Nodes, g \in Gens : tsAcc[n][g] \in 0..64
+          /\ \A g \in Gens : expected[g] \in 0..64
+
+TriggerInOrder == \A g \in Gens : triggered[g] => (\A h \in 1..(g-1) : triggered[h])
+\* A triggered generation has accounted for EXACTLY every arrival the
+\*  application issued - Total(g) is ground truth from Pattern, independent of
+\*  what the owner currently believes 'expected' to be.  A trigger against a
+\*  stale expected count (one alteration short) violates this immediately, so
+\*  this is the check that owns alter_arrival_count.
+TriggerCorrect == \A g \in Gens : triggered[g] =>
+                      (ownerAcc[g] + localTotal[Owner][g] + TsTotal(g) = Total(g))
+NoOverCount    == \A g \in Gens :
+                      ownerAcc[g] + localTotal[Owner][g] + TsTotal(g) <= Total(g)
+
+\* Scenario sanity: with only non-negative alterations the owner's expected
+\*  count climbs toward - never past - the arrivals the application will issue.
+\*  Catches a mis-specified scenario rather than a protocol defect.
+ExpectedSane == \A g \in Gens : expected[g] <= Total(g)
+
+\* No node may sit on unreported work with nothing that will ever collect it.
+\*  The in-flight cases matter: a parent that has already forwarded an
+\*  invalidation has discharged its duty and may drop the child from its list,
+\*  so the child is briefly in no tree while the message is still on the wire.
+ReachableWhileHolding ==
+    \A n \in Nodes, g \in Gens :
+        (~triggered[g] /\ Holding(n, g) /\ n # Owner) =>
+            \/ flushing[n][g]
+            \/ ~curPlan[n].inplan
+            \/ (n \in Reachable)
+
+\* Retained state is bounded: at most one parked plan per node.
+BoundedRetention == \A n \in Nodes : deferEpoch[n] \in 0..NumPlans
+
+=============================================================================

--- a/tla/barrier/BarrierArrive.tla
+++ b/tla/barrier/BarrierArrive.tla
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 ------------------------------ MODULE BarrierArrive ------------------------------
 (***************************************************************************)
 (* Realm scalable barriers - arrival protocol, generalised to a SEQUENCE of *)

--- a/tla/barrier/BarrierNotify.tla
+++ b/tla/barrier/BarrierNotify.tla
@@ -1,0 +1,277 @@
+---------------------------- MODULE BarrierNotify ----------------------------
+(***************************************************************************)
+(* Realm scalable barriers - SUBSCRIPTION / NOTIFICATION protocol.          *)
+(*                                                                         *)
+(* Companion to BarrierArrive (the arrival protocol).  This half does not need  *)
+(* to be precise: a node that is not notified pulls, and the owner answers. *)
+(* The pull is the correctness guarantee; the broadcast set is a cache.     *)
+(*                                                                         *)
+(* THE PROTOCOL                                                             *)
+(*                                                                         *)
+(*  1. The owner keeps a SET of subscribers.  There is no learned tree: the *)
+(*     multicast layer plans a fresh forwarding tree from the encoded set   *)
+(*     on every send, so a set change can never leave a stale tree.         *)
+(*  2. A notification is a DELTA - the newly triggered range and whichever  *)
+(*     of those generations are poisoned - so its size never grows with     *)
+(*     the barrier's poison history.  Old poison is delivered once, on the  *)
+(*     SUBSCRIBE REPLY, which is point to point and can be keyed to what    *)
+(*     the subscriber says it already knows.  A node that receives a delta  *)
+(*     it cannot apply (a gap below m.prev) discards it and pulls.          *)
+(*  3. MEMBERSHIP IS PUBLISHED, NEVER SELF-DECIDED.  The owner's published  *)
+(*     set is authoritative, and a shrink is published to the PRE-SHRINK    *)
+(*     set, so a node being removed always hears about it.                  *)
+(*  4. ADDS ARE MANDATORY, REMOVALS ARE DISCRETIONARY.  Refusing an add     *)
+(*     strands a waiter; refusing a removal only costs bandwidth.           *)
+(*  5. A node removed while it still holds an outstanding waiter RE-        *)
+(*     SUBSCRIBES AT ONCE.  Declining to depart while holding a waiter is   *)
+(*     NOT sufficient on its own - a node can register a waiter after its   *)
+(*     departure intent has been collected but before the owner shrinks.    *)
+(*                                                                         *)
+(* Nodes here are the REMOTE nodes; the owner is the watermark/subSet/      *)
+(* setVer/wantOut variables themselves.                                     *)
+(*                                                                         *)
+(* DELIBERATELY ABSTRACTED: the idle threshold K, the tracked-round         *)
+(* interval M, and the cost test that decides whether a shrink pays are all *)
+(* replaced by NONDETERMINISM - Depart may fire on any eligible node and    *)
+(* the owner may shrink by ANY subset of collected intents.  That is        *)
+(* strictly more general than any tuning, which is the point: the           *)
+(* constants must not be able to affect correctness.                        *)
+(*                                                                         *)
+(* NOT MODELLED: message loss (the transport is reliable), reduction        *)
+(* barriers, node failure, and the multicast tree itself - the forwarding   *)
+(* layer delivers to exactly the encoded set, so a notification is modelled *)
+(* as one message per member.                                               *)
+(***************************************************************************)
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS
+    Nodes,        \* the REMOTE nodes (the owner is the owner-side variables)
+    MaxGen,       \* generations are 1..MaxGen
+    PoisonGens,   \* SUBSET Gens - which generations the application poisons
+    WaitPattern   \* [Nodes -> SUBSET Gens] - which generations each node consults
+
+Gens  == 1..MaxGen
+Gens0 == 0..MaxGen
+
+VARIABLES
+    watermark,   \* owner: highest triggered generation
+    subSet,      \* owner: SUBSET Nodes, the current subscriber set
+    setVer,      \* owner: version, bumped on EVERY change to subSet
+    wantOut,     \* owner: SUBSET Nodes, departure intents collected so far
+    known,       \* [Nodes -> Gens0]        node's known watermark
+    knownPois,   \* [Nodes -> SUBSET Gens]  node's known poisoned set
+    member,      \* [Nodes -> {"NO","PENDING","YES"}]  node's belief about membership
+    myVer,       \* [Nodes -> Nat]  highest setVer this node has applied
+    waiting,     \* [Nodes -> SUBSET Gens]  generations this node still needs
+    msgs         \* set of in-flight messages (a set, so delivery may reorder)
+
+vars == << watermark, subSet, setVer, wantOut, known, knownPois,
+           member, myVer, waiting, msgs >>
+
+Msgs ==
+      [ kind : {"notify"},    to : Nodes, wm : Gens, prev : Gens0,
+                              pois : SUBSET Gens, inset : BOOLEAN, sv : Nat ]
+  \cup [ kind : {"subscribe"}, from : Nodes, lk : Gens0 ]
+  \cup [ kind : {"reply"},     to : Nodes, wm : Gens0, pois : SUBSET Gens,
+                              sv : Nat ]
+
+Init ==
+    /\ watermark = 0
+    /\ subSet    = {}
+    /\ setVer    = 0
+    /\ wantOut   = {}
+    /\ known     = [n \in Nodes |-> 0]
+    /\ knownPois = [n \in Nodes |-> {}]
+    /\ member    = [n \in Nodes |-> "NO"]
+    /\ myVer     = [n \in Nodes |-> 0]
+    /\ waiting   = [n \in Nodes |-> {}]
+    /\ msgs      = {}
+
+(***************************************************************************)
+(* ACTION 1 - the owner triggers the next generation (possibly poisoning    *)
+(* it) and may shrink the set by any subset of the intents it has           *)
+(* collected.  The notification goes to the PRE-SHRINK set, which is what   *)
+(* guarantees a departing node hears about its own removal.                 *)
+(***************************************************************************)
+Trigger ==
+    /\ watermark + 1 \in Gens
+    /\ \E R \in SUBSET wantOut :
+        LET g   == watermark + 1
+            sv2 == IF (R \cap subSet) = {} THEN setVer ELSE setVer + 1
+        IN  /\ watermark' = g
+            /\ subSet'    = subSet \ R
+            /\ setVer'    = sv2
+            /\ wantOut'   = wantOut \ R
+            /\ msgs' = msgs \cup
+                 { [ kind |-> "notify", to |-> c, wm |-> g, prev |-> watermark,
+                     pois |-> (IF g \in PoisonGens THEN {g} ELSE {}),
+                     inset |-> (c \notin R), sv |-> sv2 ] : c \in subSet }
+    /\ UNCHANGED << known, knownPois, member, myVer, waiting >>
+
+(***************************************************************************)
+(* ACTION 2 - local code consults the barrier: a blocking wait, an explicit *)
+(* subscribe, or registering an EventWaiter for deferred work.  A node not  *)
+(* covered by the published set pulls.                                      *)
+(***************************************************************************)
+Consult(n, g) ==
+    /\ g \in WaitPattern[n]
+    /\ g \notin waiting[n]
+    /\ known[n] < g
+    /\ waiting' = [waiting EXCEPT ![n] = @ \cup {g}]
+    /\ wantOut' = wantOut \ {n}          \* consulting resets the idle counter
+    /\ IF member[n] = "NO"
+         THEN /\ msgs'   = msgs \cup
+                            {[ kind |-> "subscribe", from |-> n, lk |-> known[n] ]}
+              /\ member' = [member EXCEPT ![n] = "PENDING"]
+         ELSE UNCHANGED << msgs, member >>
+    /\ UNCHANGED << watermark, subSet, setVer, known, knownPois, myVer >>
+
+(***************************************************************************)
+(* ACTION 3 - a notification arrives.  It is a DELTA, so it can only be    *)
+(* applied if this node has already seen everything below m.prev; otherwise *)
+(* it is discarded and the node pulls.  Membership is version gated and is  *)
+(* applied even on a gap.  A node removed while it still holds a waiter     *)
+(* re-subscribes at once.                                                   *)
+(***************************************************************************)
+RecvNotify(m) ==
+    /\ m \in msgs /\ m.kind = "notify"
+    /\ LET \* A DELTA notification is gap sensitive: if this node has not seen
+           \*  everything below m.prev it cannot apply the range, because it
+           \*  would advance its watermark over generations whose poison status
+           \*  it does not know.  Discard and pull - the reply is exact.
+           gap   == m.prev > known[m.to]
+           fresh == (~gap) /\ (m.wm > known[m.to])
+           nk    == IF fresh THEN m.wm ELSE known[m.to]
+           np    == IF fresh THEN knownPois[m.to] \cup m.pois ELSE knownPois[m.to]
+           w2    == { g \in waiting[m.to] : g > nk }
+           newv  == m.sv > myVer[m.to]
+           \* membership is applied even on a gap - the message may be this
+           \*  node's only notice of its own removal
+           mem0  == IF newv THEN (IF m.inset THEN "YES" ELSE "NO")
+                            ELSE member[m.to]
+           resub == (mem0 = "NO") /\ (w2 # {})
+           \* at most one outstanding pull per node: an in-flight subscribe
+           \*  already carries an lk at or below what a new one would, so its
+           \*  reply is a superset of what this pull would ask for
+           pull  == (gap \/ resub)
+                    /\ ~(\E x \in msgs : (x.kind = "subscribe") /\ (x.from = m.to))
+       IN  /\ known'     = [known     EXCEPT ![m.to] = nk]
+           /\ knownPois' = [knownPois EXCEPT ![m.to] = np]
+           /\ waiting'   = [waiting   EXCEPT ![m.to] = w2]
+           /\ myVer'     = [myVer     EXCEPT ![m.to] = IF newv THEN m.sv ELSE @]
+           /\ member'    = [member    EXCEPT ![m.to] =
+                              IF resub THEN "PENDING" ELSE mem0]
+           /\ msgs' = (msgs \ {m}) \cup
+                      (IF pull THEN {[ kind |-> "subscribe", from |-> m.to,
+                                       lk |-> nk ]}
+                               ELSE {})
+    /\ UNCHANGED << watermark, subSet, setVer, wantOut >>
+
+(***************************************************************************)
+(* ACTION 4 - the owner receives a pull.  The add is MANDATORY, and the     *)
+(* reply carries the current snapshot: that is what covers the race where   *)
+(* the generation triggers while the subscribe is still on the wire.        *)
+(***************************************************************************)
+RecvSubscribe(m) ==
+    /\ m \in msgs /\ m.kind = "subscribe"
+    /\ LET sv2 == IF m.from \in subSet THEN setVer ELSE setVer + 1
+       IN  /\ subSet'  = subSet \cup {m.from}
+           /\ setVer'  = sv2
+           /\ wantOut' = wantOut \ {m.from}
+           /\ msgs' = (msgs \ {m}) \cup
+                      {[ kind |-> "reply", to |-> m.from, wm |-> watermark,
+                         pois |-> { g \in PoisonGens : (g > m.lk) /\ (g <= watermark) },
+                         sv |-> sv2 ]}
+    /\ UNCHANGED << watermark, known, knownPois, member, myVer, waiting >>
+
+RecvReply(m) ==
+    /\ m \in msgs /\ m.kind = "reply"
+    /\ LET fresh == m.wm > known[m.to]
+           nk    == IF fresh THEN m.wm  ELSE known[m.to]
+           \* the reply is a DELTA keyed on what this node said it knew, so it
+           \*  is unioned in - substituting it would drop older poison
+           np    == IF fresh THEN knownPois[m.to] \cup m.pois ELSE knownPois[m.to]
+           newv  == m.sv > myVer[m.to]
+       IN  /\ known'     = [known     EXCEPT ![m.to] = nk]
+           /\ knownPois' = [knownPois EXCEPT ![m.to] = np]
+           /\ waiting'   = [waiting   EXCEPT ![m.to] = { g \in @ : g > nk }]
+           /\ myVer'     = [myVer     EXCEPT ![m.to] = IF newv THEN m.sv ELSE @]
+           /\ member'    = [member    EXCEPT ![m.to] =
+                              IF newv THEN "YES" ELSE member[m.to]]
+           /\ msgs'      = msgs \ {m}
+    /\ UNCHANGED << watermark, subSet, setVer, wantOut >>
+
+(***************************************************************************)
+(* ACTION 5 - a node signals that it wants out.  Nondeterministic: this     *)
+(* stands in for the whole idle-counter / tracked-round mechanism, so no    *)
+(* choice of K or M can be wrong.  The guard waiting[n] = {} is the         *)
+(* PREVENTION half of rule 5 - an optimisation, not the safety rule.        *)
+(***************************************************************************)
+Depart(n) ==
+    /\ n \in subSet
+    /\ member[n] = "YES"
+    /\ waiting[n] = {}
+    /\ n \notin wantOut
+    /\ wantOut' = wantOut \cup {n}
+    /\ UNCHANGED << watermark, subSet, setVer, known, knownPois,
+                    member, myVer, waiting, msgs >>
+
+(***************************************************************************)
+(* A settled run stutters, so "finished" is never mistaken for "stuck".     *)
+(***************************************************************************)
+Done ==
+    /\ watermark = MaxGen
+    /\ \A n \in Nodes : waiting[n] = {}
+    /\ msgs = {}
+    /\ UNCHANGED vars
+
+Next ==
+    \/ Done
+    \/ Trigger
+    \/ \E n \in Nodes, g \in Gens : Consult(n, g)
+    \/ \E m \in msgs : RecvNotify(m)
+    \/ \E m \in msgs : RecvSubscribe(m)
+    \/ \E m \in msgs : RecvReply(m)
+    \/ \E n \in Nodes : Depart(n)
+
+Spec == Init /\ [][Next]_vars
+
+(***************************************************************************)
+(* SAFETY                                                                   *)
+(***************************************************************************)
+TypeOK == /\ watermark \in Gens0
+          /\ known  \in [Nodes -> Gens0]
+          /\ member \in [Nodes -> {"NO","PENDING","YES"}]
+          /\ \A n \in Nodes : myVer[n] <= setVer
+          /\ msgs \subseteq Msgs
+
+\* A node is never told a generation triggered before it did.
+NeverOverstate == \A n \in Nodes : known[n] <= watermark
+
+\* A notification is a complete snapshot, so a node's poison knowledge is
+\*  always exactly the truth up to its own watermark - even after missing
+\*  arbitrarily many notifications.  A delta-based notification breaks this.
+PoisonAccurate ==
+    \A n \in Nodes : knownPois[n] = { g \in PoisonGens : g <= known[n] }
+
+\* THE liveness-critical one, encoded as safety: no node may hold an
+\*  outstanding waiter with nothing that will ever satisfy it.  In-flight
+\*  messages count - a node being removed is briefly outside the set while
+\*  its own removal notice is still on the wire.
+NoStranded ==
+    \A n \in Nodes :
+        (waiting[n] # {}) =>
+            \/ n \in subSet
+            \/ (\E m \in msgs : (m.kind = "notify" \/ m.kind = "reply") /\ m.to = n)
+            \/ (\E m \in msgs : m.kind = "subscribe" /\ m.from = n)
+
+\* Membership is published, never self-decided: a node believing it is
+\*  covered is either in the set or has its correction already on the wire.
+MembershipPublished ==
+    \A n \in Nodes :
+        (member[n] = "YES") =>
+            \/ n \in subSet
+            \/ (\E m \in msgs : m.kind = "notify" /\ m.to = n /\ ~m.inset
+                                /\ m.sv > myVer[n])
+
+=============================================================================

--- a/tla/barrier/BarrierNotify.tla
+++ b/tla/barrier/BarrierNotify.tla
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 ---------------------------- MODULE BarrierNotify ----------------------------
 (***************************************************************************)
 (* Realm scalable barriers - SUBSCRIPTION / NOTIFICATION protocol.          *)

--- a/tla/barrier/Chain.cfg
+++ b/tla/barrier/Chain.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Nodes     <- MCNodes
+    Owner     <- MCOwner
+    MaxGen    <- MCMaxGen
+    Pattern   <- MCPattern
+    NumPlans  <- MCNumPlans
+    Plans     <- MCPlans
+    PlanStart <- MCPlanStart
+    BaseCount <- MCBaseCount
+    AlterOps  <- MCAlterOps
+
+INVARIANTS
+    TypeOK
+    TriggerInOrder
+    TriggerCorrect
+    NoOverCount
+    ReachableWhileHolding
+    BoundedRetention

--- a/tla/barrier/Chain.cfg
+++ b/tla/barrier/Chain.cfg
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 SPECIFICATION Spec
 
 CONSTANTS

--- a/tla/barrier/DeadlockNoFlush.cfg
+++ b/tla/barrier/DeadlockNoFlush.cfg
@@ -1,0 +1,37 @@
+\* -------------------------------------------------------------------------
+\* The broken configuration checked as an ordinary safety invariant rather
+\* than a temporal property.  Module: MCPlanned.
+\*
+\* NotStuck says there is no reachable state in which some generation has
+\* not triggered and NO action at all is enabled.  Such a state is a genuine
+\* protocol deadlock: every arrive() has been issued, the network is empty,
+\* and no node has any work left.  TLC reports the shortest path to it,
+\* which is far more readable than a liveness lasso -- and it demonstrates
+\* that the defect is NOT a fairness artifact, since fairness only promises
+\* that ENABLED actions eventually happen.
+\*
+\* EXPECTED RESULT: NotStuck FAILS (15-state trace).
+\* -------------------------------------------------------------------------
+INIT Init
+NEXT Next
+
+CONSTANT
+    N = 4
+    R = 2
+    RootId = 0
+    G = 1
+    PlannedGens = {0}
+    EagerFlush = FALSE
+    MaxCopies = 1
+    MaxDups = 0
+    MaxRev = 6
+    Arr <- ArrDef
+    Expected <- ExpectedDef
+    Quota <- QuotaDef
+    PlannedKids <- PlannedKidsDef
+    PTotal <- PTotalDef
+
+INVARIANT
+    NotStuck
+
+CHECK_DEADLOCK FALSE

--- a/tla/barrier/DeadlockNoFlush.cfg
+++ b/tla/barrier/DeadlockNoFlush.cfg
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 \* -------------------------------------------------------------------------
 \* The broken configuration checked as an ordinary safety invariant rather
 \* than a temporal property.  Module: MCPlanned.

--- a/tla/barrier/DeepSwitch.cfg
+++ b/tla/barrier/DeepSwitch.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Nodes     <- MCNodes
+    Owner     <- MCOwner
+    MaxGen    <- MCMaxGen
+    Pattern   <- MCPattern
+    NumPlans  <- MCNumPlans
+    Plans     <- MCPlans
+    PlanStart <- MCPlanStart
+    BaseCount <- MCBaseCount
+    AlterOps  <- MCAlterOps
+
+INVARIANTS
+    TypeOK
+    TriggerInOrder
+    TriggerCorrect
+    NoOverCount
+    ReachableWhileHolding
+    BoundedRetention

--- a/tla/barrier/DeepSwitch.cfg
+++ b/tla/barrier/DeepSwitch.cfg
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 SPECIFICATION Spec
 
 CONSTANTS

--- a/tla/barrier/Deviate.cfg
+++ b/tla/barrier/Deviate.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Nodes     <- MCNodes
+    Owner     <- MCOwner
+    MaxGen    <- MCMaxGen
+    Pattern   <- MCPattern
+    NumPlans  <- MCNumPlans
+    Plans     <- MCPlans
+    PlanStart <- MCPlanStart
+    BaseCount <- MCBaseCount
+    AlterOps  <- MCAlterOps
+
+INVARIANTS
+    TypeOK
+    TriggerInOrder
+    TriggerCorrect
+    NoOverCount
+    ReachableWhileHolding
+    BoundedRetention

--- a/tla/barrier/Deviate.cfg
+++ b/tla/barrier/Deviate.cfg
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 SPECIFICATION Spec
 
 CONSTANTS

--- a/tla/barrier/Double.cfg
+++ b/tla/barrier/Double.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Nodes     <- MCNodes
+    Owner     <- MCOwner
+    MaxGen    <- MCMaxGen
+    Pattern   <- MCPattern
+    NumPlans  <- MCNumPlans
+    Plans     <- MCPlans
+    PlanStart <- MCPlanStart
+    BaseCount <- MCBaseCount
+    AlterOps  <- MCAlterOps
+
+INVARIANTS
+    TypeOK
+    TriggerInOrder
+    TriggerCorrect
+    NoOverCount
+    ReachableWhileHolding
+    BoundedRetention

--- a/tla/barrier/Double.cfg
+++ b/tla/barrier/Double.cfg
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 SPECIFICATION Spec
 
 CONSTANTS

--- a/tla/barrier/GateAhead.cfg
+++ b/tla/barrier/GateAhead.cfg
@@ -1,0 +1,35 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    Nodes     <- MCNodes
+    Owner     <- MCOwner
+    MaxGen    <- MCMaxGen
+    Pattern   <- MCPattern
+    NumPlans  <- MCNumPlans
+    Plans     <- MCPlans
+    PlanStart <- MCPlanStart
+    BaseCount <- MCBaseCount
+    AlterOps  <- MCAlterOps
+
+INVARIANTS
+    TypeOK
+    TriggerInOrder
+    TriggerCorrect
+    NoOverCount
+    ReachableWhileHolding
+    BoundedRetention

--- a/tla/barrier/GateDemote.cfg
+++ b/tla/barrier/GateDemote.cfg
@@ -1,0 +1,35 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    Nodes     <- MCNodes
+    Owner     <- MCOwner
+    MaxGen    <- MCMaxGen
+    Pattern   <- MCPattern
+    NumPlans  <- MCNumPlans
+    Plans     <- MCPlans
+    PlanStart <- MCPlanStart
+    BaseCount <- MCBaseCount
+    AlterOps  <- MCAlterOps
+
+INVARIANTS
+    TypeOK
+    TriggerInOrder
+    TriggerCorrect
+    NoOverCount
+    ReachableWhileHolding
+    BoundedRetention

--- a/tla/barrier/GateJump.cfg
+++ b/tla/barrier/GateJump.cfg
@@ -1,0 +1,35 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    Nodes     <- MCNodes
+    Owner     <- MCOwner
+    MaxGen    <- MCMaxGen
+    Pattern   <- MCPattern
+    NumPlans  <- MCNumPlans
+    Plans     <- MCPlans
+    PlanStart <- MCPlanStart
+    BaseCount <- MCBaseCount
+    AlterOps  <- MCAlterOps
+
+INVARIANTS
+    TypeOK
+    TriggerInOrder
+    TriggerCorrect
+    NoOverCount
+    ReachableWhileHolding
+    BoundedRetention

--- a/tla/barrier/GateMove.cfg
+++ b/tla/barrier/GateMove.cfg
@@ -1,0 +1,35 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    Nodes     <- MCNodes
+    Owner     <- MCOwner
+    MaxGen    <- MCMaxGen
+    Pattern   <- MCPattern
+    NumPlans  <- MCNumPlans
+    Plans     <- MCPlans
+    PlanStart <- MCPlanStart
+    BaseCount <- MCBaseCount
+    AlterOps  <- MCAlterOps
+
+INVARIANTS
+    TypeOK
+    TriggerInOrder
+    TriggerCorrect
+    NoOverCount
+    ReachableWhileHolding
+    BoundedRetention

--- a/tla/barrier/GateOver.cfg
+++ b/tla/barrier/GateOver.cfg
@@ -1,0 +1,35 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    Nodes     <- MCNodes
+    Owner     <- MCOwner
+    MaxGen    <- MCMaxGen
+    Pattern   <- MCPattern
+    NumPlans  <- MCNumPlans
+    Plans     <- MCPlans
+    PlanStart <- MCPlanStart
+    BaseCount <- MCBaseCount
+    AlterOps  <- MCAlterOps
+
+INVARIANTS
+    TypeOK
+    TriggerInOrder
+    TriggerCorrect
+    NoOverCount
+    ReachableWhileHolding
+    BoundedRetention

--- a/tla/barrier/GatePark.cfg
+++ b/tla/barrier/GatePark.cfg
@@ -1,0 +1,35 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    Nodes     <- MCNodes
+    Owner     <- MCOwner
+    MaxGen    <- MCMaxGen
+    Pattern   <- MCPattern
+    NumPlans  <- MCNumPlans
+    Plans     <- MCPlans
+    PlanStart <- MCPlanStart
+    BaseCount <- MCBaseCount
+    AlterOps  <- MCAlterOps
+
+INVARIANTS
+    TypeOK
+    TriggerInOrder
+    TriggerCorrect
+    NoOverCount
+    ReachableWhileHolding
+    BoundedRetention

--- a/tla/barrier/IMPLEMENTATION_PLAN.md
+++ b/tla/barrier/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,245 @@
+# Scalable Barriers — Implementation Plan
+
+Plan for the C++ work that enacts the two verified designs:
+
+- [`ARRIVAL_PROTOCOL.md`](ARRIVAL_PROTOCOL.md) — `BarrierArrive.tla`, 9 rules
+- [`NOTIFICATION_PROTOCOL.md`](NOTIFICATION_PROTOCOL.md) — `BarrierNotify.tla`, 8 rules
+
+Those documents are normative. This one is about sequencing, parallelism and
+where the risk sits.
+
+---
+
+## 0. What is and isn't settled
+
+**Settled and verified** — every rule in both protocols has a mutation that a
+both-directions-validated check catches.
+
+**Settled by decision, not verified** — recorded in the documents, no model:
+
+| Item | Where |
+|---|---|
+| Plan gathering / construction / forgetting / distribution | arrival §11 |
+| Negative alterations invalidate the plan; zero base count is an error | arrival rule 9 |
+| Atomicity requirement | arrival §12 |
+| Poison retention bounded by barrier lifetime | notification §8.5 |
+| K, J, shrink cost test | notification rule 8, §8.2, §8.4 |
+
+**Settled by owner decision** (recorded here; `STATE_AND_LOCKING.md` §0 has the
+same list and supersedes anything in its body that contradicts them):
+
+| # | Decision |
+|---|---|
+| D1 | **No separate reduction-state object.** All state lives directly in `BarrierImpl`. Reduction barriers still fall back to the existing path — eager messages straight to the owner — but that is a code path, not a separate object. |
+| D2 | A non-owner never guesses. With a plan it may buffer; without one it eagerly flushes down the tree, or direct to the owner if no tree exists. |
+| D3 | Migration is removed. **The lock is still required** in most of the paths it touched, to race correctly against notifications. |
+| D4 | **One counter direction, one semantics.** Every accumulator is cumulative and replace-if-higher, counting up. No incrementing counter alongside; no count-down convention from the legacy path. |
+| D5 | `alter_arrival_count` is persistent. |
+| D8 | **Store the subscriber set directly as `MulticastTargetSet`** — it already has `add`/`remove`/`contains`/`size`/`num_ranges`. No `NodeSet` staging, no cached conversion. Mutation cost is irrelevant because the set changes rarely by design (that is what K=8 hysteresis is for). |
+| D9 | The plan-gathering structure may be a temporary `BarrierImpl` member, but **must not persist across generations**. |
+| D10 | Handlers that take locks cannot be inline. |
+| Q2 | `destroy_barrier` stays a no-op for now. |
+| Q3 | Reuse `GenEventImpl`'s poison structure; past the cap, fatal log then `std::abort`. |
+| Q4 | A poisoned arrival precondition poisons that generation. |
+| Q5 | Notifications carry a single triggered-generation number — trigger-in-order makes anything wider unnecessary. Poison for a new subscriber rides the subscribe reply. **Do not widen the range.** |
+| Q6 | Payload sizing is not a concern: use active-message fragmentation. (At 4,096 nodes an eager-flush report is ~9–16 KB against a ~1 MB block.) |
+| Q7 | Exactly one mutex per `BarrierImpl` per node. |
+| Q8 | **Drop `BarrierCommunicator`.** Use the active message interface directly. |
+| Q9 | **Do not touch `external_wait`.** Unrelated to these protocols. |
+| Q10 | Defer barrier tests — a new test will be synthesised later, and it needs a few thousand nodes to be meaningful. |
+
+**A pre-existing bug to fix, not just implement around:** `alter_arrival_count`
+is documented (`event.h:271`) and expected by Legion to be **persistent** across
+all future generations. The current code applies the delta to a single
+generation — it lands in `Generation::unguarded_delta` and never touches
+`base_arrival_count`. No test in the repo calls the API. **C6 fixes this**, and
+`BarrierArrive.tla` already models the correct (persistent) semantics.
+
+**Known gap, deliberately carried:** the terminal-negative branch of
+`alter_arrival_count` (arrival §8.6) has no coverage and a *different* safety
+argument from the positive case. Either model it before implementing that branch
+or gate it behind a fatal-error check.
+
+**Scope:** `barrier_impl.{h,cc,inl}` is ~1,900 lines. Reduction barriers stay on
+the existing non-scalable path. Migration is removed (34 references, all three
+files).
+
+---
+
+## 1. Why this is mostly sequential
+
+The tempting shape is "arrival protocol and notification protocol in parallel."
+That's wrong here: both live in `BarrierImpl`, both touch the same per-generation
+state, and both need the same locking discipline. Parallel agents on one class
+produce conflicts that cost more than the concurrency saves.
+
+What *does* parallelise is **reading** and **checking** — scouting the existing
+code, and auditing finished code rule-by-rule against the specs. The plan below
+fans out on those and keeps the writing sequential.
+
+Worktree isolation only pays where agents genuinely write disjoint files, which
+here is essentially only the test phase.
+
+---
+
+## 2. Phases
+
+### Phase A — Scout (parallel, 4 agents, read-only)
+
+Independent questions over existing code; no writes, so no conflicts.
+
+1. **Deletion map.** Every site touched by migration removal; every use of
+   `remote_trigger_gens`, `held_triggers`, `previous_gen` gap-buffering. Which
+   are reachable only from the reduction path (keep) vs. the general path (cut).
+2. **Locking map.** What `BarrierImpl::mutex` currently protects, which methods
+   assume it held, where handlers run (inline vs deferred), and every path
+   `has_triggered` touches — that must end up lock-free.
+3. **Message plumbing.** How `BarrierAdjustMessage` / `BarrierTriggerMessage` /
+   `BarrierSubscribeMessage` are registered, fragmented and dispatched; what a
+   new variable-length payload costs.
+4. **Test surface.** `tests/unit_tests/barrier_test.cc`, `barrier_arrivals.cc`,
+   `barrier_reduce.cc`, `event_test.cc` — which assert on behaviour that is about
+   to change, and which are reusable as regression anchors.
+
+**Output:** one merged findings document. Nothing is written to the tree.
+
+### Phase B — State layout and locking discipline (single, sequential)
+
+The design decision everything else depends on. Produces the new `BarrierImpl`
+member layout for both protocols, and writes down the critical sections —
+explicitly mapping each spec action to one, per arrival §12.
+
+Gate: no implementation starts until this is reviewed. Getting it wrong is what
+makes the later phases conflict.
+
+### Phase C — Implementation (sequential stages)
+
+Ordered so each stage is testable before the next depends on it.
+
+| Stage | Content | Spec |
+|---|---|---|
+| C1 | Strip migration; strip `remote_trigger_gens`, gap-buffering from the general path; route reduction barriers to the legacy path | arrival §3, notification §3 |
+| C2 | Plan record + epochs; cumulative reports with staleness; steady-state quota + child-wait | arrival rules 1, 7 |
+| C3 | Eager flush: over-arrival, outsider-direct, per-generation idempotent flush | arrival rules 2, 3, 4 |
+| C4 | Plan switch: invalidate, newplan, deferral, forward-before-forget, flush-all-generations | arrival rules 5, 6 |
+| C5 | Plan lifecycle: `(node,count)` report payload, owner aggregation, tree construction, **forgetting**, plan-record distribution | arrival §11 |
+| C6 | `alter_arrival_count`: **fix persistence first**, then timestamped arrivals bypass the tree (cumulative `val`), exact-set `pending` gate, eager flush on alter, negative alterations | arrival rules 8, 9 |
+| C7 | Notification: subscriber set + `setVer`, delta notify with gap-pull, subscribe/reply with `lk` and merge, membership publication | notification rules 1–7 |
+| C8 | Departure: consultation signal, `K = 8` adaptive, unicast with `J` jitter, owner cost test and hint | notification rule 8 |
+
+C5 is the highest-risk stage — it is the only one with no model behind it, and
+the memory bound (arrival §11.3) is easy to violate by accident.
+
+### Phase D — Rule audit (parallel, ~17 agents, read-only)
+
+One agent per rule: 9 arrival + 8 notification. Each gets the rule text, its spec
+line references, and the implementation, and answers one question — *does the
+code do exactly this, including the parts the document calls out as easy to get
+wrong?*
+
+This is the phase that actually benefits from fan-out: the rules are independent,
+the failure mode is a rule quietly not implemented, and a reviewer holding one
+rule finds that better than a reviewer holding seventeen.
+
+Feed each agent the specific traps already documented, e.g.:
+
+- a receiver must accept reports from nodes not in its child list (§8.2)
+- forward the invalidation *before* dropping the child list (rule 6)
+- `seq` is a spec artifact and must **not** appear in the wire format (§8.4)
+- membership updates are version-gated on **both** notify and reply paths
+- poison deltas are **merged**, never substituted
+
+### Phase E — Adversarial verify (parallel, 3 per finding)
+
+Every Phase D finding goes to independent skeptics prompted to **refute** it,
+defaulting to refuted when uncertain. Majority refutes → dropped.
+
+Non-optional given the history: in this project roughly as many defects appeared
+in the *verification apparatus* as in the protocols. An unverified finding is a
+hypothesis.
+
+### Phase F — Tests (parallel, worktree-isolated)
+
+The one phase where agents write genuinely disjoint files.
+
+- **Per-rule unit tests**, one file per protocol area, asserting the observable
+  consequence of each rule. Note Q10: full validation needs thousands of nodes
+  and will be a separate exercise; this phase is the local-testable subset.
+- **`alter_arrival_count` coverage**, which does not exist anywhere today — the
+  reason its persistence bug survived.
+- **Concurrency tests** for arrival §12 — parallel `arrive`/`wait`/`alter` from
+  several tasks against one barrier, plus AM delivery, under TSAN.
+- **Deviation tests** driving the exact scenarios the specs encode: over-arrival,
+  outsider, two successive pattern changes, a node running two plans behind, a
+  far-future waiter, subscribe racing a trigger.
+- **Scale/regression** against the existing barrier tests from Phase A4.
+
+TSAN is not optional here. Atomicity is the one requirement no model checks, and
+it is what broke the previous attempt.
+
+---
+
+## 3. Sizing and gates
+
+| Phase | Shape | Gate before proceeding |
+|---|---|---|
+| A | 4 parallel, read-only | findings merged |
+| B | 1 sequential | **human review** — everything downstream depends on it |
+| C1–C8 | sequential | each stage builds and passes existing tests |
+| D | ~17 parallel, read-only | — |
+| E | 3 per finding, parallel | only confirmed findings reach a fix list |
+| F | parallel, worktrees | clean TSAN run |
+
+Phase B is the one hard gate. Phase C5 is the one to slow down on.
+
+---
+
+## 4. Risks
+
+**The previous attempt failed here, and it is worth naming how.** It was not
+protocol logic: it was a test harness using a 10µs `TimeLimit` that pushed work
+onto a deferred path where `get_runtime()` was null. Three "fixes" were made and
+reverted before the real cause was found. Hence Phase F's TSAN gate and Phase
+B's explicit critical sections.
+
+Other risks, in order:
+
+1. **C5 memory bound.** The aggregation structure must be deleted after
+   broadcast. O(N) barriers × O(N) map is the blow-up the whole design exists to
+   avoid, and nothing will fail loudly if it leaks — it just scales badly.
+2. **Eager-flush report size.** O(subtree) payloads re-sent per child update.
+   Use the multicast codec's encodings; measure before assuming it is fine.
+3. **Silent partial implementation of a rule.** Exactly what Phase D exists for.
+4. **`has_triggered` regressing to take a lock.** Cheap to do by accident while
+   adding the consultation signal; add an explicit test.
+
+---
+
+## 5. What to instrument from day one
+
+The specs deliberately abstract these as nondeterminism, so only measurement can
+tune them:
+
+- leave→rejoin cycles per barrier (validates `K = 8`; near zero is the
+  expectation)
+- subscribe fan-in per barrier (the last unaggregated O(N) path; escape hatch is
+  notification §"growth")
+- eager-flush episodes and their report sizes
+- plan rebuild frequency, and peak size of the aggregation structure
+
+---
+
+## 6. Re-verification triggers
+
+Change the protocol, re-run the battery. Concretely:
+
+```sh
+cd tla/barrier
+# arrival:      Seven.cfg/MCSeven (~15 min), Large, Deviate, Over, Alter
+# notification: Notify.cfg/MCNotify (~18 min)
+```
+
+Two operational warnings, both learned the hard way and repeated in the
+documents: a full run consumes tens of GB of scratch — delete `jtmp/` and
+`states/` afterwards — and mutations must be applied to a **copy** in a scratch
+directory, never to the canonical `.tla` in place.

--- a/tla/barrier/IMPLEMENTATION_PLAN.md
+++ b/tla/barrier/IMPLEMENTATION_PLAN.md
@@ -1,3 +1,20 @@
+<!--
+Copyright 2026 Stanford University, NVIDIA Corporation
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Scalable Barriers — Implementation Plan
 
 Plan for the C++ work that enacts the two verified designs:

--- a/tla/barrier/Large.cfg
+++ b/tla/barrier/Large.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Nodes     <- MCNodes
+    Owner     <- MCOwner
+    MaxGen    <- MCMaxGen
+    Pattern   <- MCPattern
+    NumPlans  <- MCNumPlans
+    Plans     <- MCPlans
+    PlanStart <- MCPlanStart
+    BaseCount <- MCBaseCount
+    AlterOps  <- MCAlterOps
+
+INVARIANTS
+    TypeOK
+    TriggerInOrder
+    TriggerCorrect
+    NoOverCount
+    ReachableWhileHolding
+    BoundedRetention

--- a/tla/barrier/Large.cfg
+++ b/tla/barrier/Large.cfg
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 SPECIFICATION Spec
 
 CONSTANTS

--- a/tla/barrier/Late.cfg
+++ b/tla/barrier/Late.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Nodes     <- MCNodes
+    Owner     <- MCOwner
+    MaxGen    <- MCMaxGen
+    Pattern   <- MCPattern
+    NumPlans  <- MCNumPlans
+    Plans     <- MCPlans
+    PlanStart <- MCPlanStart
+    BaseCount <- MCBaseCount
+    AlterOps  <- MCAlterOps
+
+INVARIANTS
+    TypeOK
+    TriggerInOrder
+    TriggerCorrect
+    NoOverCount
+    ReachableWhileHolding
+    BoundedRetention

--- a/tla/barrier/Late.cfg
+++ b/tla/barrier/Late.cfg
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 SPECIFICATION Spec
 
 CONSTANTS

--- a/tla/barrier/MCAlter.tla
+++ b/tla/barrier/MCAlter.tla
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 ------------------------------- MODULE MCAlter -------------------------------
 (***************************************************************************)
 (* alter_arrival_count.  Four nodes, two generations, one plan, one         *)

--- a/tla/barrier/MCAlter.tla
+++ b/tla/barrier/MCAlter.tla
@@ -1,0 +1,62 @@
+------------------------------- MODULE MCAlter -------------------------------
+(***************************************************************************)
+(* alter_arrival_count.  Four nodes, two generations, one plan, one         *)
+(* alteration - deliberately small, because what is being checked is a      *)
+(* COUNTING hazard rather than a routing one and it shows up at minimum     *)
+(* size.                                                                    *)
+(*                                                                         *)
+(*   plan 1            0                                                    *)
+(*                     |- 1  q1                                             *)
+(*                     |- 2  q1                                             *)
+(*                        |- 3  q1                                          *)
+(*                                                                         *)
+(* Node 2 is a RELAY, not a leaf: it alters its own count while still       *)
+(* having to forward node 3's reports.  That is the case where bypassing    *)
+(* the tree with a timestamped arrival could strand a child.                *)
+(*                                                                         *)
+(*   gen 1  base 3 arrivals; node 2 alters +1 (ts 1), which CREATES a fourth *)
+(*          arrival it must then issue - so expected and issued both reach 4 *)
+(*   gen 2  base 3 arrivals; the alteration is PERSISTENT, so node 2 owes one*)
+(*          more here too and expected is 4                                  *)
+(*                                                                         *)
+(* The hazard: if the owner counts node 2's arrivals before applying the    *)
+(* alteration, it triggers generation 1 at 3 instead of 4 - a barrier that  *)
+(* triggered too early, which is what event.h names as the failure mode.    *)
+(***************************************************************************)
+EXTENDS BarrierArrive
+
+MCNodes  == {0, 1, 2, 3}
+MCOwner  == 0
+MCMaxGen == 2
+
+MCPattern ==
+    [ g \in 1..2 |->
+        CASE g = 1 -> [n \in MCNodes |-> CASE n = 1 -> 1
+                                           [] n = 2 -> 1     \* base; +1 comes from the alteration
+                                           [] n = 3 -> 1
+                                           [] OTHER -> 0 ]
+          [] g = 2 -> [n \in MCNodes |-> CASE n = 1 -> 1
+                                           [] n = 2 -> 1
+                                           [] n = 3 -> 1
+                                           [] OTHER -> 0 ] ]
+
+NoPlan == [quota |-> 0, inplan |-> FALSE, kids |-> {}]
+
+MCPlan1 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1, 2}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] n = 2 -> [quota |-> 1, inplan |-> TRUE, kids |-> {3}]
+          [] n = 3 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCNumPlans  == 1
+MCPlans     == <<MCPlan1>>
+MCPlanStart == <<1>>
+
+\* base + persistent delta must equal what the pattern issues:
+\*   gen 1: 3 + 1 = 4   gen 2: 2 + 1 = 3
+MCBaseCount == [g \in 1..2 |-> 3]
+MCAlterOps  == { [node |-> 2, gen |-> 1, delta |-> 1, ts |-> 1] }
+
+=============================================================================

--- a/tla/barrier/MCChain.tla
+++ b/tla/barrier/MCChain.tla
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 ------------------------------- MODULE MCChain -------------------------------
 (***************************************************************************)
 (* A THREE-DEEP RELAY CHAIN - the shape the child-wait is supposed to need. *)

--- a/tla/barrier/MCChain.tla
+++ b/tla/barrier/MCChain.tla
@@ -1,0 +1,50 @@
+------------------------------- MODULE MCChain -------------------------------
+(***************************************************************************)
+(* A THREE-DEEP RELAY CHAIN - the shape the child-wait is supposed to need. *)
+(* Neither MCLarge nor MCSeven has a relay below a relay: in both, every    *)
+(* plan is owner -> relay -> leaf.  Here node 2 is a relay whose parent is  *)
+(* also a relay, so a premature forward at node 2 has somewhere to go wrong.*)
+(*                                                                         *)
+(*     0                                                                   *)
+(*     |- 1  q1                                                            *)
+(*        |- 2  q1                                                         *)
+(*           |- 3  q1                                                      *)
+(*                                                                         *)
+(*   g1  matches the plan exactly - the child-wait is the only gate         *)
+(*   g2  deviates twice: node 3 over-arrives (case 2) at the BOTTOM of the  *)
+(*       chain, and node 4 arrives while in no plan (case 3)                *)
+(***************************************************************************)
+EXTENDS BarrierArrive
+
+MCNodes  == {0, 1, 2, 3, 4}
+MCOwner  == 0
+MCMaxGen == 2
+
+MCPattern ==
+    [ g \in 1..2 |->
+        CASE g = 1 -> [n \in MCNodes |-> CASE n = 1 -> 1 [] n = 2 -> 1
+                                           [] n = 3 -> 1 [] OTHER -> 0 ]
+          [] g = 2 -> [n \in MCNodes |-> CASE n = 1 -> 1 [] n = 2 -> 1
+                                           [] n = 3 -> 2   \* over-arrival, deepest
+                                           [] n = 4 -> 1   \* outsider
+                                           [] OTHER -> 0 ] ]
+
+NoPlan == [quota |-> 0, inplan |-> FALSE, kids |-> {}]
+
+MCPlan1 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {2}]
+          [] n = 2 -> [quota |-> 1, inplan |-> TRUE, kids |-> {3}]
+          [] n = 3 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCNumPlans  == 1
+MCPlans     == <<MCPlan1>>
+MCPlanStart == <<1>>
+
+MCBaseCount == [g \in 1..MCMaxGen |->
+                  SumFn(MCNodes, [n \in MCNodes |-> MCPattern[g][n]])]
+MCAlterOps  == {}
+
+=============================================================================

--- a/tla/barrier/MCDeepSwitch.tla
+++ b/tla/barrier/MCDeepSwitch.tla
@@ -1,0 +1,71 @@
+---------------------------- MODULE MCDeepSwitch ----------------------------
+(***************************************************************************)
+(* The only scenario with BOTH a relay below a relay AND two successive     *)
+(* pattern changes.  MCLarge has two switches but is owner -> relay -> leaf;*)
+(* MCChain has the depth but one plan; MCSeven had neither the depth nor,   *)
+(* once the child-wait was removed, affordability.                          *)
+(*                                                                         *)
+(*   plan 1 (gens 1-2)     plan 2 (gen 3)      plan 3 (gen 4)              *)
+(*     0                     0                   0                         *)
+(*     |- 1  q1              |- 1  q1            |- 2  q1                  *)
+(*        |- 2  q1              |- 4  q1            |- 3  q1               *)
+(*           |- 3  q1                                                      *)
+(*                                                                         *)
+(*   g1, g2  match plan 1 - the three-deep chain in steady state            *)
+(*   g3      matches plan 2                                                 *)
+(*   g4      matches plan 3 EXCEPT node 4 arrives while in no plan, and it  *)
+(*           may run ahead into g4 while still holding plan 1 - two plans   *)
+(*           behind, which is what MCSeven existed to cover                 *)
+(***************************************************************************)
+EXTENDS BarrierArrive
+
+MCNodes  == {0, 1, 2, 3, 4}
+MCOwner  == 0
+MCMaxGen == 4
+
+MCPattern ==
+    [ g \in 1..4 |->
+        CASE g = 1 -> [n \in MCNodes |-> CASE n = 1 -> 1 [] n = 2 -> 1
+                                           [] n = 3 -> 1 [] OTHER -> 0 ]
+          [] g = 2 -> [n \in MCNodes |-> CASE n = 1 -> 1 [] n = 2 -> 1
+                                           [] n = 3 -> 1 [] OTHER -> 0 ]
+          [] g = 3 -> [n \in MCNodes |-> CASE n = 1 -> 1
+                                           [] n = 4 -> 1 [] OTHER -> 0 ]
+          [] g = 4 -> [n \in MCNodes |-> CASE n = 2 -> 1
+                                           [] n = 3 -> 1
+                                           [] n = 4 -> 1   \* outsider, may run ahead
+                                           [] OTHER -> 0 ] ]
+
+NoPlan == [quota |-> 0, inplan |-> FALSE, kids |-> {}]
+
+MCPlan1 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {2}]
+          [] n = 2 -> [quota |-> 1, inplan |-> TRUE, kids |-> {3}]
+          [] n = 3 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCPlan2 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {4}]
+          [] n = 4 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCPlan3 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {2}]
+          [] n = 2 -> [quota |-> 1, inplan |-> TRUE, kids |-> {3}]
+          [] n = 3 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCNumPlans  == 3
+MCPlans     == <<MCPlan1, MCPlan2, MCPlan3>>
+MCPlanStart == <<1, 3, 4>>
+
+MCBaseCount == [g \in 1..MCMaxGen |->
+                  SumFn(MCNodes, [n \in MCNodes |-> MCPattern[g][n]])]
+MCAlterOps  == {}
+
+=============================================================================

--- a/tla/barrier/MCDeepSwitch.tla
+++ b/tla/barrier/MCDeepSwitch.tla
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 ---------------------------- MODULE MCDeepSwitch ----------------------------
 (***************************************************************************)
 (* The only scenario with BOTH a relay below a relay AND two successive     *)

--- a/tla/barrier/MCDeviate.tla
+++ b/tla/barrier/MCDeviate.tla
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 ----------------------------- MODULE MCDeviate -----------------------------
 (***************************************************************************)
 (* Exercises the DEVIATION paths, which the other scenarios never reach     *)

--- a/tla/barrier/MCDeviate.tla
+++ b/tla/barrier/MCDeviate.tla
@@ -1,0 +1,62 @@
+----------------------------- MODULE MCDeviate -----------------------------
+(***************************************************************************)
+(* Exercises the DEVIATION paths, which the other scenarios never reach     *)
+(* because there every generation's pattern matched the plan governing it.  *)
+(*                                                                         *)
+(* One plan throughout (no pattern change at all), so nothing here depends  *)
+(* on the invalidation machinery:                                           *)
+(*                                                                         *)
+(*     0 = owner                                                            *)
+(*     |- 1  quota 1                                                        *)
+(*     |  |- 3  quota 2                                                     *)
+(*     |- 2  quota 1                                                        *)
+(*     4 is in no plan                                                      *)
+(*                                                                         *)
+(* Generation 1 matches the plan exactly - the steady-state case.           *)
+(*                                                                         *)
+(* Generation 2 DISAGREES with it in two ways at once:                      *)
+(*   - node 2 arrives 3 times against a quota of 1  -> OVER-ARRIVAL, case 2 *)
+(*   - node 4 arrives at all, and is in no plan     -> OUTSIDER,    case 3  *)
+(* so the generation can only complete if the over-arriving node flushes    *)
+(* and the outsider reports directly to the owner.                          *)
+(***************************************************************************)
+EXTENDS BarrierArrive
+
+MCNodes  == {0, 1, 2, 3, 4}
+MCOwner  == 0
+MCMaxGen == 2
+
+MCPattern ==
+    [ g \in 1..2 |->
+        IF g = 1 THEN [n \in MCNodes |-> CASE n = 0 -> 0   \* matches the plan
+                                           [] n = 1 -> 1
+                                           [] n = 2 -> 1
+                                           [] n = 3 -> 2
+                                           [] n = 4 -> 0 ]
+                 ELSE [n \in MCNodes |-> CASE n = 0 -> 0
+                                           [] n = 1 -> 1
+                                           [] n = 2 -> 3   \* over-arrives (quota 1)
+                                           [] n = 3 -> 2
+                                           [] n = 4 -> 1 ] ] \* outsider arrives
+
+NoPlan == [quota |-> 0, inplan |-> FALSE, kids |-> {}]
+
+MCPlan1 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1, 2}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {3}]
+          [] n = 2 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] n = 3 -> [quota |-> 2, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCNumPlans  == 1
+MCPlans     == <<MCPlan1>>
+MCPlanStart == <<1>>
+
+\* No alterations in this scenario: the base count is simply every arrival the
+\*  pattern issues, so the model must reduce EXACTLY to the pre-alteration one.
+MCBaseCount == [g \in 1..MCMaxGen |->
+                  SumFn(MCNodes, [n \in MCNodes |-> MCPattern[g][n]])]
+MCAlterOps  == {}
+
+=============================================================================

--- a/tla/barrier/MCDouble.tla
+++ b/tla/barrier/MCDouble.tla
@@ -1,0 +1,64 @@
+------------------------------ MODULE MCDouble ------------------------------
+(***************************************************************************)
+(* The DOUBLE-COUNT in its minimal form: four nodes, two generations, one   *)
+(* plan switch.  MCDeepSwitch exhibits it too but costs millions of states; *)
+(* this costs thousands, which is what makes iterating on a fix possible.   *)
+(*                                                                         *)
+(*   plan 1 (gen 1)        plan 2 (gen 2)                                  *)
+(*     0                     0                                             *)
+(*     |- 1  q1              |- 2  q1                                      *)
+(*        |- 2  q1              |- 3  q1                                   *)
+(*           |- 3  q1                                                      *)
+(*                                                                         *)
+(* Node 2 is RE-PARENTED from node 1 to the owner, and it has a child of    *)
+(* its own so its cumulative total can grow AFTER the move:                 *)
+(*                                                                         *)
+(*   1. node 2 runs ahead and arrives on g2 while still on plan 1; its      *)
+(*      quota is met so it reports val=1 to node 1                          *)
+(*   2. node 1 folds that into its subtree total and reports it onward      *)
+(*   3. the plan switches; node 2's parent becomes the owner                *)
+(*   4. node 3 reports to node 2, so node 2's total rises to 2 and it       *)
+(*      reports 2 - now down a different chain                              *)
+(*                                                                         *)
+(* The owner sums per SENDER, so node 2's own arrival is counted once       *)
+(* inside node 1's stale total and again in node 2's own report.            *)
+(***************************************************************************)
+EXTENDS BarrierArrive
+
+MCNodes  == {0, 1, 2, 3}
+MCOwner  == 0
+MCMaxGen == 2
+
+MCPattern ==
+    [ g \in 1..2 |->
+        CASE g = 1 -> [n \in MCNodes |-> CASE n = 1 -> 1 [] n = 2 -> 1
+                                           [] n = 3 -> 1 [] OTHER -> 0 ]
+          [] g = 2 -> [n \in MCNodes |-> CASE n = 2 -> 1
+                                           [] n = 3 -> 1 [] OTHER -> 0 ] ]
+
+NoPlan == [quota |-> 0, inplan |-> FALSE, kids |-> {}]
+
+MCPlan1 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {2}]
+          [] n = 2 -> [quota |-> 1, inplan |-> TRUE, kids |-> {3}]
+          [] n = 3 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCPlan2 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {2}]
+          [] n = 2 -> [quota |-> 1, inplan |-> TRUE, kids |-> {3}]
+          [] n = 3 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCNumPlans  == 2
+MCPlans     == <<MCPlan1, MCPlan2>>
+MCPlanStart == <<1, 2>>
+
+MCBaseCount == [g \in 1..MCMaxGen |->
+                  SumFn(MCNodes, [n \in MCNodes |-> MCPattern[g][n]])]
+MCAlterOps  == {}
+
+=============================================================================

--- a/tla/barrier/MCDouble.tla
+++ b/tla/barrier/MCDouble.tla
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 ------------------------------ MODULE MCDouble ------------------------------
 (***************************************************************************)
 (* The DOUBLE-COUNT in its minimal form: four nodes, two generations, one   *)

--- a/tla/barrier/MCGateAhead.tla
+++ b/tla/barrier/MCGateAhead.tla
@@ -1,0 +1,75 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
+------------------------------ MODULE MCGateAhead ------------------------------
+(***************************************************************************)
+(* THE RUN-AHEAD MIXED-PIN STRAND against the gate.                         *)
+(*                                                                         *)
+(*   plan 1 (gen 1)        plan 2 (gen 2)                                  *)
+(*     0                     0                                             *)
+(*     |- 1  q1              |- 3  q1                                      *)
+(*        |- 2  q1              |- 2  q1                                   *)
+(*                                                                         *)
+(*   g2  node 2 runs ahead and arrives while still on plan 1: its count     *)
+(*       pins to node 1 and reaches the owner through node 1's              *)
+(*       invalidation-time forward - arriving at the owner FROM A SENDER    *)
+(*       THE CURRENT PLAN DISOWNS.  Node 3 installs plan 2, arrives, and    *)
+(*       gates on a subtree quota (its own 1 + node 2's 1) that can never   *)
+(*       complete: node 2's count routed around it.  Node 3 is never        *)
+(*       invalidated (it was not in plan 1's tree), so no switch-time       *)
+(*       flush touches it.                                                  *)
+(*                                                                         *)
+(* The only party that can see the deviation is the OWNER: a report from a  *)
+(* sender that is not a current-plan child.  This scenario is the           *)
+(* exercise-proof for the owner-side valve.                                 *)
+(***************************************************************************)
+EXTENDS BarrierArrive
+
+MCNodes  == {0, 1, 2, 3}
+MCOwner  == 0
+MCMaxGen == 2
+
+MCPattern ==
+    [ g \in 1..2 |->
+        CASE g = 1 -> [n \in MCNodes |-> CASE n = 1 -> 1 [] n = 2 -> 1
+                                           [] OTHER -> 0 ]
+          [] g = 2 -> [n \in MCNodes |-> CASE n = 2 -> 1
+                                           [] n = 3 -> 1 [] OTHER -> 0 ] ]
+
+NoPlan == [quota |-> 0, inplan |-> FALSE, kids |-> {}]
+
+MCPlan1 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {2}]
+          [] n = 2 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCPlan2 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {3}]
+          [] n = 3 -> [quota |-> 1, inplan |-> TRUE, kids |-> {2}]
+          [] n = 2 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCNumPlans  == 2
+MCPlans     == <<MCPlan1, MCPlan2>>
+MCPlanStart == <<1, 2>>
+
+MCBaseCount == [g \in 1..MCMaxGen |->
+                  SumFn(MCNodes, [n \in MCNodes |-> MCPattern[g][n]])]
+MCAlterOps  == {}
+
+=============================================================================

--- a/tla/barrier/MCGateDemote.tla
+++ b/tla/barrier/MCGateDemote.tla
@@ -1,0 +1,76 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
+------------------------------ MODULE MCGateDemote ------------------------------
+(***************************************************************************)
+(* THE DEMOTED-RELAY STRAND: the case only the owner's NON-KID test can     *)
+(* see.  A relay is demoted from owner-child to grandchild by the new plan  *)
+(* but keeps its pinned edge to the owner for a straddling generation, so   *)
+(* its reports keep arriving at the owner - value-legal (its cumulative     *)
+(* never exceeds its own predicted subtree), never planless (so no case-3   *)
+(* or retroactive flush), yet invisible to its NEW parent, which gates on   *)
+(* a subtree that includes them.                                            *)
+(*                                                                         *)
+(*   plan 1 (gen 1)        plan 2 (gen 2)                                  *)
+(*     0                     0                                             *)
+(*     |- 1  q1              |- 3  q1                                      *)
+(*        |- 2  q1              |- 1  q1                                   *)
+(*                                 |- 2  q1                                *)
+(*                                                                         *)
+(*   g2  node 2 runs ahead under plan 1 and reports to node 1; node 1,      *)
+(*       still holding (gated), pins gen 2 to the owner and is then         *)
+(*       switched to plan 2 - where it remains a relay over node 2 but      *)
+(*       under node 3.  Its pinned forwards for gen 2 keep going to the     *)
+(*       owner; node 3 gates on quota 3 and can never complete.             *)
+(***************************************************************************)
+EXTENDS BarrierArrive
+
+MCNodes  == {0, 1, 2, 3}
+MCOwner  == 0
+MCMaxGen == 2
+
+MCPattern ==
+    [ g \in 1..2 |->
+        CASE g = 1 -> [n \in MCNodes |-> CASE n = 1 -> 1 [] n = 2 -> 1
+                                           [] OTHER -> 0 ]
+          [] g = 2 -> [n \in MCNodes |-> CASE n = 1 -> 1 [] n = 2 -> 1
+                                           [] n = 3 -> 1 [] OTHER -> 0 ] ]
+
+NoPlan == [quota |-> 0, inplan |-> FALSE, kids |-> {}]
+
+MCPlan1 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {2}]
+          [] n = 2 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCPlan2 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {3}]
+          [] n = 3 -> [quota |-> 1, inplan |-> TRUE, kids |-> {1}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {2}]
+          [] n = 2 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCNumPlans  == 2
+MCPlans     == <<MCPlan1, MCPlan2>>
+MCPlanStart == <<1, 2>>
+
+MCBaseCount == [g \in 1..MCMaxGen |->
+                  SumFn(MCNodes, [n \in MCNodes |-> MCPattern[g][n]])]
+MCAlterOps  == {}
+
+=============================================================================

--- a/tla/barrier/MCGateJump.tla
+++ b/tla/barrier/MCGateJump.tla
@@ -1,0 +1,59 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
+------------------------------ MODULE MCGateJump ------------------------------
+(***************************************************************************)
+(* THE QUOTA-JUMP CASE: why the gate is >= and never =.  Reports are        *)
+(* cumulative and REPLACE, so an accepted value can move a relay's subtree  *)
+(* total PAST its quota in one step: the over-arriving leaf's val-2 report  *)
+(* can be delivered before (or instead of) its val-1 report.  A gate that   *)
+(* tests equality never opens and the relay's own count strands - and the   *)
+(* owner valve is silent, because the aggregate it sees stays within the    *)
+(* relay's predicted subtree quota.                                         *)
+(*                                                                         *)
+(*     0                pattern g1:  node 1 -> 1   (relay, quota 1)         *)
+(*     |- 1  q1          node 2 -> 2   (over-arriving leaf)                 *)
+(*        |- 2  q1                                                          *)
+(***************************************************************************)
+EXTENDS BarrierArrive
+
+MCNodes  == {0, 1, 2}
+MCOwner  == 0
+MCMaxGen == 1
+
+MCPattern ==
+    [ g \in 1..1 |->
+        [n \in MCNodes |-> CASE n = 1 -> 1
+                             [] n = 2 -> 2
+                             [] OTHER -> 0 ] ]
+
+NoPlan == [quota |-> 0, inplan |-> FALSE, kids |-> {}]
+
+MCPlan1 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {2}]
+          [] n = 2 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCNumPlans  == 1
+MCPlans     == <<MCPlan1>>
+MCPlanStart == <<1>>
+
+MCBaseCount == [g \in 1..MCMaxGen |->
+                  SumFn(MCNodes, [n \in MCNodes |-> MCPattern[g][n]])]
+MCAlterOps  == {}
+
+=============================================================================

--- a/tla/barrier/MCGateMove.tla
+++ b/tla/barrier/MCGateMove.tla
@@ -1,0 +1,77 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
+------------------------------ MODULE MCGateMove ------------------------------
+(***************************************************************************)
+(* THE HIDDEN-DISPLACEMENT STRAND: a leaf MOVES between relays across a     *)
+(* switch and its run-ahead count ends up folded inside a LEGITIMATE        *)
+(* owner-child's aggregate.  No stale edge ever fires (the pinned edge was  *)
+(* live when used and never carries again); the owner never sees a non-kid  *)
+(* sender.  The only symptom anywhere is ARITHMETIC: the owner-child's      *)
+(* cumulative value EXCEEDS its predicted subtree quota, while the leaf's   *)
+(* new relay gates on a subtree that can never complete.                    *)
+(*                                                                         *)
+(*   plan 1 (gen 1)        plan 2 (gen 2)                                  *)
+(*     0                     0                                             *)
+(*     |- 1  q1              |- 1  q1     (keeps 1, takes 2 away from it)   *)
+(*        |- 2  q1           |- 3  q1                                      *)
+(*                              |- 2  q1                                   *)
+(*                                                                         *)
+(*   g2  node 2 runs ahead under plan 1: pins to node 1, count 1.           *)
+(*       Node 1 switches, its own arrival completes its plan-2 subtree      *)
+(*       (quota 1, no kids) PLUS the stowaway - it reports 2 where plan 2   *)
+(*       predicts 1.  Node 3 gates on quota 2 (its own + node 2's) and      *)
+(*       can never complete.  Exercise-proof for the owner's                *)
+(*       value-exceeds-subtree-quota valve.                                 *)
+(***************************************************************************)
+EXTENDS BarrierArrive
+
+MCNodes  == {0, 1, 2, 3}
+MCOwner  == 0
+MCMaxGen == 2
+
+MCPattern ==
+    [ g \in 1..2 |->
+        CASE g = 1 -> [n \in MCNodes |-> CASE n = 1 -> 1 [] n = 2 -> 1
+                                           [] OTHER -> 0 ]
+          [] g = 2 -> [n \in MCNodes |-> CASE n = 1 -> 1 [] n = 2 -> 1
+                                           [] n = 3 -> 1 [] OTHER -> 0 ] ]
+
+NoPlan == [quota |-> 0, inplan |-> FALSE, kids |-> {}]
+
+MCPlan1 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {2}]
+          [] n = 2 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCPlan2 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1, 3}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] n = 3 -> [quota |-> 1, inplan |-> TRUE, kids |-> {2}]
+          [] n = 2 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCNumPlans  == 2
+MCPlans     == <<MCPlan1, MCPlan2>>
+MCPlanStart == <<1, 2>>
+
+MCBaseCount == [g \in 1..MCMaxGen |->
+                  SumFn(MCNodes, [n \in MCNodes |-> MCPattern[g][n]])]
+MCAlterOps  == {}
+
+=============================================================================

--- a/tla/barrier/MCGateOver.tla
+++ b/tla/barrier/MCGateOver.tla
@@ -1,0 +1,63 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
+------------------------------ MODULE MCGateOver ------------------------------
+(***************************************************************************)
+(* THE GATED OVER/UNDER STRAND, minimal form.  A conserved deviation pair   *)
+(* that STRADDLES a gated relay: the under-arrival is inside the relay's    *)
+(* subtree, the over-arrival is outside it (an owner-direct leaf), so the   *)
+(* relay's subtree quota is unreachable and the over-arriver's flush fan    *)
+(* (which goes DOWN from the deviator) never touches the relay.             *)
+(*                                                                         *)
+(*        0                pattern g1:  node 1 -> 1   (relay, quota 1)      *)
+(*        |- 1  q1          node 2 -> 0   (under: relay's subtree short)    *)
+(*        |  |- 2  q1       node 3 -> 2   (over: owner-direct leaf)         *)
+(*        |- 3  q1                                                          *)
+(*                                                                         *)
+(* Without the over-arrival's count-free flush signal TO THE OWNER, nothing *)
+(* un-gates node 1 and its own count strands: deadlock.  This is the        *)
+(* exercise-proof scenario for that valve.                                  *)
+(***************************************************************************)
+EXTENDS BarrierArrive
+
+MCNodes  == {0, 1, 2, 3}
+MCOwner  == 0
+MCMaxGen == 1
+
+MCPattern ==
+    [ g \in 1..1 |->
+        [n \in MCNodes |-> CASE n = 1 -> 1
+                             [] n = 3 -> 2
+                             [] OTHER -> 0 ] ]
+
+NoPlan == [quota |-> 0, inplan |-> FALSE, kids |-> {}]
+
+MCPlan1 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1, 3}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {2}]
+          [] n = 2 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] n = 3 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCNumPlans  == 1
+MCPlans     == <<MCPlan1>>
+MCPlanStart == <<1>>
+
+MCBaseCount == [g \in 1..MCMaxGen |->
+                  SumFn(MCNodes, [n \in MCNodes |-> MCPattern[g][n]])]
+MCAlterOps  == {}
+
+=============================================================================

--- a/tla/barrier/MCGatePark.tla
+++ b/tla/barrier/MCGatePark.tla
@@ -1,0 +1,75 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
+------------------------------ MODULE MCGatePark ------------------------------
+(***************************************************************************)
+(* THE PARKED-INSTALL RE-FAN STRAND.  A relay in both plans PARKS the new   *)
+(* plan (newplan beat its invalidation), is invalidated into applying it,   *)
+(* and thereby gains a NEW child that is already gate-holding - a child     *)
+(* that was never in the old tree, so no invalidation ever flushes it, and  *)
+(* whose missing counts sit value-legal inside the relay's own aggregate    *)
+(* at the owner (no owner-valve symptom).  Only the parked install's        *)
+(* flush re-fan reaches it.                                                 *)
+(*                                                                         *)
+(*   plan 1 (gen 1)        plan 2 (gen 2)                                  *)
+(*     0                     0                                             *)
+(*     |- 1  q1              |- 1  q1                                      *)
+(*        |- 2  q1              |- 3  q1                                   *)
+(*                                 |- 2  q1                                *)
+(*                                                                         *)
+(*   g2  node 2 runs ahead under plan 1 (pins to node 1); node 1 parks      *)
+(*       plan 2, is invalidated, applies it - new kid 3 - and forwards      *)
+(*       node 2's count up its own pinned edge.  Node 3 arrives and gates   *)
+(*       on quota 2 forever unless the install re-fans the flush.           *)
+(***************************************************************************)
+EXTENDS BarrierArrive
+
+MCNodes  == {0, 1, 2, 3}
+MCOwner  == 0
+MCMaxGen == 2
+
+MCPattern ==
+    [ g \in 1..2 |->
+        CASE g = 1 -> [n \in MCNodes |-> CASE n = 1 -> 1 [] n = 2 -> 1
+                                           [] OTHER -> 0 ]
+          [] g = 2 -> [n \in MCNodes |-> CASE n = 1 -> 1 [] n = 2 -> 1
+                                           [] n = 3 -> 1 [] OTHER -> 0 ] ]
+
+NoPlan == [quota |-> 0, inplan |-> FALSE, kids |-> {}]
+
+MCPlan1 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {2}]
+          [] n = 2 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCPlan2 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {3}]
+          [] n = 3 -> [quota |-> 1, inplan |-> TRUE, kids |-> {2}]
+          [] n = 2 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCNumPlans  == 2
+MCPlans     == <<MCPlan1, MCPlan2>>
+MCPlanStart == <<1, 2>>
+
+MCBaseCount == [g \in 1..MCMaxGen |->
+                  SumFn(MCNodes, [n \in MCNodes |-> MCPattern[g][n]])]
+MCAlterOps  == {}
+
+=============================================================================

--- a/tla/barrier/MCLarge.tla
+++ b/tla/barrier/MCLarge.tla
@@ -1,0 +1,80 @@
+------------------------------ MODULE MCLarge ------------------------------
+(***************************************************************************)
+(* Six nodes, three generations, TWO pattern changes - so a node can be two *)
+(* plans behind while still holding work.                                   *)
+(*                                                                         *)
+(*   plan 1 (gen 1)        plan 2 (gen 2)        plan 3 (gen 3)             *)
+(*     0                     0                     0                        *)
+(*     |- 1  q1              |- 2  q3              |- 1  q2                 *)
+(*     |  |- 3  q2                                    |- 4  q1              *)
+(*     |- 2  q1                                                             *)
+(*                                                                         *)
+(* Node 3 is the interesting one: it expects 2 under plan 1, contributes 2  *)
+(* in generation 1, then runs ahead and issues ONE generation-3 arrival.     *)
+(* Under plan 1's quota of 2 that is silent, and plans 2 and 3 drop node 3  *)
+(* entirely - so it can only be handed over by an invalidation reaching it   *)
+(* through node 1, across two successive pattern changes.                    *)
+(*                                                                         *)
+(* Node 5 never participates at all, and node 4 appears only in plan 3.      *)
+(***************************************************************************)
+EXTENDS BarrierArrive
+
+MCNodes  == {0, 1, 2, 3, 4, 5}
+MCOwner  == 0
+MCMaxGen == 3
+
+MCPattern ==
+    [ g \in 1..3 |->
+        CASE g = 1 -> [n \in MCNodes |-> CASE n = 0 -> 0   \* matches plan 1
+                                           [] n = 1 -> 1
+                                           [] n = 2 -> 1
+                                           [] n = 3 -> 2
+                                           [] n = 4 -> 0
+                                           [] n = 5 -> 0 ]
+          [] g = 2 -> [n \in MCNodes |-> CASE n = 0 -> 0   \* matches plan 2
+                                           [] n = 1 -> 0
+                                           [] n = 2 -> 3
+                                           [] n = 3 -> 0
+                                           [] n = 4 -> 0
+                                           [] n = 5 -> 0 ]
+          [] g = 3 -> [n \in MCNodes |-> CASE n = 0 -> 0   \* node 3 runs ahead
+                                           [] n = 1 -> 2
+                                           [] n = 2 -> 0
+                                           [] n = 3 -> 1
+                                           [] n = 4 -> 1
+                                           [] n = 5 -> 0 ] ]
+
+NoPlan == [quota |-> 0, inplan |-> FALSE, kids |-> {}]
+
+MCPlan1 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1, 2}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {3}]
+          [] n = 2 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] n = 3 -> [quota |-> 2, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCPlan2 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {2}]
+          [] n = 2 -> [quota |-> 3, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCPlan3 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1}]
+          [] n = 1 -> [quota |-> 2, inplan |-> TRUE, kids |-> {4}]
+          [] n = 4 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCNumPlans  == 3
+MCPlans     == <<MCPlan1, MCPlan2, MCPlan3>>
+MCPlanStart == <<1, 2, 3>>
+
+\* No alterations in this scenario: the base count is simply every arrival the
+\*  pattern issues, so the model must reduce EXACTLY to the pre-alteration one.
+MCBaseCount == [g \in 1..MCMaxGen |->
+                  SumFn(MCNodes, [n \in MCNodes |-> MCPattern[g][n]])]
+MCAlterOps  == {}
+
+=============================================================================

--- a/tla/barrier/MCLarge.tla
+++ b/tla/barrier/MCLarge.tla
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 ------------------------------ MODULE MCLarge ------------------------------
 (***************************************************************************)
 (* Six nodes, three generations, TWO pattern changes - so a node can be two *)

--- a/tla/barrier/MCLate.tla
+++ b/tla/barrier/MCLate.tla
@@ -1,0 +1,66 @@
+------------------------------- MODULE MCLate -------------------------------
+(***************************************************************************)
+(* Tests the rule "a new plan governs only generations AFTER the one the    *)
+(* deviation was observed in".                                             *)
+(*                                                                         *)
+(*   plan 1 (gens 1-3)        plan 2 (gen 4 onward)                        *)
+(*     0                        0                                          *)
+(*     |- 1  q1                 |- 1  q1                                   *)
+(*     |  |- 3  q1              |  |- 4  q1                                *)
+(*     |- 2  q1                                                            *)
+(*                                                                         *)
+(*   g1, g2  match plan 1                                                  *)
+(*   g3      DEVIATES: node 4 arrives while in no plan (case 3)            *)
+(*   g4      matches plan 2 - and node 4, the deviating outsider, is now a *)
+(*           CHILD of node 1                                               *)
+(*                                                                         *)
+(* The switch happens at the trigger of g3, so plan 2's start (g4) is       *)
+(* strictly ABOVE the generation the deviation was seen in.  That is        *)
+(* exactly the condition the rule requires.                                *)
+(***************************************************************************)
+EXTENDS BarrierArrive
+
+MCNodes  == {0, 1, 2, 3, 4}
+MCOwner  == 0
+MCMaxGen == 4
+
+MCPattern ==
+    [ g \in 1..4 |->
+        CASE g = 1 -> [n \in MCNodes |-> CASE n = 1 -> 1 [] n = 2 -> 1
+                                           [] n = 3 -> 1 [] OTHER -> 0 ]
+          [] g = 2 -> [n \in MCNodes |-> CASE n = 1 -> 1 [] n = 2 -> 1
+                                           [] n = 3 -> 1 [] OTHER -> 0 ]
+          [] g = 3 -> [n \in MCNodes |-> CASE n = 1 -> 1 [] n = 2 -> 1
+                                           [] n = 3 -> 1
+                                           [] n = 4 -> 1   \* outsider: the deviation
+                                           [] OTHER -> 0 ]
+          [] g = 4 -> [n \in MCNodes |-> CASE n = 1 -> 1
+                                           [] n = 4 -> 1
+                                           [] OTHER -> 0 ] ]
+
+NoPlan == [quota |-> 0, inplan |-> FALSE, kids |-> {}]
+
+MCPlan1 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1, 2}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {3}]
+          [] n = 2 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] n = 3 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCPlan2 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {4}]
+          [] n = 4 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCNumPlans  == 2
+MCPlans     == <<MCPlan1, MCPlan2>>
+MCPlanStart == <<1, 4>>
+
+MCBaseCount == [g \in 1..MCMaxGen |->
+                  SumFn(MCNodes, [n \in MCNodes |-> MCPattern[g][n]])]
+MCAlterOps  == {}
+
+=============================================================================

--- a/tla/barrier/MCLate.tla
+++ b/tla/barrier/MCLate.tla
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 ------------------------------- MODULE MCLate -------------------------------
 (***************************************************************************)
 (* Tests the rule "a new plan governs only generations AFTER the one the    *)

--- a/tla/barrier/MCNotify.tla
+++ b/tla/barrier/MCNotify.tla
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 ------------------------------ MODULE MCNotify ------------------------------
 (***************************************************************************)
 (* Baseline scenario for the subscription/notification protocol.            *)

--- a/tla/barrier/MCNotify.tla
+++ b/tla/barrier/MCNotify.tla
@@ -1,0 +1,29 @@
+------------------------------ MODULE MCNotify ------------------------------
+(***************************************************************************)
+(* Baseline scenario for the subscription/notification protocol.            *)
+(*                                                                         *)
+(* Three remote nodes, three generations.  As in the arrival specs, the     *)
+(* PATTERN is scripted and only the INTERLEAVINGS are nondeterministic -    *)
+(* leaving the consultation pattern free explodes the state space without   *)
+(* covering anything the invariants can distinguish.                        *)
+(*                                                                         *)
+(*   node 1  consults gen 1, and gen 3 - a FAR-FUTURE waiter, which is what *)
+(*           makes a node look idle while it is still interested            *)
+(*   node 2  consults gen 2 (the poisoned generation)                       *)
+(*   node 3  consults gen 3 only                                            *)
+(*                                                                         *)
+(* Still nondeterministic, and deliberately so: when each node consults,    *)
+(* when a node signals departure, which subset of collected intents the     *)
+(* owner actually removes, and every message delivery order.  That covers   *)
+(* any choice of K, M, or shrink policy.                                    *)
+(***************************************************************************)
+EXTENDS BarrierNotify
+
+MCNodes      == {1, 2, 3}
+MCMaxGen     == 3
+MCPoisonGens == {2}
+MCWaitPattern == [n \in MCNodes |-> CASE n = 1 -> {1, 3}
+                                      [] n = 2 -> {2}
+                                      [] OTHER -> {3} ]
+
+=============================================================================

--- a/tla/barrier/MCNotifyBig.tla
+++ b/tla/barrier/MCNotifyBig.tla
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 ----------------------------- MODULE MCNotifyBig -----------------------------
 (***************************************************************************)
 (* Four remote nodes, three generations - one more node than MCNotify.         *)

--- a/tla/barrier/MCNotifyBig.tla
+++ b/tla/barrier/MCNotifyBig.tla
@@ -1,0 +1,25 @@
+----------------------------- MODULE MCNotifyBig -----------------------------
+(***************************************************************************)
+(* Four remote nodes, three generations - one more node than MCNotify.         *)
+(* them the LAST, so a poison snapshot has to survive a set change.         *)
+(*                                                                         *)
+(* NOTE: this scenario DOES NOT CONVERGE - it was still climbing past 47M   *)
+(* distinct states with a growing queue and was abandoned.  Kept as the      *)
+(* record of where the ceiling is: three remote nodes.                       *)
+(*                                                                         *)
+(*   node 1  gens 1 and 3  - far-future waiter across two generations       *)
+(*   node 2  gens 2 and 3  - consults on both poisoned and clean gens       *)
+(*   node 3  gen 4 only    - joins late, after the set has already shrunk   *)
+(*   node 4  gens 1 and 2  - departs early, then comes back                 *)
+(***************************************************************************)
+EXTENDS BarrierNotify
+
+MCNodes      == {1, 2, 3, 4}
+MCMaxGen     == 3
+MCPoisonGens == {2}
+MCWaitPattern == [n \in MCNodes |-> CASE n = 1 -> {1, 3}
+                                      [] n = 2 -> {2, 3}
+                                      [] n = 3 -> {3}
+                                      [] OTHER -> {1, 2} ]
+
+=============================================================================

--- a/tla/barrier/MCNotifySmall.tla
+++ b/tla/barrier/MCNotifySmall.tla
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 --------------------------- MODULE MCNotifySmall ---------------------------
 (***************************************************************************)
 (* Two remote nodes, three generations, one poisoned - small enough that a  *)

--- a/tla/barrier/MCNotifySmall.tla
+++ b/tla/barrier/MCNotifySmall.tla
@@ -1,0 +1,26 @@
+--------------------------- MODULE MCNotifySmall ---------------------------
+(***************************************************************************)
+(* Two remote nodes, three generations, one poisoned - small enough that a  *)
+(* GUARD-REMOVAL mutation still terminates.  Removing a guard ENLARGES the  *)
+(* reachable state space rather than shrinking it, so clearing a mutation   *)
+(* as benign costs far more than catching one; the full MCNotify scenario   *)
+(* is out of reach for that purpose.                                        *)
+(*                                                                         *)
+(* This is the scenario behind the battery's one deliberate negative        *)
+(* control: removing Depart's waiting[n] = {} guard is NOT caught, because  *)
+(* rule 6's re-subscribe recovery is the correctness rule and the guard is  *)
+(* only an optimisation.  It has teeth - it catches the gap, no-recovery    *)
+(* and discretionary-adds mutations - so its clean verdict is meaningful.   *)
+(*                                                                         *)
+(*   node 1  gens 1 and 3  - far-future waiter                             *)
+(*   node 2  gens 2 and 3  - consults the poisoned generation              *)
+(***************************************************************************)
+EXTENDS BarrierNotify
+
+MCNodes      == {1, 2}
+MCMaxGen     == 3
+MCPoisonGens == {2}
+MCWaitPattern == [n \in MCNodes |-> CASE n = 1 -> {1, 3}
+                                      [] OTHER -> {2, 3} ]
+
+=============================================================================

--- a/tla/barrier/MCOver.tla
+++ b/tla/barrier/MCOver.tla
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 ------------------------------- MODULE MCOver -------------------------------
 (***************************************************************************)
 (* ISOLATES CASE 2 - the eager flush on over-arrival.                       *)

--- a/tla/barrier/MCOver.tla
+++ b/tla/barrier/MCOver.tla
@@ -1,0 +1,56 @@
+------------------------------- MODULE MCOver -------------------------------
+(***************************************************************************)
+(* ISOLATES CASE 2 - the eager flush on over-arrival.                       *)
+(*                                                                         *)
+(* In MCDeviate the over-arrival and the outsider both happened in the same *)
+(* generation, and the outsider's direct report made the OWNER announce a   *)
+(* flush.  That flush reached the over-arriving node and let it proceed     *)
+(* through the "already flushing" branch, so case 2 was never the thing     *)
+(* actually under test.  Here the over-arrival is the only deviation.       *)
+(*                                                                         *)
+(*     0 = owner                                                            *)
+(*     |- 1  quota 1                                                        *)
+(*     |  |- 3  quota 2                                                     *)
+(*     |- 2  quota 1   <- arrives 3 times in generation 2                   *)
+(*     4 is in no plan and never arrives                                    *)
+(***************************************************************************)
+EXTENDS BarrierArrive
+
+MCNodes  == {0, 1, 2, 3, 4}
+MCOwner  == 0
+MCMaxGen == 2
+
+MCPattern ==
+    [ g \in 1..2 |->
+        IF g = 1 THEN [n \in MCNodes |-> CASE n = 0 -> 0
+                                           [] n = 1 -> 1
+                                           [] n = 2 -> 1
+                                           [] n = 3 -> 2
+                                           [] n = 4 -> 0 ]
+                 ELSE [n \in MCNodes |-> CASE n = 0 -> 0
+                                           [] n = 1 -> 1
+                                           [] n = 2 -> 3
+                                           [] n = 3 -> 2
+                                           [] n = 4 -> 0 ] ]
+
+NoPlan == [quota |-> 0, inplan |-> FALSE, kids |-> {}]
+
+MCPlan1 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1, 2}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {3}]
+          [] n = 2 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] n = 3 -> [quota |-> 2, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCNumPlans  == 1
+MCPlans     == <<MCPlan1>>
+MCPlanStart == <<1>>
+
+\* No alterations in this scenario: the base count is simply every arrival the
+\*  pattern issues, so the model must reduce EXACTLY to the pre-alteration one.
+MCBaseCount == [g \in 1..MCMaxGen |->
+                  SumFn(MCNodes, [n \in MCNodes |-> MCPattern[g][n]])]
+MCAlterOps  == {}
+
+=============================================================================

--- a/tla/barrier/MCOverSwitch.tla
+++ b/tla/barrier/MCOverSwitch.tla
@@ -1,0 +1,53 @@
+---------------------------- MODULE MCOverSwitch ----------------------------
+(***************************************************************************)
+(* OVER-ARRIVAL combined with a PLAN SWITCH - the one structural            *)
+(* combination that lived only in the scenarios that outgrew this machine   *)
+(* (MCLarge/MCLate/MCDeepSwitch on the final spec).  MCStale-sized.         *)
+(*                                                                         *)
+(*   plan 1 (gen 1)        plan 2 (gen 2)                                  *)
+(*     0                     0                                             *)
+(*     |- 1  q1              |- 1  q1                                      *)
+(*        |- 2  q1                                                         *)
+(*                                                                         *)
+(*   g1  matches plan 1                                                    *)
+(*   g2  node 1 OVER-ARRIVES its plan-2 quota (2 vs 1), and node 2 - kept   *)
+(*       by no plan - runs ahead into g2 while still holding plan 1.        *)
+(***************************************************************************)
+EXTENDS BarrierArrive
+
+MCNodes  == {0, 1, 2}
+MCOwner  == 0
+MCMaxGen == 2
+
+MCPattern ==
+    [ g \in 1..2 |->
+        CASE g = 1 -> [n \in MCNodes |-> CASE n = 1 -> 1 [] n = 2 -> 1
+                                           [] OTHER -> 0 ]
+          [] g = 2 -> [n \in MCNodes |-> CASE n = 1 -> 2   \* over-arrival (quota 1)
+                                           [] n = 2 -> 1   \* runs ahead, then dropped
+                                           [] OTHER -> 0 ] ]
+
+NoPlan == [quota |-> 0, inplan |-> FALSE, kids |-> {}]
+
+MCPlan1 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {2}]
+          [] n = 2 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCPlan2 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCNumPlans  == 2
+MCPlans     == <<MCPlan1, MCPlan2>>
+MCPlanStart == <<1, 2>>
+
+MCBaseCount == [g \in 1..MCMaxGen |->
+                  SumFn(MCNodes, [n \in MCNodes |-> MCPattern[g][n]])]
+MCAlterOps  == {}
+
+=============================================================================

--- a/tla/barrier/MCOverSwitch.tla
+++ b/tla/barrier/MCOverSwitch.tla
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 ---------------------------- MODULE MCOverSwitch ----------------------------
 (***************************************************************************)
 (* OVER-ARRIVAL combined with a PLAN SWITCH - the one structural            *)

--- a/tla/barrier/MCPark.tla
+++ b/tla/barrier/MCPark.tla
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 ------------------------------- MODULE MCPark -------------------------------
 (***************************************************************************)
 (* Why the DEFERRAL exists, isolated.  A node that installs a new plan      *)

--- a/tla/barrier/MCPark.tla
+++ b/tla/barrier/MCPark.tla
@@ -1,0 +1,60 @@
+------------------------------- MODULE MCPark -------------------------------
+(***************************************************************************)
+(* Why the DEFERRAL exists, isolated.  A node that installs a new plan      *)
+(* before its invalidation arrives forwards that invalidation down the NEW  *)
+(* kid list - so an old-plan descendant never receives it.  Only a          *)
+(* descendant holding BELOW QUOTA exposes that: one whose quota is met      *)
+(* reports on its own and needs no invalidation.  MCStrand2's descendants   *)
+(* all meet their quotas, which is why it cannot catch the no-deferral and  *)
+(* forget-before-forward mutations.  Here node 2 under-fills its quota and  *)
+(* an outsider provides the offset.                                         *)
+(*                                                                         *)
+(*   plan 1 (gen 1)        plan 2 (gen 2)                                  *)
+(*     0                     0                                             *)
+(*     |- 1  q1              |- 1  q1                                      *)
+(*        |- 2  q2              |- 3  q1                                   *)
+(*                                                                         *)
+(*   g1  matches plan 1 (node 2 arrives twice)                             *)
+(*   g2  node 2 runs ahead with ONE arrival (quota 2 - silent), node 3     *)
+(*       arrives as plan-2 member, node 1 arrives once.                    *)
+(***************************************************************************)
+EXTENDS BarrierArrive
+
+MCNodes  == {0, 1, 2, 3}
+MCOwner  == 0
+MCMaxGen == 2
+
+MCPattern ==
+    [ g \in 1..2 |->
+        CASE g = 1 -> [n \in MCNodes |-> CASE n = 1 -> 1 [] n = 2 -> 2
+                                           [] OTHER -> 0 ]
+          [] g = 2 -> [n \in MCNodes |-> CASE n = 1 -> 1
+                                           [] n = 2 -> 1   \* below its plan-1 quota
+                                           [] n = 3 -> 1
+                                           [] OTHER -> 0 ] ]
+
+NoPlan == [quota |-> 0, inplan |-> FALSE, kids |-> {}]
+
+MCPlan1 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {2}]
+          [] n = 2 -> [quota |-> 2, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCPlan2 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {3}]
+          [] n = 3 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCNumPlans  == 2
+MCPlans     == <<MCPlan1, MCPlan2>>
+MCPlanStart == <<1, 2>>
+
+MCBaseCount == [g \in 1..MCMaxGen |->
+                  SumFn(MCNodes, [n \in MCNodes |-> MCPattern[g][n]])]
+MCAlterOps  == {}
+
+=============================================================================

--- a/tla/barrier/MCPlanned.tla
+++ b/tla/barrier/MCPlanned.tla
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 ----------------------------- MODULE MCPlanned -----------------------------
 (***************************************************************************)
 (* A ONE-GENERATION model of the same topology as MCArrival, used for the   *)

--- a/tla/barrier/MCPlanned.tla
+++ b/tla/barrier/MCPlanned.tla
@@ -1,0 +1,44 @@
+----------------------------- MODULE MCPlanned -----------------------------
+(***************************************************************************)
+(* A ONE-GENERATION model of the same topology as MCArrival, used for the   *)
+(* liveness runs and for the transport-duplication stress runs.             *)
+(*                                                                         *)
+(* Liveness checking in TLC costs roughly 10-100x what safety costs, so the *)
+(* liveness configuration drops the second generation.  What is lost is     *)
+(* only the pipelining / trigger-ordering dimension, which is a safety      *)
+(* property (TriggerInOrder) and is checked at G=2 by the safety runs.      *)
+(*                                                                         *)
+(* Topology (N = 4, R = 2, RootId = 0), relative indices:                   *)
+(*                                                                         *)
+(*         0            <- logical root, Kids(0) = {1,2}                    *)
+(*        / \                                                              *)
+(*       1   2          <- Kids(1) = {3}, Kids(2) = {}                      *)
+(*       |                                                                 *)
+(*       3                                                                 *)
+(*                                                                         *)
+(* The single generation is frozen onto a learned plan whose quotas are     *)
+(*     node 2 -> 1,  node 3 -> 2   (subtree totals 1 and 2, root total 3)   *)
+(* but the application REDISTRIBUTES:                                       *)
+(*     node 2 arrives twice,  node 3 arrives once                           *)
+(* The total is unchanged at 3, so this is exactly the "valid              *)
+(* redistribution" of plan section 13.2: node 2 overshoots its quota (a     *)
+(* detectable positive deviation) and node 3 is underfull (silent).         *)
+(*                                                                         *)
+(* Setting PlannedGens = {} in the .cfg turns the same scenario into a      *)
+(* purely DYNAMIC generation (plan section 11), which is how the dynamic    *)
+(* protocol is liveness-checked on its own.                                 *)
+(***************************************************************************)
+EXTENDS BarrierArrival
+
+ArrDef ==
+    [ g \in Gens |-> [ n \in Nodes |-> CASE n = 2 -> 2 [] n = 3 -> 1
+                                         [] OTHER -> 0 ] ]
+
+ExpectedDef == [ g \in Gens |-> 3 ]
+
+QuotaDef       == [ n \in Nodes |-> CASE n = 2 -> 1 [] n = 3 -> 2 [] OTHER -> 0 ]
+PlannedKidsDef == [ n \in Nodes |-> CASE n = 0 -> {1, 2} [] n = 1 -> {3} [] OTHER -> {} ]
+PTotalDef      == [ n \in Nodes |-> CASE n = 0 -> 3 [] n = 1 -> 2
+                                      [] n = 2 -> 1 [] OTHER -> 2 ]
+
+============================================================================

--- a/tla/barrier/MCSeven.tla
+++ b/tla/barrier/MCSeven.tla
@@ -1,0 +1,83 @@
+------------------------------ MODULE MCSeven ------------------------------
+(***************************************************************************)
+(* Seven nodes, depth 3, three generations, three plans - sized so the full *)
+(* mutation battery is still affordable.                                    *)
+(*                                                                         *)
+(* The state space is driven by ARRIVAL INTERLEAVINGS, not by node count on *)
+(* its own: every individual arrive() is a separate action, so total        *)
+(* arrivals across all generations is the number that matters.  This        *)
+(* scenario uses 12 where MCBig3 used 16, which is what makes it tractable  *)
+(* at one more node than MCLarge.                                           *)
+(*                                                                         *)
+(*   plan 1 (gen 1)        plan 2 (gen 2)        plan 3 (gen 3)             *)
+(*     0                     0                     0                        *)
+(*     |- 1  q1              |- 2  q1              |- 1  q1                 *)
+(*     |  |- 3  q2           |  |- 5  q1           |  |- 6  q1              *)
+(*     |- 2  q1                                                             *)
+(*        |- 4  q1                                                          *)
+(*                                                                         *)
+(*   g1  matches plan 1                       -> steady state               *)
+(*   g2  DISAGREES with plan 2: node 2 over-arrives (case 2) and node 6     *)
+(*       arrives while in no plan (case 3)                                  *)
+(*   g3  matches plan 3, except node 3 runs ahead while still on plan 1,    *)
+(*       where its quota of 2 keeps it silent - so reaching it needs an     *)
+(*       invalidation across two pattern changes and two hops.              *)
+(***************************************************************************)
+EXTENDS BarrierArrive
+
+MCNodes  == {0, 1, 2, 3, 4, 5, 6}
+MCOwner  == 0
+MCMaxGen == 3
+
+MCPattern ==
+    [ g \in 1..3 |->
+        CASE g = 1 -> [n \in MCNodes |-> CASE n = 1 -> 1
+                                           [] n = 2 -> 1
+                                           [] n = 3 -> 2
+                                           [] n = 4 -> 1
+                                           [] OTHER -> 0 ]
+          [] g = 2 -> [n \in MCNodes |-> CASE n = 2 -> 2     \* over-arrival (quota 1)
+                                           [] n = 5 -> 1
+                                           [] n = 6 -> 1     \* outsider
+                                           [] OTHER -> 0 ]
+          [] g = 3 -> [n \in MCNodes |-> CASE n = 1 -> 1
+                                           [] n = 6 -> 1
+                                           [] n = 3 -> 1     \* runs ahead
+                                           [] OTHER -> 0 ] ]
+
+NoPlan == [quota |-> 0, inplan |-> FALSE, kids |-> {}]
+
+MCPlan1 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1, 2}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {3}]
+          [] n = 2 -> [quota |-> 1, inplan |-> TRUE, kids |-> {4}]
+          [] n = 3 -> [quota |-> 2, inplan |-> TRUE, kids |-> {}]
+          [] n = 4 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCPlan2 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {2}]
+          [] n = 2 -> [quota |-> 1, inplan |-> TRUE, kids |-> {5}]
+          [] n = 5 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCPlan3 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {6}]
+          [] n = 6 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCNumPlans  == 3
+MCPlans     == <<MCPlan1, MCPlan2, MCPlan3>>
+MCPlanStart == <<1, 2, 3>>
+
+\* No alterations in this scenario: the base count is simply every arrival the
+\*  pattern issues, so the model must reduce EXACTLY to the pre-alteration one.
+MCBaseCount == [g \in 1..MCMaxGen |->
+                  SumFn(MCNodes, [n \in MCNodes |-> MCPattern[g][n]])]
+MCAlterOps  == {}
+
+=============================================================================

--- a/tla/barrier/MCSeven.tla
+++ b/tla/barrier/MCSeven.tla
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 ------------------------------ MODULE MCSeven ------------------------------
 (***************************************************************************)
 (* Seven nodes, depth 3, three generations, three plans - sized so the full *)

--- a/tla/barrier/MCStale.tla
+++ b/tla/barrier/MCStale.tla
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 ------------------------------- MODULE MCStale -------------------------------
 (***************************************************************************)
 (* The STALE-EDGE case in its minimal form: a pinned report arrives at a    *)

--- a/tla/barrier/MCStale.tla
+++ b/tla/barrier/MCStale.tla
@@ -1,0 +1,59 @@
+------------------------------- MODULE MCStale -------------------------------
+(***************************************************************************)
+(* The STALE-EDGE case in its minimal form: a pinned report arrives at a    *)
+(* node AFTER it installed a live plan that dropped the sender.             *)
+(*                                                                         *)
+(*   plan 1 (gen 1)        plan 2 (gen 2)                                  *)
+(*     0                     0                                             *)
+(*     |- 1  q1              |- 1  q1                                      *)
+(*        |- 2  q1              |- 3  q1                                   *)
+(*                                                                         *)
+(*   g1  matches plan 1                                                    *)
+(*   g2  node 2 runs ahead and arrives while still on plan 1 - its report  *)
+(*       pins to node 1 and can be SLOW; node 3 arrives as plan-2 member.  *)
+(*       Node 1 never arrives on g2, so its plan-2 quota is unreachable    *)
+(*       and without stale-edge forwarding it holds node 2's report        *)
+(*       forever.                                                          *)
+(*                                                                         *)
+(* NOTE the holder stays REACHABLE (it is in plan 2), so this strand is     *)
+(* caught by DEADLOCK DETECTION, not ReachableWhileHolding - which is       *)
+(* exactly why no other scenario caught the stale-edge mutation.            *)
+(***************************************************************************)
+EXTENDS BarrierArrive
+
+MCNodes  == {0, 1, 2, 3}
+MCOwner  == 0
+MCMaxGen == 2
+
+MCPattern ==
+    [ g \in 1..2 |->
+        CASE g = 1 -> [n \in MCNodes |-> CASE n = 1 -> 1 [] n = 2 -> 1
+                                           [] OTHER -> 0 ]
+          [] g = 2 -> [n \in MCNodes |-> CASE n = 2 -> 1   \* runs ahead, then dropped
+                                           [] n = 3 -> 1 [] OTHER -> 0 ] ]
+
+NoPlan == [quota |-> 0, inplan |-> FALSE, kids |-> {}]
+
+MCPlan1 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {2}]
+          [] n = 2 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCPlan2 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {3}]
+          [] n = 3 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCNumPlans  == 2
+MCPlans     == <<MCPlan1, MCPlan2>>
+MCPlanStart == <<1, 2>>
+
+MCBaseCount == [g \in 1..MCMaxGen |->
+                  SumFn(MCNodes, [n \in MCNodes |-> MCPattern[g][n]])]
+MCAlterOps  == {}
+
+=============================================================================

--- a/tla/barrier/MCStrand.tla
+++ b/tla/barrier/MCStrand.tla
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 ------------------------------ MODULE MCStrand ------------------------------
 (***************************************************************************)
 (* The STRANDING that per-generation pinning introduces, minimally.         *)

--- a/tla/barrier/MCStrand.tla
+++ b/tla/barrier/MCStrand.tla
@@ -1,0 +1,57 @@
+------------------------------ MODULE MCStrand ------------------------------
+(***************************************************************************)
+(* The STRANDING that per-generation pinning introduces, minimally.         *)
+(* MCDeepSwitch shows it at millions of states; this shows it at thousands. *)
+(*                                                                         *)
+(*   plan 1 (gen 1)        plan 2 (gen 2)                                  *)
+(*     0                     0                                             *)
+(*     |- 1  q1              |- 3  q1                                      *)
+(*        |- 2  q1                                                         *)
+(*                                                                         *)
+(* Nodes 1 AND 2 are dropped entirely by plan 2.                            *)
+(*                                                                         *)
+(*   1. node 2 runs ahead and arrives on g2 while still on plan 1; its      *)
+(*      quota is met so it reports to node 1 and PINS that edge for g2      *)
+(*   2. the plan switches; node 1 is invalidated, flushes what it holds     *)
+(*      (nothing for g2 yet) and gets no replacement plan                   *)
+(*   3. node 2's report reaches node 1 afterwards.  Node 1 is below its own *)
+(*      quota, is no longer flushing because the switch cleared it, and is  *)
+(*      no longer reachable from the owner - plan 2's tree goes elsewhere   *)
+(***************************************************************************)
+EXTENDS BarrierArrive
+
+MCNodes  == {0, 1, 2, 3}
+MCOwner  == 0
+MCMaxGen == 2
+
+MCPattern ==
+    [ g \in 1..2 |->
+        CASE g = 1 -> [n \in MCNodes |-> CASE n = 1 -> 1 [] n = 2 -> 1
+                                           [] OTHER -> 0 ]
+          [] g = 2 -> [n \in MCNodes |-> CASE n = 2 -> 1   \* runs ahead, then orphaned
+                                           [] n = 3 -> 1 [] OTHER -> 0 ] ]
+
+NoPlan == [quota |-> 0, inplan |-> FALSE, kids |-> {}]
+
+MCPlan1 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {2}]
+          [] n = 2 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCPlan2 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {3}]
+          [] n = 3 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCNumPlans  == 2
+MCPlans     == <<MCPlan1, MCPlan2>>
+MCPlanStart == <<1, 2>>
+
+MCBaseCount == [g \in 1..MCMaxGen |->
+                  SumFn(MCNodes, [n \in MCNodes |-> MCPattern[g][n]])]
+MCAlterOps  == {}
+
+=============================================================================

--- a/tla/barrier/MCStrand2.tla
+++ b/tla/barrier/MCStrand2.tla
@@ -1,0 +1,69 @@
+------------------------------ MODULE MCStrand2 ------------------------------
+(***************************************************************************)
+(* The STRANDING that per-generation pinning introduces, minimally.         *)
+(* MCDeepSwitch shows it at millions of states; this shows it at thousands. *)
+(*                                                                         *)
+(*   plan 1 (gen 1)        plan 2 (gen 2)                                  *)
+(*     0                     0                                             *)
+(*     |- 1  q1              |- 3  q1                                      *)
+(*        |- 2  q1                                                         *)
+(*                                                                         *)
+(* Nodes 1 AND 2 are dropped entirely by plan 2.                            *)
+(*                                                                         *)
+(*   1. node 2 runs ahead and arrives on g2 while still on plan 1; its      *)
+(*      quota is met so it reports to node 1 and PINS that edge for g2      *)
+(*   2. the plan switches; node 1 is invalidated, flushes what it holds     *)
+(*      (nothing for g2 yet) and gets no replacement plan                   *)
+(*   3. node 2's report reaches node 1 afterwards.  Node 1 is below its own *)
+(*      quota, is no longer flushing because the switch cleared it, and is  *)
+(*      no longer reachable from the owner - plan 2's tree goes elsewhere   *)
+(***************************************************************************)
+EXTENDS BarrierArrive
+
+MCNodes  == {0, 1, 2, 3}
+MCOwner  == 0
+MCMaxGen == 3
+
+MCPattern ==
+    [ g \in 1..3 |->
+        CASE g = 1 -> [n \in MCNodes |-> CASE n = 1 -> 1 [] n = 2 -> 1
+                                           [] OTHER -> 0 ]
+          [] g = 2 -> [n \in MCNodes |-> CASE n = 1 -> 1
+                                           [] n = 3 -> 1 [] OTHER -> 0 ]
+          [] g = 3 -> [n \in MCNodes |-> CASE n = 2 -> 1
+                                           [] n = 3 -> 1   \* runs ahead, then orphaned
+                                           [] OTHER -> 0 ] ]
+
+NoPlan == [quota |-> 0, inplan |-> FALSE, kids |-> {}]
+
+MCPlan1 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {2}]
+          [] n = 2 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+\* node 1 is still a RELAY here, with node 3 beneath it
+MCPlan2 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {1}]
+          [] n = 1 -> [quota |-> 1, inplan |-> TRUE, kids |-> {3}]
+          [] n = 3 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+\* ...and only NOW is node 1 dropped, after node 3 has pinned to it
+MCPlan3 ==
+    [n \in MCNodes |->
+        CASE n = 0 -> [quota |-> 0, inplan |-> TRUE, kids |-> {2}]
+          [] n = 2 -> [quota |-> 1, inplan |-> TRUE, kids |-> {}]
+          [] OTHER  -> NoPlan ]
+
+MCNumPlans  == 3
+MCPlans     == <<MCPlan1, MCPlan2, MCPlan3>>
+MCPlanStart == <<1, 2, 3>>
+
+MCBaseCount == [g \in 1..MCMaxGen |->
+                  SumFn(MCNodes, [n \in MCNodes |-> MCPattern[g][n]])]
+MCAlterOps  == {}
+
+=============================================================================

--- a/tla/barrier/MCStrand2.tla
+++ b/tla/barrier/MCStrand2.tla
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 ------------------------------ MODULE MCStrand2 ------------------------------
 (***************************************************************************)
 (* The STRANDING that per-generation pinning introduces, minimally.         *)

--- a/tla/barrier/NOTIFICATION_PROTOCOL.md
+++ b/tla/barrier/NOTIFICATION_PROTOCOL.md
@@ -1,3 +1,20 @@
+<!--
+Copyright 2026 Stanford University, NVIDIA Corporation
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Realm Scalable Barriers — Subscription / Notification Protocol
 
 **Status: design frozen, formally verified.** Companion to

--- a/tla/barrier/NOTIFICATION_PROTOCOL.md
+++ b/tla/barrier/NOTIFICATION_PROTOCOL.md
@@ -277,7 +277,13 @@ explicitly **not** `has_triggered`, which must stay lock-free.
 - Measured as watermark delta since last consultation, so it is robust to the
   owner coalescing several triggers into one notification.
 - K adapts by doubling on observed churn (a leave→rejoin within a short window),
-  which is also the metric worth exporting.
+  which is also the metric worth exporting. The window must be measured on an
+  **honest clock**: a departed node receives no notifications, so its own
+  watermark freezes at the depart point and would read every return as churn.
+  A voluntary-consult rejoin is therefore judged against the **subscribe
+  reply's watermark**, not the local one; the forced rule-6 re-subscribe may
+  judge locally, because the removal notification it just processed carried
+  the current watermark.
 - Departures are **unicast to the owner**, staggered by `K + (node_id mod J)`
   with **J ≈ 16–32**. Phase changes retire many nodes at once, so the stagger is
   load-bearing rather than defensive. J is sized for spike smoothing, not

--- a/tla/barrier/NOTIFICATION_PROTOCOL.md
+++ b/tla/barrier/NOTIFICATION_PROTOCOL.md
@@ -1,0 +1,510 @@
+# Realm Scalable Barriers — Subscription / Notification Protocol
+
+**Status: design frozen, formally verified.** Companion to
+[`ARRIVAL_PROTOCOL.md`](ARRIVAL_PROTOCOL.md). `BarrierNotify.tla` in this
+directory is the formal specification; where this prose and the spec disagree,
+**the spec wins** — it is the artifact that was model-checked.
+
+Written for whoever implements this in C++. Same shape as the arrival document:
+what the protocol is, why each rule exists, where it lives in the TLA+ source,
+what was verified, and where the model deliberately isn't the implementation.
+
+---
+
+## 1. Scope
+
+**In scope:** how the owner tells the rest of the machine that a barrier
+generation has triggered, and which generations were poisoned, without O(N) fan
+out from one node and without O(N) per-barrier state.
+
+**Out of scope, deliberately:**
+
+| Excluded | Reason |
+|---|---|
+| Message loss | The transport is reliable (user decision) |
+| **Reduction barriers** | **Fall back to the existing non-scalable path entirely** (user decision) |
+| Node failure | No fault model |
+| Barrier migration | Being removed as part of this work (user decision) |
+| The multicast tree itself | Separately implemented; delivers to exactly the encoded set |
+
+Reduction barriers being excluded is load-bearing, not incidental. Per-generation
+reduction values cannot be re-derived from a watermark, so they would break the
+delta scheme in §5. Keeping them on the legacy path means the scalable path never
+grows `held_triggers`, `final_values`, or generation buffering.
+
+---
+
+## 2. Why this half is easier
+
+Arrivals must be exact: a lost arrival means the generation never triggers, and
+silence is fatal. Notification is best-effort, because **a node that isn't told
+pulls, and the owner answers.** The pull is the correctness guarantee; the
+broadcast set is a cache.
+
+What that buys, precisely:
+
+| Imprecision | Safe? | Cost |
+|---|---|---|
+| Node not notified | ✅ *if it pulls* | one round trip |
+| Node notified that never asked | ✅ | bandwidth |
+| Duplicate or reordered notification | ✅ | none — see the gap rule |
+| Stale broadcast set | ✅ | suboptimal fan-out |
+| **Watermark reported too high** | ❌ | waiter proceeds early |
+| **Waiter woken with wrong poison status** | ❌ | silent corruption |
+| **Pull lost or misrouted** | ❌ | hang — no second fallback |
+
+The last three are why this still needed a spec. In particular the poison one is
+subtle and is what the gap rule exists for.
+
+---
+
+## 3. State
+
+From `BarrierNotify.tla:56-69`. The owner is modelled as the owner-side
+variables rather than as a node.
+
+**Owner:**
+
+| Model variable | Meaning |
+|---|---|
+| `watermark` | highest triggered generation |
+| `subSet` | the subscriber set, in the multicast codec's encodings |
+| `setVer` | version, bumped on **every** change to `subSet` |
+| `wantOut` | departure requests received but not yet applied |
+
+Poison is not owner state in the model — it is derived from the `PoisonGens`
+constant. In the implementation the owner retains the poisoned-generation set
+over `[first_generation, watermark]`, since a new subscriber must be told all of
+it (§5, rule 3).
+
+**Per node:**
+
+| Model variable | Meaning |
+|---|---|
+| `known[n]` | this node's known watermark |
+| `knownPois[n]` | poisoned generations it knows about |
+| `member[n]` | `NO` / `PENDING` / `YES` — belief about its own membership |
+| `myVer[n]` | highest `setVer` it has applied |
+| `waiting[n]` | generations it still needs |
+
+**There is no learned notification tree and no per-node map at the owner.** The
+multicast layer plans a fresh forwarding tree from the encoded set on every send,
+so a set change can never leave a stale tree behind — which is why this protocol
+needs none of the invalidation machinery the arrival one does.
+
+### What this deletes from the current implementation
+
+- **`remote_trigger_gens`** — the per-node O(N) map. It exists only to compute
+  each node's individual gap. With deltas plus the gap rule, each receiver
+  computes its own. Gone, and with it the O(N²) across N barriers.
+- **`held_triggers` buffering** — a notification arriving with a gap is currently
+  buffered until the gap fills. Now it is discarded and the node pulls. **Note
+  `previous_gen` itself stays** — it is exactly the gap-detection field.
+- **Barrier migration** and `migration_target` on the wire.
+
+`base_arrival_count` moves to the arrival-plan dissemination path; it rides the
+notification today only as a lazy-init channel for nodes with no local
+`BarrierImpl`. **A barrier always has a non-zero arrival count, so `0` is an
+unambiguous "not yet known" sentinel** — document that invariant at the field,
+because it is the only thing making the sentinel safe.
+
+---
+
+## 4. Messages
+
+`BarrierNotify.tla:71-76`.
+
+| Kind | Fields | Purpose |
+|---|---|---|
+| `notify` | `to, wm, prev, pois, inset, sv` | multicast: generations `(prev, wm]` triggered, which of them are poisoned, recipient's membership, set version |
+| `subscribe` | `from, lk` | pull; `lk` is the sender's last-known generation |
+| `reply` | `to, wm, pois, sv` | answer: watermark plus poison in `(lk, wm]` |
+
+`msgs` is a **set**, so TLC explores every delivery reordering. That matters —
+Realm's network backends are explicitly permitted to reorder active messages
+between the same pair of nodes, and two of the four protocol defects found during
+design were reordering hazards.
+
+---
+
+## 5. The protocol rules
+
+Eight rules. Seven have a mutation that a validated check catches; the eighth is
+verified *not* to matter, and is documented as an optimization so nobody later
+mistakes it for a safety property.
+
+### Rule 1 — Membership is published, never self-decided
+
+`BarrierNotify.tla:147-151` (notify), `:194-200` (reply).
+
+> **The owner's published set is authoritative, and any shrink must be published
+> to the PRE-shrink set.**
+
+A node never concludes its own membership. It reads it off publications, which
+ride the notification going out anyway. Because a removal is always announced to
+the membership that still contains the departing node, nobody is silently
+dropped.
+
+This is what removes the subscribe/unsubscribe reorder hazard *structurally*,
+rather than serialising around it with an acknowledgement handshake.
+
+### Rule 2 — Membership updates are version gated
+
+`BarrierNotify.tla:147-151`, `:194-200`.
+
+```tla
+newv == m.sv > myVer[m.to]
+mem0 == IF newv THEN (IF m.inset THEN "YES" ELSE "NO") ELSE member[m.to]
+```
+
+**This is not optional.** TLC found the failure in the first second of the first
+run: a removal at generation 3 is applied, then an older in-flight notification
+from generation 2 sets `member = YES` again. The node then believes it is covered
+while the owner has dropped it, never subscribes, and hangs on its next wait.
+
+`setVer` is bumped at both places the set can change — on shrink in `Trigger`
+(`:100`) and on add in `RecvSubscribe` (`:177`) — and stamped onto every
+notification and reply. The same gate is required on the reply path; a stale
+reply resurrects membership exactly the same way.
+
+### Rule 3 — Adds are mandatory, removals are discretionary
+
+`BarrierNotify.tla:178` — `subSet' = subSet \cup {m.from}`, unconditionally.
+
+Refusing an add strands a waiter. Refusing a removal only costs bandwidth. That
+asymmetry is what lets the owner apply a cost test to shrinks (encode the set
+with and without the departing nodes, compare bytes and deliveries) and decline
+the ones that don't pay — **dropping scattered nodes from `ALL_NODES` can turn a
+0-byte encoding into a per-hop bitmap.** A declined removal is simply a
+publication in which the node still appears.
+
+### Rule 4 — Notifications are deltas, and a delta with a gap is discarded
+
+`BarrierNotify.tla:142-143`.
+
+```tla
+gap   == m.prev > known[m.to]
+fresh == (~gap) /\ (m.wm > known[m.to])
+```
+
+A notification carries `(prev, wm]` and the poison **within that range only**, so
+its size never grows with the barrier's poison history. That was the last
+unbounded quantity in the design.
+
+The cost is gap sensitivity, and it is a real hazard rather than a theoretical
+one. Active messages reorder, so a node can receive `(3,4]` before `(2,3]`. If it
+applied that, it would advance its watermark to 4 and satisfy a waiter on
+generation 3 **without knowing whether generation 3 was poisoned** — a waiter
+woken with wrong poison status.
+
+So a node whose watermark is below `prev` discards the message and pulls. This
+does *not* reinstate `held_triggers`: buffering the out-of-order notification is
+the alternative, and pulling is strictly simpler because the pull path has to
+exist anyway.
+
+Membership is still applied on a gap (`:148-151`) — that message may be the
+node's only notice of its own removal.
+
+### Rule 5 — Replies are deltas keyed on `lk`, and must be MERGED
+
+`BarrierNotify.tla:183` (owner side), `:193` (node side).
+
+```tla
+pois |-> { g \in PoisonGens : (g > m.lk) /\ (g <= watermark) }   \* owner
+np   == IF fresh THEN knownPois[m.to] \cup m.pois ELSE knownPois[m.to]   \* node
+```
+
+A reply is point-to-point and the subscriber declares what it already has, so the
+owner can answer exactly. A notification cannot do this — it goes to nodes with
+different watermarks, and keying it per-recipient is precisely the
+`remote_trigger_gens` map we deleted. (That is what the current code's
+`broadcast_previous = min(previous_gen)` is doing, and why it needs the map.)
+
+**Union, do not substitute.** Substituting drops poison the node already knew
+about below `lk`. This is a caught mutation.
+
+Soundness rests on the node's poison knowledge being *complete* up to the
+generation it reports, which is exactly what `PoisonAccurate` asserts — so the
+two compose.
+
+### Rule 6 — A node removed while holding a waiter re-subscribes at once
+
+`BarrierNotify.tla:152` — `resub == (mem0 = "NO") /\ (w2 # {})`.
+
+The idle counter advances with the watermark, so **a node waiting on a far-future
+generation looks idle.** Waiting on generation 100 while the watermark climbs
+1…99 accumulates K idle generations with no consultation; the node departs and
+never learns.
+
+The obvious guard — don't depart while holding a waiter — **is not sufficient**,
+because a node can register a waiter after its departure request is sent but
+before the owner applies the shrink. The recovery is the correctness rule; the
+guard (`:213`, verified benign) is an optimization that reduces churn.
+
+### Rule 7 — At most one outstanding pull per node
+
+`BarrierNotify.tla:156-157`.
+
+An in-flight subscribe already carries an `lk` at or below what a new one would,
+so its reply is a superset of what the second pull would ask for. Suppressing the
+duplicate is safe and keeps a burst of reordered notifications from producing a
+burst of pulls.
+
+### Rule 8 — Departure hysteresis (performance only)
+
+Not modelled — see §8.2. A node signals departure after **K = 8** consecutive
+generations without consulting the barrier, where *consulting* means
+`add_waiter`, `subscribe`, or `external_wait`/`external_timedwait`, and
+explicitly **not** `has_triggered`, which must stay lock-free.
+
+- Measured as watermark delta since last consultation, so it is robust to the
+  owner coalescing several triggers into one notification.
+- K adapts by doubling on observed churn (a leave→rejoin within a short window),
+  which is also the metric worth exporting.
+- Departures are **unicast to the owner**, staggered by `K + (node_id mod J)`
+  with **J ≈ 16–32**. Phase changes retire many nodes at once, so the stagger is
+  load-bearing rather than defensive. J is sized for spike smoothing, not
+  asymptotics: the subscribe path is *already* O(N) unicast, so an O(N)
+  unsubscribe burst is not a new complexity class.
+- The owner may publish a one-byte hint on notifications saying whether shrinking
+  currently pays, so nodes suppress unsubscribes that would just be declined.
+
+**Why unicast rather than aggregating up the multicast ack tree:** that tree is
+real (`MulticastAckMessage`, `activemsg.h:559-576`) but carries **no payload** —
+`send_ack` at `activemsg.cc:1762` attaches none and the handler ignores the
+argument. Aggregating departures would mean adding a payload-reduction facility
+to the multicast layer, and multicast completion tracking currently has *no
+callers at all*, so we would be designing that API around one speculative user.
+Deferred until measurement justifies it.
+
+---
+
+## 6. Safety properties
+
+`BarrierNotify.tla:242-274`. All five are checked in every run.
+
+| Property | Line | Meaning |
+|---|---|---|
+| `TypeOK` | 242 | well-formedness; also `myVer[n] <= setVer` |
+| `NeverOverstate` | 249 | a node is never told a generation triggered before it did |
+| `PoisonAccurate` | 254 | a node's poison knowledge is **exactly** the truth up to its own watermark |
+| `NoStranded` | 261 | **the liveness-critical one** |
+| `MembershipPublished` | 270 | a node believing it is covered is covered, or its correction is on the wire |
+
+### `NoStranded`
+
+```tla
+NoStranded ==
+    \A n \in Nodes :
+        (waiting[n] # {}) =>
+            \/ n \in subSet
+            \/ (\E m \in msgs : (m.kind = "notify" \/ m.kind = "reply") /\ m.to = n)
+            \/ (\E m \in msgs : m.kind = "subscribe" /\ m.from = n)
+```
+
+A node holding an outstanding waiter must be covered, or have something in flight
+that will cover it. This is the same shape as `ReachableWhileHolding` in the
+arrival spec — a liveness property encoded as safety — and the in-flight
+disjuncts matter for the same reason: a node being removed is briefly outside the
+set while its own removal notice is still on the wire.
+
+### `MembershipPublished`
+
+```tla
+(member[n] = "YES") =>
+    \/ n \in subSet
+    \/ (\E m \in msgs : m.kind = "notify" /\ m.to = n /\ ~m.inset /\ m.sv > myVer[n])
+```
+
+The `m.sv > myVer[n]` clause is essential: a correction the node would *ignore as
+stale* is not a correction. Without it this check passes on the very state that
+Rule 2 exists to prevent.
+
+### Why `Done` exists
+
+`BarrierNotify.tla:222` — a settled run stutters, so TLC's deadlock detection
+never mistakes "finished" for "stuck." **Deadlock checking must stay ON**; it is
+what catches the "reply carries no watermark" mutation.
+
+---
+
+## 7. What was verified
+
+### Baseline
+
+`MCNotify.tla` + `Notify.cfg` — 3 remote nodes, 3 generations, 1 poisoned:
+**83,011,199 distinct states, no error, ~18 minutes.**
+
+Scripted: which generations each node consults, and which are poisoned.
+Nondeterministic: *when* each node consults (including generations far in the
+future), when a node signals departure, which subset of requests the owner
+actually applies, and every message delivery order. That covers **any** choice of
+K, J, or shrink policy — which is the point. The constants must not be able to
+affect correctness.
+
+### Mutation battery
+
+| Mutation | Caught by |
+|---|---|
+| apply a delta notification despite a gap | `PoisonAccurate` |
+| removed node with a live waiter doesn't re-subscribe | `NoStranded` |
+| stale notify may resurrect membership | `MembershipPublished` |
+| shrink published to the post-shrink set | `MembershipPublished` |
+| adds are discretionary | `NoStranded` |
+| subscribe reply carries no watermark | deadlock |
+| delta reply substituted rather than merged | `PoisonAccurate` |
+| **may depart while holding a waiter** | **not caught — benign** ✓ |
+
+Seven catches across four different invariants, each by the check that should own
+it. The eighth is a negative control confirming the model distinguishes
+correctness rules from optimizations.
+
+**Caveat, stated precisely: the negative control is verified at 2 nodes / 3
+generations, not 3.** At 3 nodes it diverged past 268M distinct states with a
+growing queue. The 2-node scenario was separately shown to have teeth — it
+catches the gap, no-recovery, and discretionary-adds mutations — so its clean
+verdict is meaningful rather than vacuous, but it is weaker evidence than the
+other seven rows.
+
+### Sizing
+
+| Scenario | Nodes | Gens | Distinct states | Time |
+|---|---|---|---|---|
+| `MCNotifySmall` (in `/tmp`, not retained) | 2 | 3 | 341,647 | seconds |
+| **`MCNotify`** | **3** | **3** | **83,011,199** | **~18 min** |
+| `MCNotifyBig` | 4 | 3 | >47M, diverging | abandoned |
+
+**Three nodes is the ceiling.** Two lessons worth carrying forward:
+
+1. **Unconstrained nondeterminism is what explodes this.** The first attempt left
+   the consultation pattern free and blew past 75M states without finishing;
+   scripting the pattern and leaving only interleavings free brought the same
+   scenario to 898k. (The later jump to 83M is the delta change, not the
+   patterns.)
+2. **A guard-removal mutation enlarges the state space rather than shrinking it**,
+   so clearing one as benign costs far more than catching a real defect — caught
+   mutations stop at the first violation. Size scenarios for the negative
+   controls, not for the baseline.
+
+Also worth knowing: switching notifications from snapshots to deltas cost
+898k → 83M states and 6s → 18min. Gap-insensitivity was doing enormous work for
+the *model* even while it was a liability on the *wire*.
+
+---
+
+## 8. Fidelity notes — where the model isn't the implementation
+
+### 8.1 The multicast tree is abstracted away
+
+A notification is modelled as one message per member. The forwarding layer is
+verified separately and delivers to exactly the encoded set, so this is sound —
+but it means **nothing here verifies the tree**.
+
+Relevant property the implementation gets for free: `plan_children` partitions
+the target set and `activemsg.cc:1210` sends each slice to `slice.first_node()`,
+so **every relay is itself a member of the destination set.** No node outside it
+is ever touched, and the delivered message count is exactly `|set|`.
+
+### 8.2 K, J, and the shrink policy are nondeterminism
+
+`Depart` (`:210`) may fire on any eligible node, and `Trigger` may apply any
+subset of pending requests. That is strictly more general than any tuning, so no
+choice of constants can be wrong — but it also means **§5 rule 8 is entirely
+unverified**. It is a performance mechanism whose failure modes are bandwidth,
+not correctness.
+
+### 8.3 The owner is variables, not a node
+
+`Nodes` is the set of *remote* nodes. An owner that is itself a waiter is a
+local, trivially-satisfied case and is not modelled.
+
+### 8.4 What the owner does with departure requests is unmodelled
+
+The cost test that decides whether a shrink pays is described in rule 3 but not
+specified or verified. Same gap as plan construction in the arrival spec: what is
+verified is that **any** shrink the owner chooses is safe, not that it chooses
+well.
+
+### 8.5 Poison retention is a constant here
+
+The model derives poison from `PoisonGens`. The implementation must actually
+retain the poisoned-generation set over `[first_generation, watermark]`, because
+rule 5 requires answering a new subscriber with everything above its `lk`.
+
+**That set is bounded by the barrier's lifetime, not by MAX_PHASES.**
+`first_generation` advances when a barrier is destroyed and its id handed out
+again, so retention only ever reaches back to the generation at which *this*
+barrier was created. `destroy_barrier` also implicitly waits for every generation
+up to that point to trigger, so there is a clean point at which the whole set is
+discarded.
+
+If poisoning ever were dense enough to matter within one barrier's life, the
+escape hatch is to cap what a *notification* carries and let nodes pull for
+detail — rule 5 is what makes that pull cheap. Not specified; no workload has
+justified it.
+
+### 8.6 Concurrency is not modelled
+
+Every action here is atomic; the implementation is not. See
+[`ARRIVAL_PROTOCOL.md` §12](ARRIVAL_PROTOCOL.md#12-atomicity) — the requirement
+applies identically to this protocol, and the `has_triggered` carve-out
+originates here.
+
+---
+
+## 9. Reproducing
+
+```sh
+cd tla/barrier
+java -Xmx8g -XX:+UseParallelGC \
+    -Djava.io.tmpdir=jtmp -cp tools/tla2tools.jar tlc2.TLC \
+    -workers 8 -config Notify.cfg MCNotify.tla
+```
+
+Expect `Model checking completed. No error has been found.` and 83,011,199
+distinct states.
+
+**Two operational warnings, both learned the hard way:**
+
+- **This run consumes tens of GB of scratch.** Delete `jtmp/` and `states/`
+  afterwards. Filling the volume kills runs in ways that look like unrelated
+  failures — an empty log and a bare non-zero exit.
+- **Never mutate `BarrierNotify.tla` in place.** Copy the module, the `MC*`
+  scenario and the `.cfg` into a scratch directory, mutate *there*, and run TLC
+  in that directory. A `finally` block does not survive a kill, and a cleanup
+  step that never runs leaves a silently corrupted spec on disk. Assert that each
+  mutation pattern matches **exactly one** site — after the delta change,
+  `RecvNotify` and `RecvReply` contain identically-worded poison-merge lines, and
+  an unanchored replace silently patches the wrong one and reports a result for a
+  test it never ran.
+
+To classify a verdict, grep for `Error: Invariant <name> is violated.` — note the
+`Error:` prefix.
+
+---
+
+## 10. Implementation checklist
+
+- [ ] Owner keeps an encoded subscriber set + `setVer` + watermark + poisoned set;
+      **no per-node map.**
+- [ ] Bump `setVer` on every set change; stamp it on every notification and reply.
+- [ ] Apply a membership update only if `sv` exceeds the highest already applied —
+      on **both** the notify and reply paths.
+- [ ] Publish every shrink to the **pre-shrink** set.
+- [ ] Never refuse an add. Refuse removals freely, subject to the cost test.
+- [ ] Notification carries `(prev, wm]` + poison in that range; a node below
+      `prev` **discards and pulls**, but still applies membership.
+- [ ] Subscribe carries `lk`; reply carries poison in `(lk, wm]`; the node
+      **unions** it.
+- [ ] Reply must carry the watermark — that is what covers the trigger-during-
+      subscribe race.
+- [ ] On removal while holding a waiter, **re-subscribe immediately.**
+- [ ] At most one outstanding pull per node.
+- [ ] Consultation = `add_waiter` / `subscribe` / `external_wait`; **never**
+      `has_triggered`.
+- [ ] Departures unicast, `K = 8` adaptive, staggered by `J ≈ 16–32`.
+- [ ] Reduction barriers route to the legacy path; `base_arrival_count == 0`
+      means unknown, documented at the declaration.
+
+If you change any of these, re-run the battery. A rule with no mutation covering
+it is a rule nobody has verified.

--- a/tla/barrier/Notify.cfg
+++ b/tla/barrier/Notify.cfg
@@ -1,0 +1,14 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Nodes       <- MCNodes
+    MaxGen      <- MCMaxGen
+    PoisonGens  <- MCPoisonGens
+    WaitPattern <- MCWaitPattern
+
+INVARIANTS
+    TypeOK
+    NeverOverstate
+    PoisonAccurate
+    NoStranded
+    MembershipPublished

--- a/tla/barrier/Notify.cfg
+++ b/tla/barrier/Notify.cfg
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 SPECIFICATION Spec
 
 CONSTANTS

--- a/tla/barrier/NotifyBig.cfg
+++ b/tla/barrier/NotifyBig.cfg
@@ -1,0 +1,14 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Nodes       <- MCNodes
+    MaxGen      <- MCMaxGen
+    PoisonGens  <- MCPoisonGens
+    WaitPattern <- MCWaitPattern
+
+INVARIANTS
+    TypeOK
+    NeverOverstate
+    PoisonAccurate
+    NoStranded
+    MembershipPublished

--- a/tla/barrier/NotifyBig.cfg
+++ b/tla/barrier/NotifyBig.cfg
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 SPECIFICATION Spec
 
 CONSTANTS

--- a/tla/barrier/Over.cfg
+++ b/tla/barrier/Over.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Nodes     <- MCNodes
+    Owner     <- MCOwner
+    MaxGen    <- MCMaxGen
+    Pattern   <- MCPattern
+    NumPlans  <- MCNumPlans
+    Plans     <- MCPlans
+    PlanStart <- MCPlanStart
+    BaseCount <- MCBaseCount
+    AlterOps  <- MCAlterOps
+
+INVARIANTS
+    TypeOK
+    TriggerInOrder
+    TriggerCorrect
+    NoOverCount
+    ReachableWhileHolding
+    BoundedRetention

--- a/tla/barrier/Over.cfg
+++ b/tla/barrier/Over.cfg
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 SPECIFICATION Spec
 
 CONSTANTS

--- a/tla/barrier/OverSwitch.cfg
+++ b/tla/barrier/OverSwitch.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Nodes     <- MCNodes
+    Owner     <- MCOwner
+    MaxGen    <- MCMaxGen
+    Pattern   <- MCPattern
+    NumPlans  <- MCNumPlans
+    Plans     <- MCPlans
+    PlanStart <- MCPlanStart
+    BaseCount <- MCBaseCount
+    AlterOps  <- MCAlterOps
+
+INVARIANTS
+    TypeOK
+    TriggerInOrder
+    TriggerCorrect
+    NoOverCount
+    ReachableWhileHolding
+    BoundedRetention

--- a/tla/barrier/OverSwitch.cfg
+++ b/tla/barrier/OverSwitch.cfg
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 SPECIFICATION Spec
 
 CONSTANTS

--- a/tla/barrier/Park.cfg
+++ b/tla/barrier/Park.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Nodes     <- MCNodes
+    Owner     <- MCOwner
+    MaxGen    <- MCMaxGen
+    Pattern   <- MCPattern
+    NumPlans  <- MCNumPlans
+    Plans     <- MCPlans
+    PlanStart <- MCPlanStart
+    BaseCount <- MCBaseCount
+    AlterOps  <- MCAlterOps
+
+INVARIANTS
+    TypeOK
+    TriggerInOrder
+    TriggerCorrect
+    NoOverCount
+    ReachableWhileHolding
+    BoundedRetention

--- a/tla/barrier/Park.cfg
+++ b/tla/barrier/Park.cfg
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 SPECIFICATION Spec
 
 CONSTANTS

--- a/tla/barrier/README.md
+++ b/tla/barrier/README.md
@@ -1,3 +1,20 @@
+<!--
+Copyright 2026 Stanford University, NVIDIA Corporation
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Formal Specifications for Realm's Scalable Barriers
 
 TLA+ models, model-checking scenarios, and the design documents for the

--- a/tla/barrier/README.md
+++ b/tla/barrier/README.md
@@ -1,0 +1,96 @@
+# Formal Specifications for Realm's Scalable Barriers
+
+TLA+ models, model-checking scenarios, and the design documents for the
+scalable barrier arrival and notification protocols implemented in
+`src/realm/barrier_impl.{h,cc}`.
+
+**Start with the documents — they are the normative record:**
+
+| Document | What |
+|---|---|
+| [`ARRIVAL_PROTOCOL.md`](ARRIVAL_PROTOCOL.md) | The arrival/aggregation protocol: 10 rules, each a caught mutation; safety properties; fidelity notes; implementation checklist |
+| [`NOTIFICATION_PROTOCOL.md`](NOTIFICATION_PROTOCOL.md) | The subscription/notification protocol: 8 rules; same structure |
+| [`STATE_AND_LOCKING.md`](STATE_AND_LOCKING.md) | `BarrierImpl` member layout, one critical section per spec action, the decisions record (§0 supersedes the body where they disagree) |
+| [`IMPLEMENTATION_PLAN.md`](IMPLEMENTATION_PLAN.md) | How the implementation was staged; the settled design decisions (D1–D10, Q1–Q10); known deferred items |
+| [`SCALE_TEST_PLAN.md`](SCALE_TEST_PLAN.md) | The 2–128 node testing program; drives `tests/barrier_scale_test.cc` |
+
+Where prose and spec disagree, **the spec wins** — it is what was model-checked.
+
+## The specifications
+
+- **`BarrierArrive.tla`** — the arrival protocol: learned plans, eager flush,
+  plan switching with deferral, `alter_arrival_count`, and the pinned-edge
+  rules (rule 10). Checked with six safety invariants plus deadlock detection.
+- **`BarrierNotify.tla`** — the notification protocol: subscriber set,
+  version-gated membership, delta notifications with gap-pull, departure.
+
+## Running
+
+TLC is not vendored. Fetch the TLA+ tools (2.19 or later) into `tools/`:
+
+    curl -Lo tools/tla2tools.jar \
+      https://github.com/tlaplus/tlaplus/releases/latest/download/tla2tools.jar
+
+Check one scenario (each `MC*.tla` pairs with the like-named `.cfg`):
+
+    java -Xmx8g -XX:+UseParallelGC -Djava.io.tmpdir=jtmp \
+      -cp tools/tla2tools.jar tlc2.TLC -workers 8 -config Stale.cfg MCStale.tla
+
+Expect `No error has been found`. Delete `jtmp/` and `states/` afterwards —
+large runs spill tens of GB.
+
+**If you change a protocol rule, run the battery:**
+
+    python3 battery.py all        # ~15-30 min; suites: arrival, alter, notify
+
+Every rule in both documents is paired with a mutation and a scenario chosen
+to catch exactly it. The battery fails loudly on a pattern that no longer
+matches the spec — do not "fix" that by loosening the pattern; it exists
+because an unanchored replacement once silently tested the wrong site.
+
+## The scenarios
+
+The load-bearing scenarios are the **minimal** ones, distilled from failing
+traces; the big ones exist for breadth. A scenario is trusted only because it
+kills mutations — see the battery table in each document.
+
+| Scenario | Size | What it uniquely covers |
+|---|---|---|
+| `MCDouble` | 4 nodes | the re-parent double-count (`NoOverCount`); pinning; stale-edge forwarding |
+| `MCStale` | 4 nodes | run-ahead outsider + over-predicting quota; found five bugs in candidate fixes |
+| `MCStrand` | 4 nodes | single-switch control (one switch is *not* enough to strand) |
+| `MCStrand2` | 4 nodes | two successive switches + run-ahead: the dead-plan guards |
+| `MCPark` | 4 nodes | why the deferral exists (invalidation routing down the old tree) |
+| `MCOver` | 5 nodes | over-arrival with no outsider to mask it |
+| `MCOverSwitch` | 3 nodes | over-arrival × plan switch |
+| `MCDeviate` | 5 nodes | the outsider (case 3) |
+| `MCChain` | 5 nodes | a relay below a relay |
+| `MCAlter` | 4 nodes | `alter_arrival_count`, altering node is a relay |
+| `MCDeepSwitch` | 5 nodes | three plans over a relay chain — found the `NoOverCount` violation that forced rule 10; **no longer completes** on the final spec |
+| `MCNotify` | 3 nodes | notification baseline (83M states) |
+| `MCNotifySmall` | 2 nodes | small enough to *clear* a guard-removal mutation (negative controls) |
+
+Historical, kept as records (do not extend): `MCSeven`, `MCLarge`, `MCLate`
+— early scenarios that outgrew practical checking as the spec gained rules; `BarrierArrival.tla` + `MCPlanned.tla` +
+`DeadlockNoFlush.cfg` — the model of the *previous* barrier design, in which
+TLC proved a terminal deadlock (all arrivals issued, network empty, no action
+enabled anywhere); that proof is why the redesign happened. A note on the old
+model's other configs: its `EventuallyTriggers` liveness property was later
+shown never to have fired at all — the deadlock detector did the real work —
+so the `Liveness*.cfg` results should not be cited.
+
+## Hard-won methodology (short form; details in the documents)
+
+- A green run proves nothing about which paths executed. A rule is verified
+  only when a scenario **catches its removal**, and a scenario is trusted only
+  when it kills mutations. A NOT-CAUGHT is a mis-pairing until the structure
+  the mutation strands has been deliberately built and still fails to catch.
+- Validate every property in both directions: silent on a known-healthy spec,
+  firing on a known-broken one.
+- When a big scenario fails, distil the trace into a minimal scenario and
+  iterate there. `MCStale` (~8k states) found bugs that 20M-state scenarios
+  never reached.
+- Guard-removal mutations *enlarge* the state space; size negative controls
+  for that (`MCNotifySmall` exists for exactly this reason).
+- Mutate copies in scratch directories, never the canonical files; assert
+  every mutation pattern matches exactly once. `battery.py` encodes both.

--- a/tla/barrier/README.md
+++ b/tla/barrier/README.md
@@ -83,11 +83,18 @@ kills mutations — see the battery table in each document.
 | `MCDeviate` | 5 nodes | the outsider (case 3) |
 | `MCChain` | 5 nodes | a relay below a relay |
 | `MCAlter` | 4 nodes | `alter_arrival_count`, altering node is a relay |
-| `MCDeepSwitch` | 5 nodes | three plans over a relay chain — found the `NoOverCount` violation that forced rule 10; **no longer completes** on the final spec |
+| `MCGateOver` | 4 nodes | quota gate: over/under pair straddling a gated relay (the value-exceeds valve) |
+| `MCGateAhead` | 4 nodes | quota gate: run-ahead mixed pins routing counts around the new relay (the non-kid valve) |
+| `MCGateMove` | 4 nodes | quota gate: a value accepted legally under plan k−1 made deviant by plan k (the switch audit) |
+| `MCGateDemote` | 4 nodes | quota gate: demoted owner-child + flush fan dying at a planless relay (audit orphan branch; install re-fan) |
+| `MCGatePark` | 4 nodes | quota gate: parked install — catches the parked re-fan AND the stale-edge signal via its two interleavings |
+| `MCGateJump` | 3 nodes | quota gate: cumulative replace jumps PAST the quota (why `>=`, never `=`) |
+| `MCLate` | 5 nodes | plan governs only generations after the deviation; outgrew the ungated spec, **completes again under quota gating** (~22M distinct states, checkpointed) |
+| `MCDeepSwitch` | 5 nodes | three plans over a relay chain — found the `NoOverCount` violation that forced rule 10; **no longer completes** (bounded partial runs only, no violation) |
 | `MCNotify` | 3 nodes | notification baseline (83M states) |
 | `MCNotifySmall` | 2 nodes | small enough to *clear* a guard-removal mutation (negative controls) |
 
-Historical, kept as records (do not extend): `MCSeven`, `MCLarge`, `MCLate`
+Historical, kept as records (do not extend): `MCSeven`, `MCLarge`
 — early scenarios that outgrew practical checking as the spec gained rules; `BarrierArrival.tla` + `MCPlanned.tla` +
 `DeadlockNoFlush.cfg` — the model of the *previous* barrier design, in which
 TLC proved a terminal deadlock (all arrivals issued, network empty, no action

--- a/tla/barrier/SCALE_TEST_PLAN.md
+++ b/tla/barrier/SCALE_TEST_PLAN.md
@@ -425,6 +425,44 @@ covers every driver-reachable deviation shape, and the valve's unique cases
 rare-interleaving paths for phase 3's scale runs to hunt, exactly as
 `pin_conflicts_avoided` was.
 
-**Phase 3** re-runs the functional ladder and the §7 A/B rungs; the
-prediction to check is new-uniform tails collapsing to new-half's profile
-and a pipe-throughput lift, with owner fan-in ≈ radix at every scale.
+**Phase 3, functional half — COMPLETE** (eos: 2 nodes ×2 radices ×2 seeds,
+16 nodes ×2 radices ×3 seeds, all 11 phases green).  `reports_gated` = 340k
+(radix 2) / 564k (radix 8) per 3-seed job at 64 ranks; declines stayed
+generation-flat (and DROPPED at radix 2 — gating reduces eager traffic);
+steady/step convergence signatures unchanged.  And a first: the
+**dead-PARKED-plan door fired on hardware** ("discarding dead parked
+barrier plan: parked=65 retired-by=65", churn, radix 2) — the one mechanism
+§6 documented as fabric-unreachable; gating's hold patterns widened exactly
+that window.  Every arrival-protocol mechanism has now been exercised on
+real hardware except `owner_valve_flushes`, whose scenarios are
+TLC-certified and whose hardware hunt continues at the A/B scales.
+
+**Phase 3, A/B half — COMPLETE.**  The §7 rungs re-run with the gated
+build (main arm unchanged); every prediction verified:
+
+| Ranks | serial uniform main→gated (ungated) | pipe uniform main→gated (ungated) | owner fan-in serial (was) |
+|---|---|---|---|
+| 32  | 123 → **83 µs** (90)   | 22k → 24k (21k)          | **8.1/gen** (31)  |
+| 128 | 486 → **116 µs** (211) | 6.1k → **~23k** (10.9k)  | **9.4/gen** (126) |
+| 512 | 7570 → **~150 µs** (591) | 570 → **~17k** (5.9k)  | **13.8/gen** (501) |
+
+- **Owner fan-in tracks the radix, not N, at every scale and radix**
+  (512-rank sweep, pipe barriers: 6.2/7.1/8.6/17.0 per gen at radix
+  2/4/8/16 - was ~N/6 to N−1).  The cascade is gone.
+- **At 512 ranks the gated build is ~50× main on serial-uniform latency
+  and ~30× on pipe throughput**, and 2.6-4× better than its own ungated
+  self.  Gated serial-uniform grows 83→116→147 µs across 32→512 ranks
+  (~+27% per 4× ranks) - the log-depth shape the tree was built for.
+- Half-pattern tails: max ≤ 181 µs every rep at 128 ranks.  Uniform tails
+  improved from most-reps-stalling to ~1-2 reps in 5 with episodic maxes,
+  no longer N-scaling and now appearing in BOTH patterns at 512 - i.e. a
+  background transport event, not protocol incast.  Radix 2 - pathological
+  ungated BECAUSE of the cascade - improved ~9× on pipe and is no longer an
+  outlier; **radix 8 stays the default**.
+- `owner_valve_flushes` = 0 on hardware everywhere (4096 counter lines at
+  512 ranks): the valve's strand shapes remain TLC-certified
+  (MCGateOver/Move/Demote/Park) but unreproduced by this fabric, joining
+  the §6 note on reordering-dependent paths.
+
+Quota-gated forwarding is COMPLETE: verified (§9 phases 1), implemented
+(phase 2), and measured at target scale (this section).

--- a/tla/barrier/SCALE_TEST_PLAN.md
+++ b/tla/barrier/SCALE_TEST_PLAN.md
@@ -273,6 +273,65 @@ barrier).
   delivery is near-FIFO per peer pair. TLC-verified (MCStrand2); not
   reachable on this fabric without message-reordering injection.
 
-**Still open from §4/§5:** the T3 soak (10⁵ generations, RSS curve) and the
-T4 A/B performance comparison against `main`. The functional ladder is
-complete; the scaling-performance claims remain to be measured.
+**Still open from §4/§5:** the T3 soak (10⁵ generations, RSS curve). The
+T4 A/B performance comparison is COMPLETE — see §7.
+
+---
+
+## 7. Benchmark record — T4 A/B, eos, August 2026 (COMPLETE)
+
+Instrument: `benchmarks/barrier_bench` (public-API-only; the identical source
+compiles against both builds, so A/B is by build) driven by
+`benchmarks/barrier_bench/barrier_bench.sbatch` (interleaved A,B,A,B reps in
+one allocation).  Fast-path proof comes from the `reports_received` /
+`notifies_received` counters, not from timing.  Patterns: `uniform` (all
+arrive 1) and `half` (lower half arrive 2, upper half only wait).
+
+**Serial medians (µs, one arrive→trigger→notify→wake round) and pipelined
+throughput (gens/sec, window 32), default plan radix 8:**
+
+| Ranks | serial uniform main→new | serial half main→new | pipe uniform | pipe half |
+|---|---|---|---|---|
+| 8   | 41 → 47 (main +15%) | 35 → 42 (main +20%) | comparable | comparable |
+| 32  | 124 → 90 (**1.4×**) | 109 → 71 (**1.5×**) | comparable | comparable |
+| 128 | 485 → 211 (**2.3×**) | 425 → 130 (**3.3×**) | 6.0k → 10.9k (**1.8×**) | 5.4–8.9k → 11.1k |
+| 512 | 7503 → 591 (**12.7×**) | 1650 → 344 (**4.8×**) | 585 → ~5.9k (**~10×**) | ~1.0k → ~6.8k (**6.5×**) |
+
+- **Crossover ≈ 16 ranks.**  Legacy's round grows linearly in N (its 512-rank
+  uniform trace shows EVERY generation at 7.4–9.7 ms — the O(N) owner incast
+  plus O(N) unicast notification saturated into the steady state); the new
+  path grows sub-linearly (16× ranks → 6.6× time).
+- **Adoption cost**: the plan installs in 2–4 generations at every scale
+  (spikes of ~3–17 ms, then flat), `plan_rebuilds=1`, flush confined to
+  startup.  Legacy has no adoption but also no fast path to adopt.
+- **Tails**: at 128 ranks the implementations stall in OPPOSITE patterns —
+  main-half is catastrophic (p95 4–12 ms in 4/5 reps) while new-half is
+  pristine (p99 ≤ 145 µs every rep); main-uniform is saturated-but-smooth
+  while new-uniform stalls episodically (rare multi-ms maxes).  The common
+  trigger is per-generation message burst size at the owner.
+
+**The cascade (measured, radix-independent).**  The verified no-child-wait
+rule means a relay forwards every child report that arrives after its own
+quota lands, so steady-state owner fan-in is NOT O(radix): measured ≈ N−1
+per generation in serial mode and ≈ N/6 pipelined, at EVERY plan radix
+(2/4/8/16).  The tree buys latency and relay locality, not owner message
+count.  This cascade is the sole source of the new build's remaining tail
+artifact (episodic uniform-serial stalls) and the likely ceiling on its pipe
+throughput.
+
+**Plan-radix sweep at 512 ranks**: serial medians are radix-flat (±10%);
+radix 8 wins throughput (6.1k vs 4.9k @16, 3.5k @4, 2.1k @2); radix 16 has
+the cleanest tails; radix 2 is pathological (nine forwarding hops amplify
+the cascade storm: half p95 11.3 ms).  **Default radix 8 is validated.**
+The sweep also refuted burst-SHAPE mitigation: deeper trees make tails
+worse, so only reducing the COUNT helps.
+
+**Follow-up identified (TLC-first, not yet designed): quota-gated
+forwarding.**  Gate a relay's re-reports on its subtree quota so the owner
+sees ~radix messages per steady generation instead of ~N−1.  Child-wait was
+removed as a verified stranding trap, but rule 10.1's pinned edges postdate
+that decision and fix a generation's inflow at first touch, which may make
+quota-gating safe now (deviations already bypass via flush mode).  Requires
+new mutation-battery rows against MCStale/MCStrand2/MCDeepSwitch before any
+implementation.  Expected payoff: removes the last tail artifact and lifts
+pipelined throughput.

--- a/tla/barrier/SCALE_TEST_PLAN.md
+++ b/tla/barrier/SCALE_TEST_PLAN.md
@@ -364,3 +364,67 @@ One seed, 64 nodes / 256 ranks, plan radix 8 (the shipping default),
 With §6 (functional ladder), §7 (A/B benchmark) and this section, every
 tier of §4 has run and every claim in §0's gates is either verified or
 recorded with its measured value.
+
+---
+
+## 9. Quota-gated forwarding — TLC campaign record (follow-up phase 1, COMPLETE)
+
+§7 identified the follow-up: cut steady-state owner fan-in from ≈N−1 to
+≈radix messages per generation by gating a relay's report on its SUBTREE
+quota.  Child-wait was a verified stranding trap in the original design, so
+this went TLC-first.  Seven design iterations, four of them killed by
+counterexamples — each kill producing a permanent probe scenario:
+
+| Iter | Killed by | Lesson | Mechanism added |
+|---|---|---|---|
+| v1 | MCDouble | model infidelity: report targets were derived from OTHER nodes' records, a re-aiming barrier_impl cannot perform | F0: parent from the sender's own epoch's plan |
+| v2 | MCGateAhead | owner silently accepts counts from plan-disowned senders | owner receipt valve: non-kid ⇒ flush |
+| v4 | MCGateMove | a value accepted legally under plan k−1 is made deviant RETROACTIVELY by plan k | owner switch-time audit (value-exceeds + orphaned-sender) |
+| v5 | MCGateDemote | flush fans are kid-list snapshots; later-gained children never hear | install-time re-fan (newplan + parked) |
+| v6 | MCGatePark | mis-pinned counts hide value-legal inside a legitimate chain; only the stale-edge forwarder witnesses it | stale-edge ⇒ count-free flush signal to the owner |
+
+**Final design (v7), landed in BarrierArrive.tla rules 1 and 6**: the `>=`
+subtree-quota gate at relays, the composite owner valve (receipt +
+switch-audit), install re-fans, and the stale-edge signal.  Full protocol
+text: ARRIVAL_PROTOCOL.md §13.
+
+**Verification record (all from the landed repo files):**
+- 16 scenarios pass: the 10 affordable arrival scenarios plus the 6 new
+  MCGate probes.  MCLate — previously outgrown — COMPLETES again under
+  gating (~22M distinct states, checkpointed); MCDeepSwitch remains
+  bounded-partial (no violation, ~50M+ generated states), as it already was
+  on the ungated spec.
+- Battery: arrival 14/14, gate 9/9 (8 mechanisms CATCH-certified + the gate
+  itself documented-benign to remove), alter 4/4.  MCGatePark certifies TWO
+  mechanisms through its two interleavings.
+- Mask probe: under the valves, the case-3 flush signals (immediate and
+  retroactive) are NO LONGER LOAD-BEARING FOR SAFETY — no scenario strands
+  without them across the full roster.  They stay in the protocol as the
+  plan-learning evidence (§11); their battery rows are documented-benign.
+- Control: the F0 fidelity fix alone passes the entire ungated fast suite.
+
+**Phase 2 (implementation) — COMPLETE.**  Landed per §13's mapping:
+`should_report_locked` gates on `subtree_quota` (computed at install from
+the payload slices each node already receives — nothing new on the wire,
+O(radix) storage); the owner receipt valve and switch-time audit in
+`handle_remote_report`/`build_new_plan_locked`; the receiver-side
+stale-edge signal (the sender-side `is_direct` half already existed, and
+the C++ already had the install re-fan the model campaign had to add — the
+implementation was AHEAD of the model on two mechanisms).  Counters
+`reports_gated` and `owner_valve_flushes` join the exercise table.
+
+Local validation (8 ranks, MPI, gens=512): all 11 functional phases PASS at
+plan radix 2 and 8, several seeds; `barrier_arrivals`/`barrier_reduce`
+regression OK.  **The acceptance metric holds exactly: owner
+`reports_received` = 2.01/gen serial and 2.04/gen pipelined at radix 2 —
+down from the measured 4.35 and ~5 — i.e. fan-in = radix, with
+`reports_gated` counting thousands of suppressed forwards.**
+`owner_valve_flushes` stayed 0 locally: the broad `is_direct` machinery
+covers every driver-reachable deviation shape, and the valve's unique cases
+(stowaway values across switches, receiver-side stale edges) are
+rare-interleaving paths for phase 3's scale runs to hunt, exactly as
+`pin_conflicts_avoided` was.
+
+**Phase 3** re-runs the functional ladder and the §7 A/B rungs; the
+prediction to check is new-uniform tails collapsing to new-half's profile
+and a pipe-throughput lift, with owner fan-in ≈ radix at every scale.

--- a/tla/barrier/SCALE_TEST_PLAN.md
+++ b/tla/barrier/SCALE_TEST_PLAN.md
@@ -1,0 +1,188 @@
+# Scalable Barriers — Scale Testing Program (2–128 nodes)
+
+Companion to [`ARRIVAL_PROTOCOL.md`](ARRIVAL_PROTOCOL.md) and
+[`NOTIFICATION_PROTOCOL.md`](NOTIFICATION_PROTOCOL.md). The specs verify the
+protocol against every message interleaving at 3–5 nodes; this program tests
+what the specs cannot: real transports, real concurrency, real scale, and the
+implementation's fidelity to the verified rules.
+
+**The governing principle is inherited from the mutation battery: a green run
+proves nothing about which paths executed.** Every deviation case in this
+program is paired with a counter that must move, and a run reports which
+counters *never* moved so coverage holes are visible instead of silent. This is
+the masking lesson applied at runtime.
+
+---
+
+## 0. Preflight gates — before any cluster time
+
+These run on one workstation and gate everything below. Skipping them means
+debugging protocol-shaped phantoms at 128 nodes.
+
+| Gate | What | Why | Status |
+|---|---|---|---|
+| G1 | **2–4 rank smoke over a real transport** (MPI and UCX builds), steady-state + one forced deviation per case | The new wire formats — plan subtree payloads, flush maps, `BarrierFlushMessage` to owner, delta notifications — had never been serialized across a transport | **Steady-state half DONE** (2026-08-09): open-mpi 5.0.9 on the dev machine, 12/12 runs of `barrier_arrivals`+`barrier_reduce` at 2 and 4 ranks, exit clean. **Deviation half needs the driver** — counters and INFO logs confirm the deviation machinery never executes under the existing tests. |
+| G2 | **TSAN soak, single rank, many threads**: concurrent `arrive`/`wait`/`alter_arrival_count`/`external_wait` from 8+ tasks against shared barriers, thousands of generations | Atomicity (ARRIVAL §12) is the one requirement no model checks, and a race at scale presents as a protocol bug. The previous implementation attempt died exactly here. | **Smoke DONE**: TSAN build at `/tmp/claude/btsan`, 8 runs of both tests, zero reports. Full soak needs the driver's concurrency mode. |
+| G3 | **Debug-build ladder pass at 2–8 ranks** with `REALM_BARRIER_ASSERT_LOCKED` active and counters asserted | Catches lock-contract violations and counter regressions before they get expensive. | **Driver DONE** (`tests/barrier_scale_test.cc`, registered in ctest): 9 phases, 9/9 PASS at 1, 2 and 4 ranks; TSAN run clean; the 8 rule-10 counters are wired and the per-phase dump works. |
+
+**STRUCTURAL FINDING (2026-08-09), changes the ladder:** the plan tree radix is
+8, so below ~10 ranks every plan is a flat owner→all tree — **no relays exist,
+and therefore parks, dead-plan discards, stale-edge forwards and pin conflicts
+are structurally impossible, not just improbable**. A 6-seed × 128-generation
+churn campaign at 4 ranks produced 281 plan rebuilds and 395 retroactive
+flushes with all four race-window counters at zero, which is consistent.
+Consequences:
+- ~~run at ≥10 ranks~~ **DONE instead: `-ll:barrier_plan_radix N` added**
+  (default 8 unchanged; distinct from `-ll:barrier_radix`, which is the
+  MULTICAST fan-out radix consumed by activemsg.cc). Radix 2 puts relay trees
+  at 4 ranks.
+
+**Race-window campaign results with radix 2** (2026-08-09, this machine):
+- 4 ranks, all 9 phases: `plans_parked=11`, all applied correctly, 9/9 PASS —
+  **the deferral race ran on hardware for the first time**.
+- 6 ranks × 8 seeds × 128 gens (churn+runahead+chaos): `plans_parked=21`,
+  `stale_edge_forwards=853`, `retro_flushes_sent=489`, `gap_pulls=1`,
+  zero failures.
+- Still never moved: `dead_plans_discarded` (needs a THIRD switch racing a
+  parked plan — cross-pair message reordering loopback rarely produces) and
+  `pin_conflicts_avoided`. These two are the remaining cluster-tier targets;
+  everything else in the exercise contract is now demonstrated at ≤6 ranks.
+
+First 4-rank exercise table (9 phases × 64 gens): plan_rebuilds=76,
+flush_episodes=860, report_edges_pinned=1317, retro_flushes_sent=205,
+gap_pulls=9, departs→shrinks→removals=3→2→2, adaptive K doubled (churn_backoffs=2).
+Everything moved except the four relay-dependent counters above.
+
+**Build facts learned running G1/G2** (bake into every test build):
+- `-DREALM_LOG_LEVEL=INFO` is required to see protocol logs at all — the
+  default compile-time floor is WARNING, and `-level barrier=N` silently shows
+  nothing below it (a one-line warning is the only hint).
+- `dump_counters` fires only on `destroy_barrier`/slot recycle. The existing
+  tests never destroy barriers, so counters are invisible. The driver must
+  destroy its barriers (or a shutdown-time dump must be added) — otherwise the
+  exercise-proof contract of §1 cannot be checked.
+
+Also before the PR: decide the **`alter_arrival_count` flag-day question**. Its
+semantics changed from (buggy) per-generation to (documented) persistent. No
+test in the repo calls it, so nothing will catch a Legion app that compensated
+for the old behaviour. Recommend: grep Legion for call sites and eyeball each
+before merging, and say so in the PR description.
+
+---
+
+## 1. Instrumentation: the exercise-proof contract
+
+`BarrierCounters` exists and dumps at destroy. The following **must be added**
+so every rule-10 case is observable (each is one increment on a path that
+already holds the mutex):
+
+| New counter | Increments when | Proves exercised |
+|---|---|---|
+| `plans_parked` | RecvNewPlan parks (deferral) | rule 5 deferral |
+| `parked_plans_applied` | invalidation applies a live parked plan | deferral resolution |
+| `dead_plans_discarded` | live guard or install guard fires | rule 10.2/10.3 — the race windows |
+| `retro_flushes_sent` | retroactive case-3 flush to owner | rule 10.4 |
+| `stale_edge_forwards` | receiver forwards a non-child report | rule 10.5 |
+| `report_edges_pinned` / `pin_conflicts_avoided` | first-report pin; pinned target ≠ current parent at report time | rule 10.1 |
+| `gap_pulls` (notification) | delta discarded, pull sent | notification rule 4 |
+
+Add a per-rank end-of-run dump (aggregate across barriers) and a tiny reducer
+script that merges all ranks' dumps into one table with zero-counters
+highlighted. **The run artifact is that table, not the exit code.**
+
+---
+
+## 2. The oracle: what "correct" means at runtime
+
+Each test wraps barriers with independent verification (side-channel MPI
+collectives, not Realm barriers):
+
+1. **No early trigger** (the safety property, `TriggerCorrect`/`NoOverCount` at
+   runtime): each rank counts arrivals it issued per generation; after a
+   waiter wakes for generation g, an `MPI_Allreduce` confirms the global sum
+   for g had reached the expected count *before* the wake was observed. Run
+   the check on a sampled subset of generations (e.g. 1 in 64) to keep the
+   oracle from serialising the test.
+2. **Exactly-once, in-order triggering** per rank: generation g wakes after
+   g−1, never twice.
+3. **No hang** (the liveness property): every phase has a global timeout
+   generous enough for the slowest tier (minutes, not seconds — this is a
+   deadlock detector, not a performance gate). A timeout dumps all ranks'
+   counters and current barrier state before aborting.
+4. **Poison fidelity**: a rank that observes generation g poisoned must never
+   have observed it triggered clean, and vice versa; poison must be observed
+   by *every* waiter of that generation.
+5. **Memory bound** (the O(N²) guard, D9/§11.3): RSS per rank sampled per
+   phase; `agg_peak_entries` and `flush_report_bytes_max` reported. Growth
+   across a soak run fails the test.
+
+---
+
+## 3. The driver phases — one per protocol case
+
+One parameterised driver (`barrier_scale_test`) executes a script of phases.
+Each phase runs G generations (default 64) of one pattern, then rotates. Every
+rank knows the full script (seeded), so expected counts are computable locally.
+
+| Phase | Pattern | Protocol case | Counter that must move |
+|---|---|---|---|
+| P1 steady | same participants + counts every generation | rule 1 steady state, plan reuse | `plan_rebuilds` stays **flat** after first |
+| P2 grow | participant set grows by one rank every k generations | outsider → case 3 → plan rebuild | `flush_episodes`, `plan_rebuilds`, subscribe fan-in |
+| P3 shrink | set shrinks by one rank every k generations | under-arrival absorbed by conservation; departure hysteresis (K=8) on the notify side | `departs_sent`, `shrinks_applied`, `nodes_removed` |
+| P4 over | one rank doubles its arrivals for one generation, rotating | rule 2 over-arrival | `flush_episodes` on non-owner ranks |
+| P5 outsider | one silent rank arrives for one generation, rotating | rule 3 | `retro_flushes_sent` or direct-flagged reports |
+| P6 run-ahead | ranks arrive on advanced handles up to R generations ahead (staggered by rank id), R up to 8 | pinning, straddling generations, retroactive case 3 | `report_edges_pinned`, `retro_flushes_sent`, `stale_edge_forwards` |
+| P7 churn | pattern changes **every** generation (rotate a random subset) | plan switch machinery under pressure: deferral, dead plans, invalidation routing | `plans_parked`, `parked_plans_applied`, `dead_plans_discarded` |
+| P8 alter | `alter_arrival_count` ±d mid-stream, rotating ranks; verify persistence across ≥3 subsequent generations | rules 8/9, the persistence fix | ts-bypass traffic; expected counts shift permanently |
+| P9 waiters | waiter set disjoint from arriver set (few-to-many / many-to-few); far-future waiters (wait on g+50) | notification rules 1–7, far-future waiter, subscribe race | `gap_pulls` (opportunistic), subscribe fan-in, re-subscribes |
+| P10 poison | poisoned precondition feeds an arrival, rotating | Q4 poison propagation | oracle check 4 |
+| P11 chaos | seeded random: participants, counts, waiters, alters, run-ahead all drawn per generation | everything at once — the runtime analogue of TLC's nondeterminism | full counter spread; **report zero-counters** |
+
+Phases P6/P7 deserve emphasis: the race-window cases (park, dead-plan discard,
+gap-pull) **cannot be forced deterministically from application level** — they
+need message timing. They are exercised probabilistically: high generation
+counts, many seeds, and the counters are the proof. A campaign where
+`dead_plans_discarded` never moved has not tested rule 10.2/10.3, no matter how
+green it is — rerun P7 with more seeds or tighter generation pacing until it
+moves.
+
+---
+
+## 4. The scale ladder
+
+| Tier | Nodes | Build | What runs | What it answers |
+|---|---|---|---|---|
+| T1 | 2, 4, 8 | Debug + assertions | P1–P11, all seeds, oracle on every generation | functional correctness with maximum checking |
+| T2 | 16, 32 | Release + counters | P1–P11, oracle sampled 1/64; plus P11 with 20+ seeds | race-window coverage (this is where parks/dead-plans actually fire) |
+| T3 | 64 | Release | P1–P11 + soak: 10⁵ generations of P7+P11 interleaved; RSS tracked | memory bound, leak detection, plan-lifecycle stability |
+| T4 | 128 | Release | full script + **performance comparison** | scaling claims |
+
+Performance comparison at T4 (and spot-checked at T2): run the identical
+script against a build of `main` (the pre-rewrite implementation) — **A/B by
+build, not by runtime toggle**. Metrics: wall time per 1k generations for P1
+(steady state must not regress — this is the O(log N) claim), owner-rank
+message counts (steady-state fan-in must be O(radix), not O(N)), and P9
+notification latency (trigger-to-wake on a far rank).
+
+Scaling assertions worth automating:
+- steady-state messages received at the owner per generation ≈ radix, flat in N
+- `subscribe_fan_in` ≈ N once per barrier, not per generation
+- `flush_report_bytes_max` bounded by the deviating subtree, not N, in P4/P5
+- `agg_peak_entries` ≤ participants, and zero between rebuilds
+
+---
+
+## 5. Suggested schedule
+
+1. G1–G3 preflight (workstation, ~a day of machine time).
+2. T1 with every phase; fix what falls out; iterate until counters table is
+   fully non-zero except the documented-probabilistic ones.
+3. T2 seeds campaign until `plans_parked`, `dead_plans_discarded`, `gap_pulls`
+   have all moved. **This is the exit criterion that matters most** — these are
+   the paths TLC verified and hardware has never run.
+4. T3 soak overnight.
+5. T4 with the A/B baseline.
+
+Each tier's artifact: merged counter table + oracle violations (must be zero) +
+RSS curve + (T4) the perf comparison. Keep the seeds of any failing run —
+a seed is this program's equivalent of a TLC trace.

--- a/tla/barrier/SCALE_TEST_PLAN.md
+++ b/tla/barrier/SCALE_TEST_PLAN.md
@@ -1,3 +1,20 @@
+<!--
+Copyright 2026 Stanford University, NVIDIA Corporation
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Scalable Barriers — Scale Testing Program (2–128 nodes)
 
 Companion to [`ARRIVAL_PROTOCOL.md`](ARRIVAL_PROTOCOL.md) and

--- a/tla/barrier/SCALE_TEST_PLAN.md
+++ b/tla/barrier/SCALE_TEST_PLAN.md
@@ -273,8 +273,8 @@ barrier).
   delivery is near-FIFO per peer pair. TLC-verified (MCStrand2); not
   reachable on this fabric without message-reordering injection.
 
-**Still open from §4/§5:** the T3 soak (10⁵ generations, RSS curve). The
-T4 A/B performance comparison is COMPLETE — see §7.
+**T3 soak and T4 A/B are both COMPLETE — see §7 and §8.  Every tier of §4
+has now run.**
 
 ---
 
@@ -327,7 +327,7 @@ The sweep also refuted burst-SHAPE mitigation: deeper trees make tails
 worse, so only reducing the COUNT helps.
 
 **Follow-up identified (TLC-first, not yet designed): quota-gated
-forwarding.**  Gate a relay's re-reports on its subtree quota so the owner
+forwarding (see end of §8).**  Gate a relay's re-reports on its subtree quota so the owner
 sees ~radix messages per steady generation instead of ~N−1.  Child-wait was
 removed as a verified stranding trap, but rule 10.1's pinned edges postdate
 that decision and fix a generation's inflow at first touch, which may make
@@ -335,3 +335,32 @@ quota-gating safe now (deviations already bypass via flush mode).  Requires
 new mutation-battery rows against MCStale/MCStrand2/MCDeepSwitch before any
 implementation.  Expected payoff: removes the last tail artifact and lifts
 pipelined throughput.
+
+---
+
+## 8. Soak record — T3, eos, August 2026 (COMPLETE)
+
+One seed, 64 nodes / 256 ranks, plan radix 8 (the shipping default),
+`PHASES=272` (churn + chaos — the two plan-lifecycle stress phases),
+`GENS=100000` each.  Instrumentation: `rss_mb` samples from rank 0 every
+8192 generations (tests/barrier_scale_test.cc), plus the counter dump.
+
+- **Both phases PASS**: 2×10⁵ generations, ~790 s wall (churn 3.7 ms/gen at
+  radix 8; an aborted first attempt at radix 2 ran exactly 2× slower,
+  consistent with §7's radix findings — its per-seed `RUN_TIMEOUT` was the
+  only failure).
+- **RSS flat**: 1193 → 1201 MB end to end; +5 MB in the first sample
+  interval (warm-up), then +3 MB across ~190k generations — a per-generation
+  residue bound of ~15 bytes, allocator noise.  No leak.
+- **Memory bound held by counters too**: `agg_peak_entries = 510`
+  (= 2 barriers × 255 participants) and `flush_report_bytes_max = 4130` —
+  both track PARTICIPANTS, not generation count, at 200× the campaign's
+  generation length.  `subscribe_fan_in = 510`: once per barrier, never per
+  generation (§4's scaling assertion, verified at soak length).
+- **Plan lifecycle held cadence without drift**: `plan_rebuilds = 100001`
+  over 2×10⁵ generations — exactly the one-rebuild-per-two-generations
+  churn/chaos design rate, sustained; 899 parks, all applied.
+
+With §6 (functional ladder), §7 (A/B benchmark) and this section, every
+tier of §4 has run and every claim in §0's gates is either verified or
+recorded with its measured value.

--- a/tla/barrier/SCALE_TEST_PLAN.md
+++ b/tla/barrier/SCALE_TEST_PLAN.md
@@ -85,6 +85,9 @@ already holds the mutex):
 | `stale_edge_forwards` | receiver forwards a non-child report | rule 10.5 |
 | `report_edges_pinned` / `pin_conflicts_avoided` | first-report pin; pinned target ≠ current parent at report time | rule 10.1 |
 | `gap_pulls` (notification) | delta discarded, pull sent | notification rule 4 |
+| `plan_rebuilds_declined` | completeness gate said no | §11.5 — high ratio vs `plan_rebuilds` under P_STEP = cannot re-learn |
+| `gathering_declared` | owner declared a gathering generation | §11.5 convergence |
+| `identical_plans_skipped` | rebuild reproduced the current plan | §11.5; ≥1 per barrier at startup is the normal signature |
 
 Add a per-rank end-of-run dump (aggregate across barriers) and a tiny reducer
 script that merges all ranks' dumps into one table with zero-counters
@@ -137,6 +140,7 @@ rank knows the full script (seeded), so expected counts are computable locally.
 | P9 waiters | waiter set disjoint from arriver set (few-to-many / many-to-few); far-future waiters (wait on g+50) | notification rules 1–7, far-future waiter, subscribe race | `gap_pulls` (opportunistic), subscribe fan-in, re-subscribes |
 | P10 poison | poisoned precondition feeds an arrival, rotating | Q4 poison propagation | oracle check 4 |
 | P11 chaos | seeded random: participants, counts, waiters, alters, run-ahead all drawn per generation | everything at once — the runtime analogue of TLC's nondeterminism | full counter spread; **report zero-counters** |
+| P12 step | ONE persistent pattern shift at mid-phase | §11.5: can the owner re-learn a plan whose deviation is discovered mid-generation? | `plan_rebuilds` = 2, `gathering_declared` ~ 1, flush quiet after convergence |
 
 Phases P6/P7 deserve emphasis: the race-window cases (park, dead-plan discard,
 gap-pull) **cannot be forced deterministically from application level** — they

--- a/tla/barrier/SCALE_TEST_PLAN.md
+++ b/tla/barrier/SCALE_TEST_PLAN.md
@@ -207,3 +207,72 @@ Scaling assertions worth automating:
 Each tier's artifact: merged counter table + oracle violations (must be zero) +
 RSS curve + (T4) the perf comparison. Keep the seeds of any failing run —
 a seed is this program's equivalent of a TLC trace.
+
+---
+
+## 6. Campaign record — eos, August 2026 (COMPLETE through T4 functional)
+
+The ladder was run on eos (GASNet-EX/IB, 4 ranks/node, `gens=512`,
+`phases=-1`, radix 2 and radix 4 at every rung). **Every rung passed every
+phase on every seed**; the driver grew an 11th phase (`depart`, mask 1024)
+mid-campaign to reach the notification-shrink machinery the split phase
+structurally cannot exercise (its departs are products of the final triggers,
+so they always arrive after the last trigger and die unweighed with the
+barrier).
+
+| Ranks (nodes) | Seeds×radix | Result | Firsts at this rung |
+|---|---|---|---|
+| 8 (2) | 4×2, +depart probe | PASS | gathering-generation fix validated; depart phase: `shrinks_applied`, `leave_rejoin`, `churn_backoffs` all first-ever |
+| 16 (4) | 4×2 | PASS | `pin_conflicts_avoided` (53, radix 2) |
+| 32 (8) | 10×2 + 512-gen soak | PASS | decline storm confirmed dead at scale |
+| 64 (16) | 10×2 | PASS | `dead_plans_discarded` (2, radix 2, install-guard door) — **last dormant counter; exercise table 100% complete** |
+| 128 (32) | 5×2 | PASS | — |
+| 256 (64) | 3×2 | PASS | — |
+| 512 (128) | 2×2 | PASS | — |
+
+**Scaling shape (the campaign's quantitative findings):**
+
+- **Decline volume is generation-linear and rank-invariant**: ~285/seed at
+  gens=128 and ~1210–1280/seed at gens=512, flat across SIX rank doublings
+  (8→512). Partial-evidence declines are a per-generation constant, not a
+  scaling term.
+- **Steady state converges in one plan build** (plus at most one
+  identical-plan skip from the documented startup transient, which vanishes
+  entirely at ≥256 ranks). Step converges in exactly two builds within ~4
+  generations of the shift at every rung.
+- **`flush_report_bytes_max` approaches linear-in-nodes**: 64→73→101→155 KB
+  across 64→512 ranks (per-doubling ratio 1.15→1.38→1.53). This is the design
+  floor, not a defect — flush reports carry per-node counts — but budget
+  ~O(nodes) bytes for worst-case reports during full-eager windows
+  (~1.2 MB at 4K nodes; fragmented-message territory).
+- **`pin_conflicts_avoided` scales with tree depth** (radix 2 ≫ radix 4;
+  ~24.5k/seed at 512 ranks) with zero conservation failures — rule 10.1 is
+  load-bearing in production, not just in TLC.
+
+**Behaviors observed and classified as design-working-as-intended:**
+
+- At ≥256 ranks the depart phase's shrinks collapse to zero via the rule-3
+  cost test + rule-8 hint: the phase's even-rank departure pattern is the
+  encoded-target worst case (scattered removals shatter a compact range set
+  into a per-delivery bitmap — see `multicast_cost()` in barrier_impl.cc,
+  whose comment predicts exactly this). Contiguous idle blocks — the realistic
+  phase-change pattern — keep paying at any scale. Coverage for the
+  shrink/rejoin paths comes from the ≤128-rank rungs.
+- The depart phase's churn arm sits deliberately on the
+  `DEPART_CHURN_WINDOW` boundary, so its churn/clean classification flips
+  with per-generation latency across rungs (all-churn at 128 ranks, all-clean
+  at 256 ranks, radix-dependent in between). The honest-clock judgment
+  (deferred to the subscribe reply — see NOTIFICATION_PROTOCOL.md) was
+  validated at 8 ranks where both arms behave deterministically.
+
+**Never exercised (and why that is acceptable):**
+
+- The **dead-parked-plan door** ("discarding dead parked barrier plan") never
+  fired; both 64-rank kills came through the install guard. It requires an
+  invalidation to overtake its own newplan in flight, and GASNet-over-IB
+  delivery is near-FIFO per peer pair. TLC-verified (MCStrand2); not
+  reachable on this fabric without message-reordering injection.
+
+**Still open from §4/§5:** the T3 soak (10⁵ generations, RSS curve) and the
+T4 A/B performance comparison against `main`. The functional ladder is
+complete; the scaling-performance claims remain to be measured.

--- a/tla/barrier/STATE_AND_LOCKING.md
+++ b/tla/barrier/STATE_AND_LOCKING.md
@@ -1,0 +1,1190 @@
+# BarrierImpl — State Layout and Locking Discipline
+
+> ## §0. DECISIONS — these supersede anything below
+>
+> Reviewed and decided by the owner after this document was drafted. Where the
+> body disagrees, **these win**; the body is retained as the supporting analysis.
+>
+> - **D1 — no the legacy reduction members object.** All state lives directly in
+>   `BarrierImpl`. Reduction barriers still fall back to the existing eager
+>   path, but that is a code path, not a separate object. No unnecessary
+>   abstractions.
+> - **D4 — one counter direction, one semantics.** Every accumulator is
+>   cumulative and replace-if-higher, counting up. `BarrierArrive.tla` was changed to
+>   match: a timestamped arrival now carries the node's *cumulative* bypassed
+>   count and the owner keeps it per-node, exactly like `childAcc`. The `seq`
+>   discriminator is gone.
+> - **D8 — store the subscriber set directly as `MulticastTargetSet`.** It
+>   already has `add`/`remove`/`contains`/`size`/`num_ranges`. No `NodeSet`
+>   staging and no cached conversion: the set changes rarely by design, so
+>   run-list mutation cost is irrelevant and a per-send conversion is not.
+> - **Q8 — drop `BarrierCommunicator`.** No injectable transport seam; use the
+>   active message interface directly.
+> - **Q9 — do not touch `external_wait`.** Out of scope for both protocols.
+> - **Q5 — notifications carry one triggered-generation number.** Barriers
+>   trigger in order, so a wider range buys nothing; poison for a new subscriber
+>   rides the subscribe reply. Do not widen `prev`.
+> - **Q6 — do not hand-roll payload chunking.** Use active-message
+>   fragmentation.
+> - **Q1/D5 — `alter_arrival_count` is persistent**, and the current code is
+>   **buggy**, not merely unimplemented. Fixing it is part of C6.
+> - **Q2** destroy stays a no-op. **Q3** reuse `GenEventImpl`'s poison structure;
+>   past the cap, fatal log then `std::abort`. **Q4** a poisoned precondition
+>   poisons the generation. **Q7** exactly one mutex per barrier. **Q10** defer
+>   tests.
+> - **D2, D3, D6, D7, D10** as drafted. Note D3: migration goes, but the lock is
+>   still needed in most paths it touched, to race correctly with notifications.
+
+
+**Phase B of [`IMPLEMENTATION_PLAN.md`](IMPLEMENTATION_PLAN.md) §2. This is the hard
+gate: every stage of Phase C is written against this document.**
+
+Normative inputs, in priority order:
+
+1. `BarrierArrive.tla`, `BarrierNotify.tla` — the model-checked artifacts. Where anything
+   below disagrees with them, they win.
+2. [`ARRIVAL_PROTOCOL.md`](ARRIVAL_PROTOCOL.md) (9 rules, §11 plan lifecycle, §12
+   atomicity), [`NOTIFICATION_PROTOCOL.md`](NOTIFICATION_PROTOCOL.md) (8 rules).
+3. This document, which fixes the C++ realisation: members, ownership, and which
+   critical section each spec ACTION runs in.
+
+Nothing here changes a protocol rule. Where this document makes a choice the specs
+leave open, it says so and §9 records it as an open question rather than pretending it
+is settled.
+
+---
+
+## 1. Decisions this document fixes
+
+These are the choices the four scouts left open. They are stated here so no
+implementation stage has to re-derive them.
+
+| # | Decision |
+|---|---|
+| D1 | ~~Forked into a separate the legacy reduction members object.~~ **SUPERSEDED by §0: no separate object — these members live directly in `BarrierImpl` and are simply unused on the scalable path.** `remote_trigger_gens`, `remote_subscribe_gens`, `held_triggers`, `final_values`, `value_capacity` and `initial_value` move inside it and are unreachable from the scalable path. This answers the deletion-map scout's first open question: the map is not globally deleted and it is not shared — it is fenced. |
+| D2 | **The fork point needs no advance knowledge on a remote node.** `redop_id` is immutable and known at the owner from `create_barrier`. A non-owner never has to guess: it aggregates only if it holds a plan record, and the owner only ever sends a `newplan` for a barrier with `redop_id == 0`. A node with no plan record sends its arrival straight to the owner — which is simultaneously the legacy behaviour and arrival rule 3. |
+| D3 | **`owner` becomes write-once.** Migration is deleted, so `EventImpl::owner` is written only by `init()` and may be read without the mutex. Several lock acquisitions that exist only to read it consistently (`subscribe`, `add_waiter`, the `adjust_arrival` prologue) lose their reason to exist. |
+| D4 | **The scalable arrival path counts UP.** `local_total`, `child_acc`, `ts_acc` are non-negative running totals compared against `expected(g)`. The legacy path keeps the existing count-down convention (`base_arrival_count + unguarded_delta == 0`). `Barrier::arrive(count)` passes `-int(count)` today; on the scalable path it contributes `+count`. Mixing the two conventions in one accumulator is the single easiest way to produce a barrier that triggers early. |
+| D5 | **`alter_arrival_count` is persistent**, per `event.h:271-273` and `BarrierArrive:433-434`. The current implementation is *not* — it folds the delta into one generation's `unguarded_delta` and `base_arrival_count` never changes. This is a behaviour change; see Q1. |
+| D6 | **`BarrierImpl` never calls `get_runtime()`.** Collaborators are injected through a `BarrierImplAllocator`, exactly as `GenEventImpl` already does (`event_impl.h:263-277`, `DynamicTableAllocator`'s `Constructor` hook at `dynamic_table.h:61,144`). This is the structural fix for the previous attempt's failure. |
+| D7 | **Poison uses the `GenEventImpl` representation**: an append-only, never-reallocated `gen_t*` array plus an `atomic<int>` count (`event_impl.h:326-332`, `event_impl.cc:1396-1410`). That is what keeps `has_triggered` lock-free while `PoisonAccurate` holds. |
+| D8 | ~~Lives as a `NodeSet`, converted and cached.~~ **SUPERSEDED by §0: store it directly as `MulticastTargetSet`** (it has `add`/`remove`/`contains`/`size`/`num_ranges`). No staging type, no cached conversion — the set changes rarely by design, so run-list mutation cost is irrelevant and a per-send conversion is not. `NodeSet` is inline for ≤4 nodes or ≤2 ranges and otherwise a pooled bitmask (`nodeset.h:145-172`); `MulticastTargetSet` stores 8 bytes per run, which is worse than a bitmask for a scattered set. The codec is the wire form and the cost-test oracle, not the storage form. |
+| D9 | **The plan-construction aggregation structure is never a member.** It *is* the per-generation flush maps; the plan is computed from them inside the `Trigger` critical section, before that generation's record is freed. There is nothing to forget, so arrival §11.3 cannot be violated by omission. |
+| D10 | **No barrier active-message handler declares `handle_inline`.** This matches today (`activemsg.inl:711-715` SFINAE fallback) and is now a rule, not an accident. |
+
+---
+
+## 2. The new `BarrierImpl` member layout
+
+Members are grouped into tiers by *what synchronises access to them*. The tier is the
+contract; the grouping in the header must make the tier obvious.
+
+### 2.0 Tier summary
+
+| Tier | Access rule |
+|---|---|
+| 0 — lock-free | Read with no lock. Written only inside `mutex`, published with release stores in the order of §3.5. |
+| 1 — immutable | Written by `init()` / `create_barrier` before the object is reachable; read anywhere. |
+| 2 — injected | Set once by the allocator; never `get_runtime()`. |
+| 3 — mutex | Every read and every write inside `BarrierImpl::mutex`. Includes everything reached through the sub-state pointers. |
+| 4 — external wait | `external_waiter_mutex` (INNER). Only `has_external_waiters` bridges tiers 3 and 4. |
+
+### 2.1 Tier 0 — lock-free
+
+```cpp
+  // ---- TIER 0: readable without the mutex ---------------------------------
+  // Written ONLY inside 'mutex'.  Publication order is fixed by §3.5:
+  //   poison slots -> num_poisoned_generations (release) -> generation (release).
+  atomic<gen_t> generation{0};                    // THE WATERMARK
+  atomic<int>   num_poisoned_generations{0};
+  gen_t        *poisoned_generations = nullptr;   // append-only, never realloc'd,
+                                                  //  entries below the published
+                                                  //  count are immutable
+```
+
+`gen_subscribed` is **deleted**. Its two jobs are taken over by tier-3 fields:
+duplicate-pull suppression becomes `pull_outstanding` (notification rule 7, which is
+about *outstanding-ness*, not about a generation), and "have I told the owner I care"
+becomes `member`.
+
+### 2.2 Tier 1 — immutable after init / create
+
+```cpp
+  // ---- TIER 1: immutable once the object is reachable ---------------------
+  // ID     me;      (EventImpl)
+  // NodeID owner;   (EventImpl) - WRITE-ONCE in init(); see D3
+  gen_t                     first_generation = 0;  // retention floor
+  ReductionOpID             redop_id = 0;          // 0 => scalable, !=0 => legacy
+  const ReductionOpUntyped *redop = nullptr;       // non-null iff redop_id != 0
+
+  // INVARIANT: a barrier ALWAYS has a non-zero expected arrival count
+  //  (arrival rule 9), so 0 is an unambiguous "not yet known" sentinel on a
+  //  node that has not yet been told.  This is the only thing that makes the
+  //  sentinel safe - NOTIFICATION_PROTOCOL §3.
+  unsigned                  base_arrival_count = 0;
+```
+
+`base_arrival_count` on a non-owner is filled in by the `newplan` payload
+(arrival §11.4), **not** by a trigger message. The trigger-message field it rides on
+today is dead (`barrier_impl.cc:363-368` is gated on `migration_target != -1`, which
+`DISABLE_BARRIER_MIGRATION` makes unreachable) and is deleted with migration.
+
+### 2.3 Tier 2 — injected collaborators
+
+```cpp
+  // ---- TIER 2: injected; NEVER get_runtime() ------------------------------
+  EventTriggerNotifier                 *event_triggerer = nullptr;
+  // Q8: BarrierCommunicator is DROPPED - send active messages directly.
+  const ReductionOpTable               *reduce_op_table = nullptr;  // legacy only
+```
+
+with
+
+```cpp
+  struct BarrierImplAllocator {   // mirrors GenEventImpl::GenEventImplAllocator
+    EventTriggerNotifier   *triggerer = nullptr;
+    const ReductionOpTable *redop_table = nullptr;
+    void construct(BarrierImpl *storage, ID id, unsigned owner) const;
+  };
+  typedef DynamicTableAllocator<BarrierImpl, 10, 4, BarrierImplAllocator>
+      BarrierTableAllocator;
+```
+
+This deletes the `get_runtime()->get_module_config("core")` call in the default
+constructor (`barrier_impl.cc:512-513`) and both `get_runtime()` calls on the deferred
+arrival path (`barrier_impl.cc:582`, and the `reduce_op_table` lookups at `:422`,
+`:1425`). See §5.
+
+> **§0/Q8 SUPERSEDES the following paragraph: `BarrierCommunicator` is dropped
+> entirely. Use the active message interface directly.**
+
+`BarrierCommunicator` is retained as the single injectable transport seam, but with
+**all** sends routed through it (today only 6 of 12 sites use it) and with the new
+method set of §6. Whether it stays a per-object `unique_ptr` or becomes a per-node hook
+is a cost question, not a correctness one — see Q8.
+
+### 2.4 Tier 3 — under `BarrierImpl::mutex`
+
+#### 2.4.1 Core, present on every node for every barrier
+
+```cpp
+  Mutex mutex;                       // THE lock.  UnfairMutex.  Non-reentrant.
+
+  // open generations only; an entry is created on first need and DELETED when
+  //  the generation triggers (or when this node learns it triggered)
+  std::map<gen_t, Generation *> generations;
+
+  // ---- notification, node side (needed on BOTH paths) --------------------
+  // NB: this is THIS NODE's belief about ITS OWN membership.  It is one enum
+  //  per barrier, not a map over nodes - the owner keeps no per-node map
+  //  (NOTIFICATION_PROTOCOL §3).
+  enum MemberState : uint8_t { MEMBER_NO = 0, MEMBER_PENDING = 1, MEMBER_YES = 2 };
+  MemberState member          = MEMBER_NO;
+  uint64_t    my_set_ver      = 0;     // highest setVer applied here (rule 2)
+  bool        pull_outstanding = false; // rule 7: at most one outstanding pull
+  gen_t       last_consult_wm = 0;     // rule 8 idle counter, in GENERATIONS
+  gen_t       last_depart_wm  = 0;     // for the churn test that doubles K
+  unsigned    depart_K        = 8;     // K, doubled on observed churn
+  bool        depart_outstanding = false;
+
+  // ---- scalable arrival: the plan record, on every node -------------------
+  ArrivalPlan cur_plan;                // curPlan[n]
+  uint32_t    my_epoch    = 0;         // myEpoch[n]
+  uint32_t    inval_epoch = 0;         // invalEpoch[n]
+  uint32_t    defer_epoch = 0;         // deferEpoch[n], 0 = none
+
+  // At most ONE parked plan (BarrierArrive BoundedRetention).  This holds the
+  //  encoded SUBTREE payload, not just an epoch, because the node must forward
+  //  it to its own children when the invalidation lands.  COPIED out of the
+  //  active-message buffer before the handler returns (§5 R4).
+  std::vector<unsigned char> deferred_plan_payload;
+
+  // ---- alteration state on the ISSUING node -------------------------------
+  // myTs[n][g] as a step function: the greatest breakpoint <= g gives the
+  //  timestamp this node's arrivals for g must carry.  Alterations are
+  //  persistent, so this is a handful of entries, pruned at trigger.
+  std::map<gen_t, Barrier::timestamp_t> ts_floor;
+
+  // ---- external waiters (bridges to tier 4) -------------------------------
+  bool has_external_waiters = false;
+
+  // ---- owner-only / legacy-only sub-state ---------------------------------
+  std::unique_ptr<OwnerState>            owner_state;  // non-null iff owner == me
+  // D1: NO separate object. These live directly in BarrierImpl and are used
+  //  only when redop_id != 0 (the legacy eager path).
+  std::map<unsigned, gen_t> remote_trigger_gens, remote_subscribe_gens;
+  std::map<gen_t, gen_t>    held_triggers;
+  std::vector<char>         final_values;
+```
+
+#### 2.4.2 `ArrivalPlan` — `curPlan[n]`, O(fanout)
+
+```cpp
+  struct ArrivalPlan {
+    uint32_t            quota  = 0;      // predicted local arrivals
+    bool                inplan = false;  // membership rule: quota 0 => not in the
+                                         //  tree at all (ARRIVAL §3)
+    NodeID              parent = -1;     // -1 means "report direct to owner";
+                                         //  stored, not derived (ARRIVAL §8.1)
+    std::vector<NodeID> kids;            // O(radix)
+  };
+```
+
+`ParentOf` in the model is a global search (`BarrierArrive:144-146`); the implementation
+stores it. `inplan == false` ⇒ `parent` is unused and every arrival goes `direct` to
+the owner.
+
+#### 2.4.3 `Generation` — per open generation
+
+```cpp
+  class Generation {
+  public:
+    EventWaiter::EventWaiterList local_waiters;
+
+    // ---- scalable arrival, every node ------------------------------------
+    int64_t local_total = 0;   // localTotal[n][g]  (COUNTS UP, see D4)
+    int64_t reported_up = 0;   // reportedUp[n][g]
+    int64_t child_sum   = 0;   // running sum of child_acc[*].total
+    bool    flushing    = false;
+
+    struct ChildReport {
+      int64_t                  total = 0;  // staleness key (rule 7)
+      std::map<NodeID,int64_t> counts;     // per-node map; NON-EMPTY ONLY in
+                                           //  flush mode (ARRIVAL §11.1)
+    };
+    // childAcc[n][c][g].  Keyed by sender, NOT by the current child list -
+    //  ARRIVAL §8.2 requires accepting reports from nodes not listed as kids.
+    std::map<NodeID, ChildReport> child_acc;
+
+    // ---- owner only -------------------------------------------------------
+    int64_t ts_acc = 0;                              // tsAcc[g]
+    std::map<Barrier::timestamp_t,int64_t> ts_pending; // arrivals waiting on the
+                                                       //  alteration they witnessed
+
+    // ---- legacy (reduction) only -----------------------------------------
+    int                            unguarded_delta = 0;
+    std::map<int, PerNodeUpdates*> pernode;
+  };
+```
+
+Derived, never stored:
+
+```
+  SubtreeKnown = local_total + child_sum
+  Unreported   = SubtreeKnown - reported_up
+  Holding      = Unreported > 0
+  PlanSatisfied = cur_plan.inplan
+                  && local_total == cur_plan.quota
+                  && every k in cur_plan.kids has child_acc[k].total > 0
+```
+
+The flush report's `(node,count)` map is also derived on demand —
+`{me: local_total} ∪ ⋃_c child_acc[c].counts` — so the merged map is never a member.
+That is D9.
+
+#### 2.4.4 `OwnerState` — owner only
+
+```cpp
+  struct OwnerState {
+    // ---- notification (NOTIFICATION_PROTOCOL §3) -------------------------
+    MulticastTargetSet sub_set;       // D8: the wire form IS the storage form
+    uint64_t set_ver  = 0;            // bumped on EVERY change to sub_set
+    MulticastTargetSet want_out;      // departure intents, usually empty
+
+    // derived form for multicast + the rule-3 cost test; valid iff
+    //  cached_ver == set_ver
+    uint64_t           cached_ver = ~uint64_t(0);
+    MulticastTargetSet cached_targets;
+
+    // ---- arrival: the expected count, as a step function -----------------
+    // expected(g) = expected_floor + sum of alter_steps entries with key <= g.
+    // Alterations are PERSISTENT (D5), so this is base + accumulated deltas,
+    //  NOT a per-generation delta.
+    int64_t                 expected_floor = 0;   // == base_arrival_count at init
+    std::map<gen_t,int64_t> alter_steps;          // breakpoints above the watermark
+
+    // appliedTs, with the generation each alteration applies from, so entries
+    //  can be pruned (§7.3).  Gate is EXACT membership, never "<= max" -
+    //  two alterations from one node can be applied out of order.
+    std::map<Barrier::timestamp_t, gen_t> applied_ts;
+
+    // ---- arrival: plan epochs --------------------------------------------
+    uint32_t next_epoch          = 1;
+    bool     plan_rebuild_pending = false;   // set by any deviation signal
+  };
+```
+
+`ownerAcc[g]` from the model is **not** a separate member: at the owner it is exactly
+`generations[g]->child_sum`, and the model's
+`ownerAcc' = @ - childAcc[Owner][from][g] + val` is the incremental maintenance of that
+sum. Keeping one representation removes a whole class of divergence bug.
+
+#### 2.4.5 Legacy reduction members — reduction barriers only
+
+> **§0/D1: these are plain `BarrierImpl` members, not a separate object.** The
+> text below describes which members they are; ignore the wrapper struct.
+
+```cpp
+  // D1: plain BarrierImpl members - NO wrapper object.  Used only when
+  //  redop_id != 0; inert on the scalable path.
+  std::map<unsigned, gen_t> remote_subscribe_gens;
+  std::map<unsigned, gen_t> remote_trigger_gens;   // KEPT: slices final_values
+                                                   //  per recipient
+  std::map<gen_t, gen_t>    held_triggers;         // KEPT: legacy path only
+  std::unique_ptr<char[]>   initial_value;
+  unsigned                  value_capacity = 0;
+  std::vector<char>         final_values;
+```
+
+Rationale for keeping `held_triggers` here rather than deleting it everywhere: C1's
+mandate is "route reduction barriers to the legacy path", and the lowest-risk reading
+of that is a pure relocation. The deletion-map scout is right that reduction barriers
+could also move to discard-and-pull, but that is a change to a path this project is not
+otherwise touching, and it would need its own tests.
+
+### 2.5 Tier 4 — external wait
+
+```cpp
+  KernelMutex           external_waiter_mutex;    // INNER lock
+  KernelMutex::CondVar  external_waiter_condvar;
+```
+
+Unchanged, including the hand-over-hand handoff at `barrier_impl.cc:1148-1152`. See
+§3.6.
+
+### 2.6 What is deleted
+
+Everything below goes, on both paths, in stage C1.
+
+| Deleted | Where | Why |
+|---|---|---|
+| `BarrierMigrationMessage` (struct, handler, registration) | `cc:296-319`, `:1573` | migration removed; unreachable today (needs `forwarded`, which needs a stale `owner`) |
+| Migration election block + `#define DISABLE_BARRIER_MIGRATION` | `cc:28`, `:902-924` | already compiled out; its `redop == 0` guard shows it never served reduction barriers |
+| `migration_target` — wire field, parameter, both receive blocks | `h:40,86,95,157,168`, `inl:87`, `cc:335,362-368,799,1011-1015,1474-1478` | always `-1` on the wire |
+| `inform_migration` (both sites) and the `subscriber == my_node_id` self-loop guard | `cc:801,812-819,992-995,1275,1287-1294,1354-1359` | migration machinery |
+| `bool forwarded` — 4 signatures, 3 structs, ~29 refs | `h:61,68,147,152`, `cc:188,263,559-601` | its only two readers were the `inform_migration` branches |
+| `base_arrival_count` on the trigger message | `h:87` | its only consumer was gated on `migration_target != -1`; the count moves to `newplan` |
+| `needs_ordering`, `ordered_buffer` | `h:222-223` | never read |
+| `broadcast_radix`, `get_broadcast_targets`, `broadcast_trigger`, `BarrierTriggerPayload`, `BarrierTriggerMessageArgs{,Internal}`, `RemoteNotification`, their `serdez` | `h:35-54,74-77,164-171,224`, `inl:31,62-92`, `cc:659-725,1029-1036,1363-1397` | the `BARRIER_ENABLE_BROADCAST` half; superseded by `realm/multicast.h`, and it references `ActiveMessageAuto`/`AutoMessageRegistrar`, which do not exist in the tree |
+| `BarrierImpl::handle_remote_trigger` | `cc:1405-1541` | the second, divergent, *unlocked* copy of the trigger receive path |
+| `held_triggers` drain loops + `held_triggers[prev] = trigger_gen` on the scalable path | `cc:377-389,408-414` (and the dead twin at `:1487-1499,1520-1525`) | notification rule 4: discard and pull. The `previous_gen` **field and the gap test at `cc:375` stay** — they become rule 4's `gap == m.prev > known` |
+| `remote_trigger_gens` / `remote_subscribe_gens` on the scalable path | `h:213` | replaced by `sub_set` + `set_ver`; the maps survive only inside the legacy reduction members |
+| `gen_subscribed` | `h:175` | replaced by `member` + `pull_outstanding` |
+| `#ifdef BARRIER_HAS_TRIGGERED_DOES_SUBSCRIBE` block | `cc:1055-1086` | defined nowhere; it is the exact anti-pattern §4 forbids |
+| `-ll:barrier_radix` / `barrier_broadcast_radix` config | `runtime_impl.cc:763,803`, `runtime_impl.h:187` | **only if** `activemsg.cc:1691-1700` does not still consume it — the scout reports it does. Verify before removing the key; the *barrier's* use of it goes regardless |
+
+Also deleted, though not a member: the four `TimeLimit::responsive()` call sites
+(`cc:95,125,1239` and the deferred-arrival path). See §5 R2.
+
+### 2.7 Memory bound
+
+Arrival §11.3 requires O(fanout), not O(N). Per barrier, per node, with `R` = plan
+radix, `G` = open (untriggered, locally-known) generations, `N` = nodes:
+
+| Component | Steady state | Deviation episode | Freed by |
+|---|---|---|---|
+| tier 0 + tier 1 + tier 2 scalars | ~96 B | — | destroy |
+| `poisoned_generations` | 0 B until a generation is actually poisoned, then 64 B (16 × `gen_t`) | — | destroy |
+| `cur_plan` | O(R) — 24 B + 4R | — | plan switch |
+| `deferred_plan_payload` | 0 | **O(subtree)** bytes, at most one | the invalidation that applies it |
+| `generations` | G × (~120 B + O(R) child entries) | G × O(deviating senders) | the generation's trigger |
+| `ts_floor` | O(1) — one live breakpoint | O(open alterations) | trigger (prune) |
+| **owner** `sub_set` | 16 B inline for ≤4 subscribers or ≤2 ranges; otherwise a pooled bitmask, `N/8` B | — | destroy |
+| **owner** `cached_targets` | O(ranges) | — | rebuilt on `set_ver` change |
+| **owner** `want_out` | 16 B (normally empty) | O(departing) bits | applied at the next trigger |
+| **owner** `alter_steps`, `applied_ts` | O(nodes that ever altered *this* barrier) | — | trigger (prune) |
+| **owner** aggregation structure | **does not exist** (D9) | is the per-generation flush maps | the generation's trigger |
+| legacy the legacy reduction members | O(N) maps + O(generations × sizeof_lhs) | — | destroy. Reduction barriers are explicitly not scalable |
+
+Two honest statements:
+
+- **The only O(N) term on the scalable path is the owner's subscriber set, and it is a
+  bitmask, not a map.** Today the owner holds `remote_subscribe_gens` **and**
+  `remote_trigger_gens`, two `std::map<unsigned,gen_t>` at roughly 48 B per node per
+  barrier — about 96·N bytes. The replacement is N/8 bytes worst case and *zero
+  additional allocation* whenever the subscriber set is ≤4 nodes or ≤2 contiguous
+  ranges, which covers "a few waiters" and "everybody". That is the O(N²)-across-N
+  barriers reduction notification §3 is asking for; it is a large constant-factor and
+  representation win, not an asymptotic one for the pathological scattered case.
+- **The deviation-episode terms are genuinely O(subtree)**, and both of them —
+  `deferred_plan_payload` and the per-generation flush maps — are bounded by the ~1 MB
+  `MessageBlock` ceiling on the receive side (`activemsg.cc:353`, an assert, and
+  fragmentation does **not** raise it because reassembly happens first). Whether that
+  ceiling can be reached at target scale is Q6.
+
+---
+
+## 3. The critical sections
+
+### 3.1 Lock inventory and order
+
+| Lock | Kind | Scope |
+|---|---|---|
+| `BarrierImpl::mutex` | `UnfairMutex`, non-reentrant | all of tier 3, including everything behind `owner_state` / `legacy` / `generations` |
+| `BarrierImpl::external_waiter_mutex` | `KernelMutex` | the condvar handoff only |
+
+**Order: `mutex` (OUTER) → `external_waiter_mutex` (INNER). Never the reverse.** The
+three existing signal sites (`cc:449-454`, `:968-974`, `:1527-1533`) already obey this
+and the broadcast must stay *inside* the outer section — it is what pairs with the
+hand-over-hand in `external_wait`.
+
+There is exactly one lock per barrier. Arrival §12 asks for each ACTION to be atomic
+with respect to that barrier's state; a single per-barrier mutex satisfies it trivially.
+Splitting per-generation state under a second lock would tear `Arrive`, which reads
+`flushing`, the quota, the child check and `local_total` together — a §12 defect. See
+Q7 for the arrival-rate question.
+
+### 3.2 The five structural rules
+
+**S1 — A critical section may perform a *sequence* of whole spec actions, never a
+*fraction* of one.** Merging is always sound (it is two atomic actions with no
+interleaving, which the spec permits); splitting is a defect even when both halves are
+locked, because the model never exposes the intermediate state and no invariant
+constrains it. This is what lets `Arrive` and the `Trigger` it completes share one
+section.
+
+**S2 — Compute under the lock, emit after it.** Never send an active message and never
+invoke a waiter callback while holding `mutex`. Under the lock, append to a local list
+of outbound actions; release; then send.
+
+**S3 — The emit phase reads only locals.** Every outbound message is fully materialised
+inside the section: target node, generation, values, and any payload bytes. The emit
+phase must not read `first_generation`, `redop_id`, `base_arrival_count`, `cur_plan`, or
+anything else off `this`. This is a live defect today at `cc:1022-1028` and
+`cc:1364-1367`, and it is what makes `RecvInvalidate`'s "forward before forgetting" work
+without effort: the target was resolved before the child list was replaced.
+
+**S4 — Every helper declares its locking contract.** A helper that assumes the lock is
+held says so in its name (`..._locked`) and asserts it with a `MutexChecker`
+(`mutex.h:80-112`, already in the tree). `broadcast_trigger` — called once with the lock
+and once without — is the anti-pattern being removed.
+
+**S5 — Emit-after-unlock is admissible for every message in both protocols.** Two
+threads can leave the lock in one order and reach the wire in the other; that is
+indistinguishable from network reordering, which both models already explore because
+`msgs` is a set. Per kind:
+
+| Kind | Why reordering is harmless |
+|---|---|
+| `report`, `direct` | cumulative; receiver replaces and drops non-increasing (rule 7) |
+| `flush` | idempotent per generation (rule 4) |
+| `invalidate`, `newplan` | epoch-monotone; the deferral rule is *specifically* the verified resolution of these two racing (rule 5) |
+| `alter` | `expected` is updated by addition (commutes); `applied_ts` is a set insert (commutes) |
+| `tsdirect` | counted by addition; the gate is exact-set membership, so it needs no ordering with respect to its `alter` — parking it is the designed behaviour |
+| `notify` | gap rule discards what it cannot apply; membership is version-gated, so an older shrink notice cannot resurrect membership (rule 2) |
+| `subscribe`, `reply` | reply is a delta keyed on `lk`, merged not substituted (rule 5) |
+
+The one thing that is *not* reorder-tolerant is publishing a shrink to the post-shrink
+set. That is handled by snapshotting the **pre-shrink** target set inside the section
+(§3.4, action T) — not by ordering.
+
+### 3.3 Notation
+
+`recorded` means "appended to a local outbound list, emitted after the unlock".
+`drained` means "absorbed into a local `EventWaiter::EventWaiterList`, triggered after
+the unlock". All actions below hold `BarrierImpl::mutex` for exactly one section unless
+stated.
+
+### 3.4 Action → critical section
+
+#### A — `Arrive(n,g)` — `BarrierArrive:182`
+Entry points: `Barrier::arrive`, `DeferredBarrierArrival::event_triggered`, subgraph
+arrivals (`tests/subgraphs.cc:214-248` reaches `adjust_arrival` by a different route and
+must land on the same routing decision).
+
+One section:
+1. `g <= generation` ⇒ **application error** (arriving on a triggered generation), log
+   fatal. Distinct from a stale *message*, which is silently dropped (action R step 1).
+   The current `assert(barrier_gen > generation.load())` at `cc:827` conflates the two.
+2. Find or create `generations[g]`.
+3. `ts = greatest ts_floor entry with key <= g` (0 if none).
+4. **If `ts != 0`** (rule 8.1): the arrival **bypasses the tree**. Do *not* touch
+   `local_total`. Record `tsdirect(owner, g, ts, count)`. If this node is the owner,
+   perform action TS inline instead of recording a message.
+5. **Else** `local_total += count`; `sub = local_total + child_sum`; then exactly one of:
+   - `flushing` ⇒ record `report(cur_plan.parent, g, sub, flush_map)`; `reported_up = sub`
+   - `!cur_plan.inplan` ⇒ record `direct(owner, g, sub, {me: local_total})` (rule 3)
+   - `local_total > quota` ⇒ `flushing = true`; record `report(parent, g, sub, flush_map)`
+     **and** `flush(k, g)` for every `k` in `cur_plan.kids`; `reported_up = sub` (rule 2)
+   - `local_total == quota` **and** every `k` in `cur_plan.kids` has
+     `child_acc[k].total > 0` ⇒ record `report(parent, g, sub)`; `reported_up = sub`
+     (rule 1 — **both** halves; the child-wait is a correctness requirement)
+   - otherwise ⇒ **silence**, no state change beyond `local_total`
+6. If this node is the owner, evaluate action T in the same section.
+7. If the watermark advanced, signal external waiters (inner lock, still inside).
+
+Tear set honoured (§12): `local_total`, `flushing`, the quota and child check, and the
+send decision are one section. `unissued` has no implementation counterpart — it is the
+application's own arrival budget, and its guard is the API contract of
+`event.h:290-292`, not runtime state.
+
+After unlock: send; then `event_triggerer->trigger_event_waiters(drained, poisoned, work_until)`.
+
+#### R — `RecvReport(m)` / `DropStale` — `BarrierArrive:231`, `:260`
+Handler for `report` and `direct`. One section:
+1. `m.gen <= generation` ⇒ **drop silently and return.** This is what makes freeing a
+   triggered generation's record safe: without it, a late report would look
+   "increasing" from an absent `child_acc` entry and be forwarded again.
+2. Find or create `generations[m.gen]`.
+3. `m.val <= child_acc[m.from].total` ⇒ **`DropStale`**: return with no state change.
+   Never treat a report as an increment (rule 7 — accepting stale reports lets the
+   owner's count go *down*, a caught mutation).
+4. `child_sum += m.val - child_acc[m.from].total`; `child_acc[m.from].total = m.val`;
+   if the message carried a `(node,count)` map, replace `child_acc[m.from].counts`
+   wholesale (cumulative-replace applies to the map too).
+   **Accept from any `m.from`, including nodes not in `cur_plan.kids`** (§8.2 — this is
+   easy to get wrong because the defensive check looks worthwhile).
+5. If `m.kind == direct` and this node is the owner and `!flushing` ⇒ `flushing = true`
+   and record `flush(k, m.gen)` for every `k` in `cur_plan.kids` (rule 3).
+6. `sub = local_total + child_sum`; forward iff
+   `not owner && sub > reported_up && (flushing || PlanSatisfied)`; if so record the
+   report and set `reported_up = sub`.
+7. If owner, evaluate action T.
+
+`DropStale` is not a separate critical section — it is step 3's early return. The model
+makes it an action only because a set-of-messages model needs an explicit way to remove
+an element.
+
+#### F — `RecvFlush(m)` — `BarrierArrive:272`
+One section:
+1. Find **or create** `generations[m.gen]` — the record must exist even with no local
+   arrivals yet, or a later arrival will not know it is in flush mode.
+2. `flushing` already true ⇒ return (this is what terminates the fan-out).
+3. `flushing = true`; record `flush(k, m.gen)` for every `k` in `cur_plan.kids`;
+   if `Unreported > 0`, record `report(parent, m.gen, SubtreeKnown, flush_map)` and set
+   `reported_up = SubtreeKnown`.
+
+Flush is per generation. The next generation starts back in planned mode.
+
+#### T — `Trigger` — `BarrierArrive:292` **and** `BarrierNotify:96`, owner only
+**These are one critical section.** They are separate actions in two separate models but
+they are the same real-world event, they share `watermark`, and the notification's
+`prev` must be the pre-trigger watermark of the same contiguous chain. Splitting them
+leaves a window in which the watermark has advanced but no notification describes it.
+
+Guard, evaluated inside: `g == generation + 1` and
+`child_sum + local_total + ts_acc == expected(g)`.
+
+One section, in this order:
+1. **Drain the contiguous run.** While the next generation's record satisfies the guard:
+   drain its `local_waiters`; note whether it is poisoned; free the record. Record
+   `old_wm` before the loop and `new_wm` after. Coalescing several triggers into one
+   notification is explicitly supported (notification rule 8: the idle counter is
+   "measured as watermark delta since last consultation, so it is robust to the owner
+   coalescing several triggers into one notification").
+2. **Publish poison, then the watermark** — in that order, §3.5.
+3. **Prune** `alter_steps` (fold entries `<= new_wm` into `expected_floor`),
+   `applied_ts` (§7.3), and `ts_floor`.
+4. **Notification half.** Choose `R ⊆ want_out` by the cost test (rule 3: encode
+   `sub_set` with and without `R`, compare `EncodedMulticastTargets::encoded_size` and
+   the delivery count; decline shrinks that do not pay — dropping scattered nodes from
+   `ALL_NODES` turns a 0-byte encoding into a per-hop bitmap). Then:
+   - **snapshot the PRE-shrink `sub_set`** into the local outbound target set — rule 1,
+     "any shrink must be published to the PRE-shrink set";
+   - `sub_set -= R`; `set_ver += (R ∩ sub_set_pre ≠ ∅)`; `want_out -= R`;
+     invalidate `cached_ver` if the set changed;
+   - compose the notify header `(wm = new_wm, prev = old_wm, sv = set_ver)` plus poison
+     in `(old_wm, new_wm]`, and — **only if `sv` changed** — the encoded `R` as payload.
+5. **Arrival half.** If a plan switch is due at `new_wm + 1`:
+   - build the new plan from the just-drained generation's flush maps (`std::map::swap`
+     them into a local first — O(1) — then build). This is D9: there is no persistent
+     aggregation structure to forget;
+   - record `invalidate(k, my_epoch)` for every `k` in the **current** `cur_plan.kids`;
+   - install the owner's own new record; `my_epoch = k`; `inval_epoch = k - 1`;
+   - record `newplan(k, subtree payload)` for every `k` in the new plan's kids.
+   **At most one plan switch per section.** The owner chooses `PlanStart`, so it can
+   simply never schedule two switches inside one drain; this keeps the implementation a
+   faithful refinement of the model's one-switch-per-`Trigger`.
+6. Signal external waiters (inner lock).
+
+After unlock: `multicast_message` the notify to the snapshot target set; unicast the
+invalidate/newplan messages; trigger drained waiters.
+
+Tear set honoured: "count comparison and the plan switch that follows it".
+
+Note on `inset`: the model gives each recipient its own `inset` field, but a multicast
+delivers identical bytes to everyone. The resolution is that the notify carries **`R`**,
+and each recipient computes `inset = (my_node_id ∉ R)`. This is exact, because the
+message goes only to the pre-shrink set — every recipient is in it, so membership is
+precisely "not being removed". When `R = {}` the `sv` is unchanged, `newv` is false at
+every recipient, and no membership bytes are sent at all.
+
+#### I — `RecvInvalidate(m)` — `BarrierArrive:320`
+One section. **Order is load-bearing and both halves are separately verified.**
+1. `inval_epoch >= m.epoch` ⇒ return.
+2. **Forward first.** Record `invalidate(k, m.epoch)` for every `k` in the **current**
+   `cur_plan.kids`, *before* anything replaces that list. Dropping the child list first
+   strands the whole subtree — a caught mutation.
+3. **Flush every open generation, not just the switch generation.** For every record in
+   `generations` with `gen > generation`: set `flushing = true`; if `Unreported > 0`
+   record `report(cur_plan.parent, gen, SubtreeKnown, flush_map)` and set `reported_up`.
+   The target is `cur_plan.parent` as it is *now* — the old parent — which S3 gives for
+   free because the target is resolved into the recorded message before step 5 replaces
+   the plan. Flushing only the switch generation is a caught mutation.
+4. `inval_epoch = m.epoch`.
+5. If `defer_epoch != 0`: decode and install the parked plan; `my_epoch = defer_epoch`;
+   record `newplan` to the parked plan's kids; `defer_epoch = 0`; free
+   `deferred_plan_payload`.
+
+#### P — `RecvNewPlan(m)` — `BarrierArrive:358`
+One section:
+1. `my_epoch >= m.epoch` ⇒ drop.
+2. **`cur_plan.inplan && inval_epoch < my_epoch` ⇒ PARK.** `defer_epoch = m.epoch`;
+   **copy** the subtree payload into `deferred_plan_payload` (the AM buffer is dead
+   after the handler returns). At most one parked plan — a second one replaces it, which
+   is safe because epochs are monotone. This is the deferral whose removal TLC catches
+   in ~46 s as `ReachableWhileHolding`.
+3. Otherwise install: `cur_plan = my record from the payload`; `my_epoch = m.epoch`;
+   record `newplan` with the appropriate sub-subtree for each of the new kids; and for
+   every open generation with `Unreported > 0`, record a report and set `reported_up`.
+   **Do not set `flushing` here** — the model reports held work but leaves the flag
+   alone (`BarrierArrive:367-377`), because the new plan is authoritative and the node can
+   aggregate under it.
+
+#### AL — `Alter(delta)` — `BarrierArrive:391`, on the issuing node
+`Barrier::alter_arrival_count`. One section — the timestamp is minted **inside** it.
+Today it is minted at `cc:91` and consumed at `cc:839` in a different section.
+1. Mint `ts = barrier_adjustment_timestamp.fetch_add(1)`. The counter is seeded at
+   `runtime_impl.cc:1962-1965` with `my_node_id << 48`, so timestamps are globally
+   unique and **monotone per node**.
+2. Reserved-arrival guard: the caller must still hold an unissued arrival from the
+   pre-alteration count (`event.h:290-292`). The runtime cannot check this; it is the
+   API contract, and removing the model's guard is caught by `TriggerCorrect`.
+3. `ts_floor[g] = ts` — every subsequent arrival for `g' >= g` now carries `ts` and
+   bypasses the tree.
+4. **Enter eager flush for every affected open generation** (`g' >= g`, untriggered):
+   `flushing = true`; record `flush` to `cur_plan.kids`; if `Unreported > 0` record a
+   report. Skipping this is a caught mutation (deadlock): a node whose arrivals bypass
+   the tree can never reach its own quota, so as a *relay* it would go silent and strand
+   its children.
+5. Record `alter(owner, g, delta, ts)`; if this node is the owner, run action RA inline.
+6. If `delta < 0` (rule 9): the alteration also invalidates the plan — set
+   `plan_rebuild_pending` at the owner (or let the owner set it on receipt).
+
+Tear set honoured: "reserved-arrival guard, `unissued`, `myTs`, flush state, sends".
+
+#### RA — `RecvAlter(m)` — `BarrierArrive:431`, owner only
+One section:
+1. `m.gen <= generation` ⇒ **contract violation** (`event.h:305-306` names the symptom
+   as "a barrier that triggered too early"). Log fatal; still apply persistently for
+   generations above the watermark so later counts stay consistent.
+2. `alter_steps[m.gen] += m.delta`. If `expected(g)` would become `<= 0` for any open
+   generation ⇒ fatal (rule 9: a zero base arrival count is an error, and it is what
+   makes 0 a safe sentinel).
+3. `applied_ts[m.ts] = m.gen`.
+4. **Drain the gate**: for every open generation, move any `ts_pending[t]` with
+   `t ∈ applied_ts` into `ts_acc`. Steps 3 and 4 must be in the same section — the model
+   expresses this as `RecvTsDirect` becoming *enabled*, and fusing an enabling action
+   with the action it enables is a legal refinement.
+5. If `m.delta < 0`: `plan_rebuild_pending = true`; enter flush for the affected open
+   generations and record the fan-out.
+6. Evaluate action T.
+
+#### TS — `RecvTsDirect(m)` — `BarrierArrive:447`, owner only
+One section:
+1. `m.gen <= generation` ⇒ drop.
+2. `m.ts ∈ applied_ts` ⇒ `ts_acc += m.count`; evaluate action T.
+3. Otherwise `ts_pending[m.ts] += m.count` — parked until its alteration lands.
+
+**The wire form carries a count, not a `seq`.** `seq` (`BarrierArrive:192`) exists only to
+keep two identical arrivals from collapsing into one element of a message *set*
+(§8.4); putting it on the wire would be implementing a modelling artifact.
+
+The gate is **exact set membership**, never `ts <= max_applied_ts_for_node`. Two
+alterations from one node can be applied out of order (messages reorder), and a
+"max" gate would admit an arrival whose alteration has not yet been applied — a safety
+failure. The existing code's `pn->last_ts` comparison at `cc:647` is precisely that
+shape and carries its own `TODO: really need two timestamps` comment.
+
+#### C — `Consult(n,g)` — `BarrierNotify:116`
+Entry points: `add_waiter`, `subscribe`, `external_wait`, `external_timedwait`.
+**Explicitly NOT `has_triggered`** — see §4.
+
+One section:
+1. `g <= generation` ⇒ record `trigger_now` (and the poison answer); skip to 3.
+2. Find or create `generations[g]`; push the waiter (for `add_waiter`).
+3. `last_consult_wm = generation` — the idle counter reset. In the model this is
+   `wantOut' = wantOut \ {n}`; the node-side realisation is resetting its own counter,
+   and the owner-side realisation is that any `subscribe` removes the node from
+   `want_out` (action S step 1).
+4. If `owner != my_node_id && member == MEMBER_NO && !pull_outstanding`:
+   record `subscribe(owner, lk = generation)`; `pull_outstanding = true`;
+   `member = MEMBER_PENDING`.
+
+After unlock: send; if `trigger_now`, call `waiter->event_triggered(poisoned, work_until)`
+with the **caller's** budget, never a manufactured one (§5 R2).
+
+`subscribe` carries **both** `lk` (what I have) and `subscribe_gen` (what I need).
+`lk` is what replaces the pull-side `remote_trigger_gens` lookup (notification rule 5);
+`subscribe_gen` is still needed by the legacy path's one-shot `remote_subscribe_gens`
+erase, and it is 4 bytes.
+
+#### N — `RecvNotify(m)` — `BarrierNotify:136`, scalable path only
+One section, in this order:
+1. `newv = m.sv > my_set_ver`. If `newv`: `member = (my_node_id ∈ decoded R) ? MEMBER_NO
+   : MEMBER_YES`; `my_set_ver = m.sv`. **Membership is applied even on a gap** — this
+   message may be the node's only notice of its own removal (`BarrierNotify:148-151`).
+2. `gap = m.prev > generation`; `fresh = !gap && m.wm > generation`.
+3. If `fresh`: append the poison entries in `(m.prev, m.wm]` (deduplicated) and publish;
+   then `generation.store_release(m.wm)` (§3.5); drain every `generations` record with
+   `gen <= m.wm` and free it; signal external waiters.
+   If `gap`: **discard the delta entirely.** Do not buffer it. `held_triggers` is not
+   coming back — pulling is strictly simpler because the pull path has to exist anyway.
+4. `resub = (member == MEMBER_NO) && waiters remain`; if so `member = MEMBER_PENDING`.
+5. `pull = (gap || resub) && !pull_outstanding` ⇒ record
+   `subscribe(owner, lk = generation)`; `pull_outstanding = true`.
+6. Departure hysteresis (rule 8), evaluated here because this is where the watermark
+   advances: if `member == MEMBER_YES && no waiters && !depart_outstanding &&
+   (generation - last_consult_wm) >= depart_K + (my_node_id % J)` ⇒ record
+   `depart(owner)`; `depart_outstanding = true`; `last_depart_wm = generation`.
+   **The stagger is expressed in generations, not in time**, so it needs no timer and
+   the protocol stays feed-forward.
+
+"Waiters remain" is `any record in generations has a non-empty local_waiters, or
+has_external_waiters` — the model's `waiting[n] # {}`. No new member is needed.
+
+#### S — `RecvSubscribe(m)` — `BarrierNotify:175`, owner only
+One section:
+1. `sv2 = (m.from ∈ sub_set) ? set_ver : set_ver + 1`; `sub_set.add(m.from)`
+   — **unconditionally; adds are mandatory** (rule 3: refusing an add strands a waiter);
+   `set_ver = sv2`; `want_out.remove(m.from)`; invalidate `cached_ver` if the set changed.
+2. Compose the reply: `wm = generation`, `pois = poison ∩ (m.lk, generation]`,
+   `sv = sv2`. **The reply must carry the watermark** — that is what covers the
+   trigger-during-subscribe race, and omitting it is caught as a deadlock.
+3. If `redop_id != 0`: instead compose the **legacy** trigger message (`final_values`
+   slice derived from `m.lk`) and maintain `legacy->remote_subscribe_gens` /
+   `legacy->remote_trigger_gens` exactly as today. One subscribe message type, two reply
+   shapes, forked at the owner — which is why a remote node never needs to know in
+   advance whether the barrier is a reduction barrier (D2).
+
+The set mutation and the `sv` stamping are in one section because rule 2 requires it.
+
+#### RP — `RecvReply(m)` — `BarrierNotify:187`
+One section:
+1. `pull_outstanding = false`.
+2. `newv = m.sv > my_set_ver` ⇒ `member = MEMBER_YES`; `my_set_ver = m.sv`. The same
+   version gate is required here — a stale reply resurrects membership exactly the way a
+   stale notify does.
+3. `fresh = m.wm > generation` ⇒ **union** `m.pois` into the poison array (dedup),
+   publish, then `generation.store_release(m.wm)`; drain and free satisfied records;
+   signal external waiters.
+   **Union, never substitute** — substituting drops poison the node already knew about
+   below `lk`. Caught by `PoisonAccurate`.
+4. If `!fresh`, do not merge poison. Safe because `PoisonAccurate` says the node's
+   knowledge is already exactly the truth up to its own (higher) watermark.
+
+#### D — `Depart(n)` — `BarrierNotify:210`
+Not a message receipt and not a timer. The eligibility test lives in action N step 6
+(and in RP, at the same point) because that is where the watermark moves. The unicast is
+emitted after the unlock.
+
+Owner side: the `depart` handler takes one section and does `want_out.add(m.from)`.
+It is applied — or declined — at the next `Trigger` (action T step 4).
+
+`depart_outstanding` is cleared when the node next consults (action C) or when it is
+removed (action N step 1 sets `member = MEMBER_NO`). Churn adaptation: if the node
+re-subscribes with `generation - last_depart_wm` below a small window, `depart_K *= 2`
+(capped). Both are node-local and cost 8 bytes.
+
+### 3.5 Publication order for the lock-free tier
+
+Every writer, inside `mutex`:
+
+```
+  for each newly poisoned generation g in (old_wm, new_wm]:
+      poisoned_generations[n++] = g;          // plain store, slot not yet published
+  num_poisoned_generations.store_release(n);  // publishes the slots
+  generation.store_release(new_wm);           // publishes the watermark
+```
+
+Reader (`has_triggered`), no lock:
+
+```
+  gen_t wm = generation.load_acquire();
+  if (needed_gen > wm) { poisoned = false; return false; }
+  poisoned = is_generation_poisoned(needed_gen);   // acquire-load the count, scan
+  return true;
+```
+
+Why this is sufficient: the reader's acquire load of `generation` synchronises with the
+writer's release store, so every poison slot written before that store is visible.
+Slots are **append-only and never rewritten**, so a concurrent later append can only
+extend the array beyond the count the reader observes, and the reader's own acquire load
+of the count bounds its scan to slots whose writes happen-before that count's release
+store. This is exactly `GenEventImpl::is_generation_poisoned`
+(`event_impl.cc:1396-1410`), which is already lock-free in production.
+
+### 3.6 External wait
+
+`external_wait` / `external_timedwait` keep the hand-over-hand handoff verbatim
+(`cc:1148-1152`): `external_waiter_mutex.lock(); mutex.unlock(); condvar.wait();
+external_waiter_mutex.unlock(); mutex.lock();`. That is what makes the signal
+lost-wakeup-free — the signaller cannot enter `external_waiter_mutex` until the waiter
+is already inside `wait()`, because until then the waiter still holds the outer mutex.
+
+Do not "simplify" this by moving `external_wait` off `mutex` on the strength of
+`generation` being atomic. It would shrink the `Trigger` section (no nested
+`KernelMutex` acquisition), but the lost-wakeup argument has to be re-derived from
+scratch together with all three signal sites. Q9.
+
+### 3.7 The §12 tear table, honoured
+
+| Action (§12) | Reads/writes that must not tear | Section |
+|---|---|---|
+| `Arrive` | `unissued`, `localTotal`, `flushing`, quota + child check, then the send | A, steps 2–5 (the send is *recorded* in the section) |
+| `RecvReport` | staleness test, `childAcc`, recomputed subtree total, forward decision, `reportedUp` | R, steps 3–6 |
+| `RecvInvalidate` | child list read **before** it is replaced, every open generation flushed, parked plan applied | I, steps 2–5, in that order; S3 makes step 2's target survive step 5 |
+| `Trigger` | count comparison and the plan switch that follows it | T, one section, together with the notification `Trigger` |
+| `Alter` | reserved-arrival guard, `unissued`, `myTs`, flush state, sends | AL, including the timestamp mint |
+
+---
+
+## 4. The `has_triggered` carve-out
+
+`BarrierImpl::has_triggered` is already what §12 demands (`cc:1046-1054`) and must stay
+that way.
+
+```cpp
+  bool BarrierImpl::has_triggered(gen_t needed_gen, bool &poisoned)
+  {
+    // TIER 0 ONLY.  No lock.  No allocation.  No message.  No member write.
+    gen_t wm = generation.load_acquire();
+    if(needed_gen > wm) {
+      poisoned = false;
+      return false;
+    }
+    poisoned = is_generation_poisoned(needed_gen);
+    return true;
+  }
+```
+
+Cost: one acquire load, plus — only when the generation has triggered — one more
+acquire load and a scan bounded by the poison limit. **The poison machinery costs
+nothing at all until a barrier is actually poisoned**, because
+`num_poisoned_generations` is 0 and the early-out in `is_generation_poisoned` returns
+immediately, exactly as `GenEventImpl` does today.
+
+Three prohibitions, all of which the current file demonstrates the temptation for:
+
+1. **No subscribe.** Delete the `#ifdef BARRIER_HAS_TRIGGERED_DOES_SUBSCRIBE` block
+   (`cc:1055-1086`). It is defined nowhere in the tree and it is a ready-made regression:
+   it takes `mutex`, mutates `gen_subscribed`, and sends.
+2. **No consultation signal.** Notification rule 8 defines *consulting* as `add_waiter`,
+   `subscribe`, `external_wait`/`external_timedwait`, and **explicitly not**
+   `has_triggered`. `last_consult_wm` is written **only** in action C, which already
+   holds the lock for other reasons. Nothing on the `has_triggered` path may touch it.
+3. **No member write of any kind**, including a relaxed store. The reason to be
+   absolute: the moment one relaxed store is permitted, the natural next step is a
+   second, then a compare-exchange, then a `trylock`.
+
+**How the prohibition is enforced, not merely stated:**
+
+- `last_consult_wm`, `member`, `pull_outstanding` and `depart_*` are tier-3 members, and
+  tier 3 is defined as "every access inside `mutex`". A `MutexChecker` (`mutex.h:80-112`)
+  asserting the barrier lock is held can be placed in the `..._locked` helpers that own
+  them, which makes a stray write from `has_triggered` fail in a debug build rather than
+  silently.
+- Plan §4 risk 4 ("`has_triggered` regressing to take a lock") gets an explicit test:
+  Phase F asserts that `has_triggered` on a fresh `BarrierImpl` built with a mock
+  communicator sends **zero** messages and leaves `member`, `pull_outstanding` and
+  `last_consult_wm` unchanged across a large number of calls, including after a trigger.
+
+**The consequence, stated plainly:** a node that only ever polls `has_triggered` never
+subscribes, so it is never in `sub_set` and is never notified. That is already true
+today. What is *new* is that a node which subscribed once and then only polls will be
+departed after `K + (id % J)` idle generations and will then poll a frozen watermark
+forever. `benchmarks/task_throughput/task_throughput.cc:92-101` contains exactly that
+loop (behind `TestConfig::use_posttriger_barrier`, default false). See Q4 — this needs a
+decision, and it is the one place where the carve-out and rule 8 genuinely pull against
+each other.
+
+---
+
+## 5. The deferred-handler hazard
+
+The previous attempt did not fail on protocol logic. It failed because barrier code
+called
+
+```cpp
+  get_runtime()->event_triggerer.trigger_event_waiters(list, POISON_FIXME, work_until);
+```
+
+with a manufactured 10 µs `TimeLimit::responsive()`. `trigger_event_waiters`
+(`event_impl.cc:456-511`) drains through `static thread_local` lists and never touches
+`this` — **until** the budget expires with waiters still queued, at which point
+`event_impl.cc:497-507` locks `this->mutex` and `make_active()` reads `this->manager`
+(`bgwork.cc:386`). With a null `runtime_singleton` both are null-derived. The bug is
+invisible with one waiter, invisible when the callbacks are fast, and fatal under load.
+
+Six rules. R1 is the structural one; the rest are defence in depth.
+
+**R1 — `BarrierImpl` must never call `get_runtime()`.** Every collaborator is injected
+(§2.3) via `BarrierImplAllocator`, the same mechanism `GenEventImpl` already uses. After
+this change the failing expression is `event_triggerer->trigger_event_waiters(...)` on an
+injected, non-null pointer, and the null-runtime path *does not exist* — including in
+`realm_unit_tests`, where `runtime_singleton` is null for the whole binary. Grep target:
+zero occurrences of `get_runtime` in `barrier_impl.cc`.
+
+**R2 — Propagate `TimeLimit`; never manufacture one.** `TimeLimit::responsive()` must
+not appear anywhere in barrier code. Handlers propagate the `work_until` they were given.
+Public API entry points that have no inbound budget (`Barrier::arrive`,
+`Barrier::alter_arrival_count`, the immediate-trigger path in `add_waiter`) pass a
+default-constructed `TimeLimit()`, which is infinite (`timers.inl:289-292`). An infinite
+budget means `trigger_event_waiters` never takes the deferral branch and never touches
+`this` at all — the hazard is removed at the source rather than survived. An application
+thread that completes a generation has no bgwork quantum to respect; shortening its
+budget buys nothing and costs the deferral.
+
+**R3 — No `handle_inline` on any barrier handler.** (D10.) The inline contract
+(`activemsg.h:326-335`) forbids blocking on a mutex and forbids allocation; every barrier
+action takes `mutex` and touches maps. Multicast-delivered notifications arrive through
+`MulticastForwarder::deliver_local` → `IncomingMessageManager::add_incoming_message`
+(`activemsg.cc:1358-1360`), so a barrier handler that declared `handle_inline` would run
+*inside* the envelope handler with a 5 µs budget. If an inline fast path is ever wanted,
+it must be `mutex.trylock()` + fixed-size state only, returning false on any miss — and
+it must be justified with measurements, not added opportunistically.
+
+**R4 — A deferred continuation captures what it needs at creation.**
+`DeferredBarrierArrival` stores the `BarrierImpl*` (and, if needed, the injected
+notifier), not a `Barrier` handle to be re-resolved through `get_runtime()`
+(`cc:582`). It must also copy any payload out of the active-message buffer before the
+handler returns — the pointer handed to a handler is valid only for that call
+(`activemsg.cc:353`, `:404-438`). Same obligation for `deferred_plan_payload` (§3.4
+action P step 2) and for any parked report.
+
+**R5 — Correct with an already-expired budget, and with no budget.** A queued handler
+runs either on a bgwork worker with the *shared* 100 µs quantum
+(`activemsg.cc:765-767`, `bgwork.cc:570`, `bgwork.h:48`) — so it routinely starts with
+microseconds left, and `TimeLimit::is_expired()` also returns true whenever the worker's
+`interrupt_flag` flips asynchronously — or on a dedicated handler thread with an
+infinite `TimeLimit()` (`activemsg.cc:874`). **Protocol progress must never be
+conditional on time remaining.** No loop may assume it gets one iteration. Every
+critical section runs to completion; only the post-unlock waiter drain consults the
+budget, and only because `trigger_event_waiters` does.
+
+**R6 — S2/S3 apply to the deferral seam too.** The post-unlock phase reads only locals.
+That is what makes it safe for the drained waiter list to outlive the section, and it is
+what stops a waiter callback that re-enters the barrier from observing half an action.
+
+---
+
+## 6. Consequences for the wire (summary only)
+
+Recorded here because the state layout depends on them; the message catalogue itself is
+C-stage work.
+
+| Message | Carries | Notes |
+|---|---|---|
+| `report` / `direct` | `gen`, cumulative `val`; **plus** a `(node,count)` map when the sender is flushing | header stays < 128 B (GASNet-EX `INLINE_SIZE`, `gasnetex_module.cc:159-186`); the map is payload. Use `EncodedMulticastTargets` for the node set plus a parallel varint count array, or an interleaved `(delta_node,count)` varint stream — Q6 |
+| `flush` | `gen` | fixed size |
+| `invalidate` | `epoch` | fixed size |
+| `newplan` | `epoch`, `base_arrival_count`, and the recipient's **subtree** (its own quota/kids plus its descendants') | must carry the subtree, not just the node's own record, because the recipient forwards it. This is why `deferred_plan_payload` is bytes, not a struct |
+| `alter` | `gen`, `delta`, `ts` | fixed size |
+| `tsdirect` | `gen`, `ts`, `count` | **no `seq`** (§8.4) |
+| `notify` | `wm`, `prev`, `sv`, poison in `(prev,wm]`; payload = encoded `R` **only when `sv` changed** | sent via `multicast_message` (`activemsg.inl:796-806`), fire-and-forget, origin-as-sender |
+| `subscribe` | `lk`, `subscribe_gen` | one type for both paths; the owner forks on `redop_id` |
+| `reply` | `wm`, `sv`, poison in `(lk,wm]` | point-to-point, so it can be keyed exactly to `lk` |
+| `depart` | — | unicast to owner, staggered in generations |
+
+Message structs must move out of the anonymous namespace in `barrier_impl.cc` into a
+shared header if the implementation is split across translation units; internal linkage
+would otherwise pin every send site to one `.cc`.
+
+`prev` is the owner's pre-trigger watermark, exactly as the model has it. A tempting
+robustness extension — send `prev = max(first_generation, wm - W)` for a small window
+`W` with `pois` widened to match, so one reordered notification does not cost every
+subscriber a pull — appears sound (the receiver's gap test only becomes *more*
+permissive, and the wider `pois` keeps the union exact). It is **not** adopted here,
+because it is not what was model-checked. Q5.
+
+---
+
+## 7. Reset, reclaim, and the retention contract
+
+Arrival §8.8 and notification §8.5 both make this an explicit obligation, and
+`BarrierImpl::init` currently discharges none of it: it clears `remote_subscribe_gens`
+and `remote_trigger_gens` but not `generations` or `held_triggers`, never resets
+`redop_id`, `has_external_waiters`, `first_generation` or `value_capacity`, and
+`~BarrierImpl` is empty so every `Generation` in the map leaks.
+
+### 7.1 `init(ID, owner)` — full reset
+
+Must leave the object indistinguishable from a fresh one. Every tier-3 member is reset;
+every `Generation*` in `generations` is deleted; `owner_state` and `legacy` are reset to
+null; `poisoned_generations` is freed and `num_poisoned_generations` stored to 0;
+`generation` and `first_generation` are stored last. `init` runs before the object is
+reachable by any other thread, so it needs no lock — but that is a *precondition to be
+asserted*, not an assumption to leave implicit.
+
+### 7.2 Per-generation reclamation
+
+A `Generation` record is freed:
+- at the owner, in action T, as its generation is drained;
+- at a non-owner, in action N/RP, for every record at or below the new watermark.
+
+Once freed, any late `report`/`direct`/`tsdirect` for that generation is dropped by the
+`gen <= generation` test that opens actions R and TS. Those two tests are what make
+reclamation safe; they are not optional.
+
+### 7.3 Pruning the alteration state (owner)
+
+At each trigger:
+- fold `alter_steps` entries with key `<= watermark` into `expected_floor`;
+- drop `applied_ts` entry `(ts, g)` for node `n` once there is a later entry `(ts2, g2)`
+  from the same node with `watermark >= g2 - 1` — at that point every generation below
+  `g2` has triggered, so no future arrival from `n` can carry `ts`
+  (arrivals for generation `h` carry the timestamp of `n`'s latest alteration with
+  `gen <= h`);
+- on the issuing node, drop `ts_floor` breakpoints below the greatest one `<= watermark + 1`.
+
+Steady state is O(1) per altering node. The residual is one `applied_ts` entry per node
+that has *ever* altered this barrier — O(N) for a barrier every node alters. Alterations
+are rare by assumption; if that assumption breaks, this is where it shows up.
+
+### 7.4 Poison retention
+
+The owner retains the poisoned set over `[first_generation, watermark]` because rule 5
+requires answering a new subscriber with everything above its `lk`. With the
+fixed-capacity array of D7 that is a hard cap on how many generations of one barrier may
+be poisoned. Q3.
+
+### 7.5 `destroy_barrier`
+
+`Barrier::destroy_barrier` is a bare log statement today (`cc:63-66`) and there is no
+`free_entry` to match `alloc_entry` (`cc:139`), so barriers are never recycled and
+`first_generation` never advances. Notification §8.5's bound on poison retention rests
+on `first_generation` advancing when an id is reused — a mechanism that does not exist.
+Q2 asks whether to implement it or to state explicitly that retention is bounded by
+process lifetime. Whichever is chosen, **the retention floor is `first_generation`** and
+every retention rule above is expressed against it.
+
+---
+
+## 8. What this buys, versus today
+
+| | Today | After |
+|---|---|---|
+| Owner state per barrier | 2 × `std::map<unsigned,gen_t>` ≈ 96·N bytes | `NodeSet` (16 B inline, else N/8 B) + `set_ver` |
+| Trigger notification | one unicast per subscriber, keyed by a per-node map | one multicast to the encoded set; the delta is uniform |
+| Out-of-order notification | buffered in `held_triggers` indefinitely | discarded; one pull; `previous_gen` survives as the gap detector |
+| `owner` | mutable, read unlocked at `cc:744` (a real race) | write-once |
+| Trigger receive path | two divergent copies, one of them unlocked | one |
+| Sends under the lock | `broadcast_trigger` at `cc:1031-1035` | forbidden by S2, asserted by S4 |
+| `get_runtime()` in barrier code | 12 call sites, one on a deferred path | zero |
+| `TimeLimit::responsive()` | 4 manufactured budgets | zero |
+
+---
+
+## 9. Open questions
+
+These are the things I could not settle from the code and the two protocol documents.
+Each one changes either the layout above or an externally visible behaviour, so each one
+needs an answer before the stage that depends on it.
+
+**Q1 — Is `alter_arrival_count` persistent, and does Legion already depend on it not
+being?** `event.h:271-273` says the change applies to this generation *and every
+subsequent one*; `BarrierArrive:433-434` models it that way; `TriggerCorrect` is checked
+against it. The current implementation is **not** persistent — the delta lands in one
+generation's `unguarded_delta` and `base_arrival_count` never changes. If Legion's
+`PhaseBarrier` / dynamic-collective code calls `alter_arrival_count` once per generation
+(which is the natural thing to do against the current behaviour), making it persistent
+double-counts and the barrier hangs. This is the single highest-risk item in the whole
+plan and it is not visible in this repository: there is **zero** coverage of
+`alter_arrival_count` anywhere in `tests/`, `tutorials/`, `examples/` or `benchmarks/`.
+Blocks C6. *Needs: an answer from the Legion side, or a Legion-integration run that
+actually exercises the API.*
+
+**Q2 — Is destroy/reuse in scope?** `destroy_barrier` is a no-op, there is no
+`free_entry`, and `first_generation` never advances. Notification §8.5 bounds poison
+retention on that advance; arrival §8.8 makes `destroy_barrier` the cleanup point. Either
+implement destroy + id reuse (which also decides what a use-after-destroy does — today
+`has_triggered` on a stale handle silently answers from the recycled barrier's watermark),
+or state that retention is bounded by process lifetime and that the §8.5 bound is
+currently unenforced. Also: `tests/barrier_reduce.cc:289` destroys the *advanced* handle
+rather than the created one, which will start to matter.
+
+**Q3 — Poison capacity and the overflow policy.** D7 adopts `GenEventImpl`'s fixed
+array. `POISONED_GENERATION_LIMIT` is 16 (`event_impl.h:325`) and `GenEventImpl` handles
+overflow by refusing to recycle the id (`event_impl.cc:1768-1769`). A barrier has up to
+2²⁰ generations, so 16 is a real cap on how many of them may be poisoned in one
+barrier's life. Options: (a) same limit, same "retire the id" policy — cheapest, and
+barriers are never recycled today anyway; (b) a larger fixed limit; (c) the §8.5 escape
+hatch — cap what a *notification* carries and let nodes pull for detail, which needs the
+owner to retain more than the reader array does. Blocks C7.
+
+**Q4 — Can a barrier generation be poisoned at all, and by what?** The only plausible
+source is `arrive(wait_on = <poisoned event>)`, which today hits
+`assert(poisoned == POISON_FIXME)` at `cc:579` and aborts. Three possible semantics:
+propagate (the generation is poisoned and every waiter is woken poisoned), count the
+arrival and ignore the poison, or keep the fatal error. Notification rules 4 and 5 and
+`PoisonAccurate` are being implemented for behaviour that has never existed, and there is
+no baseline to preserve — nothing in the tree would notice any of the three. Related, and
+listed separately because it is a *regression* rather than a gap: §4's last paragraph —
+a node that subscribes once and then only polls `has_triggered` will now be departed and
+will poll a frozen watermark forever. The clean options are (i) document that polling
+without an outstanding waiter or subscribe is unsupported and fix
+`benchmarks/task_throughput/task_throughput.cc:92-101`, or (ii) allow `has_triggered` a
+single **relaxed** store to a `poll_watermark` that `Depart` consults — lock-free and
+wait-free, but it violates the letter of §12 ("a single atomic load of the watermark and
+nothing else"). I have specified (i); (ii) needs an explicit ruling because it is a
+deliberate deviation from a normative document.
+
+**Q5 — May a notification use `prev < watermark` with a widened poison range?** §6
+sketches it: it costs nothing, it makes a single reordered notification free instead of
+costing every subscriber a pull, and the receiver logic is unchanged. I believe it is
+sound (the gap test only becomes more permissive and the union stays exact), but it is
+not the state `BarrierNotify` was checked in. If it is wanted, it needs a re-run of
+`Notify.cfg` with `prev` weakened, not an argument.
+
+**Q6 — What bounds an eager-flush report and a `newplan` subtree payload?** Both are
+O(subtree). The ~1 MB `MessageBlock` (`activemsg.cc:353`) is an assert, not graceful
+degradation, and active-message fragmentation does **not** raise it because reassembly
+happens first. If either can exceed it at target scale, chunking has to be a
+*protocol-level* rule (the receiver reassembling a multi-part plan or report), which is
+new protocol surface and would want its own model. Also unsettled: whether the
+`(node,count)` payload uses the codec's node-set encoding plus a parallel varint count
+array, or a single interleaved `(delta_node,count)` varint stream. The codec wins hard
+when the participating set is contiguous or nearly all nodes; the interleaved form is
+simpler for small scattered sets. Settle with `encoded_size()` measurements before C5.
+
+**Q7 — Is one mutex per barrier acceptable for the arrival rate?** §12 is satisfied
+trivially by a single lock, but every local `arrive()` serialises on it. The obvious
+refinement — make `local_total` an atomic increment and take the lock only when it
+crosses the quota — tears `Arrive`, whose guard reads `flushing`, the quota, the child
+states and `local_total` together. If measurement shows the barrier lock is hot, the
+change is a protocol question (does a "fast arrive" that observes a stale `flushing`
+still satisfy rule 2?), not a local optimisation. Do not attempt it before Phase F has a
+concurrency baseline.
+
+**Q8 — One injectable transport seam, or none?** `BarrierCommunicator` today is used by
+6 of 12 send sites, its `trigger()` body is compiled out in the shipping configuration,
+and its only consumer — `tests/unit_tests/barrier_test.cc` — **is not in any CMake
+target and has never run in CI**. §2.3 keeps it and routes everything through it, because
+the alternative (deleting it) gives up the ability to drive both protocols in-process the
+way `MulticastTransport` lets `multicast_test.cc` drive a whole tree — and Phase F needs
+exactly that. But the current per-object `unique_ptr` costs a heap allocation, a vtable
+and (today) a runtime config lookup per barrier, and barriers are bulk-constructed 16 at
+a time. A per-node hook injected by `BarrierImplAllocator` would be cheaper. Decide
+before C1 fixes the method set, because every Phase F unit test depends on its shape.
+
+**Q9 — ANSWERED: NO. Leave `external_wait` exactly as it is; it is unrelated to these protocols and out of scope. Original question retained below for context.** ~~Should `external_wait` come off the main mutex?~~ The wait condition is
+`gen_needed > watermark` and the watermark is atomic, so the outer lock is arguably there
+only to serialise the hand-over-hand against the signal sites. Removing it would take a
+nested `KernelMutex` acquisition out of the `Trigger` critical section — which is
+attractive precisely because `Trigger` is now the biggest section in the file. But the
+lost-wakeup argument and all signal sites have to be re-derived together; a plain
+`generation.load()` plus a condvar reintroduces the race. Not required for correctness;
+worth doing only if `Trigger` measures badly.
+
+**Q10 — Which existing tests are the baseline?** `tests/unit_tests/barrier_test.cc` is
+absent from `REALM_UNIT_TESTS` (`tests/CMakeLists.txt:93-130`) and has never run —
+`git log -S` finds it was never registered there at all. It still compiles. Before C1
+deletes anything, it should be registered and run *as-is*, purely to learn whether the
+current implementation passes its own tests; roughly 8 of its 24 tests assert on
+machinery being deleted and must be rewritten, 7 are genuine regression anchors, and 5
+cover the reduction path. Related: `tests/barrier_arrivals.cc` returns immediately below
+8 ranks (CI runs 1–2), has 2 of its 3 patterns commented out, and creates a zero-count
+barrier that arrival rule 9 makes a fatal error — it looks like coverage and is inert.
+And the Phase F TSAN gate does not exist: every sanitizer configuration in
+`.github/workflows/ci.yml` sets `gasnet:OFF` and `ucx:OFF`, so all sanitizer coverage is
+single-node, and the two networked configurations have no sanitizer.

--- a/tla/barrier/STATE_AND_LOCKING.md
+++ b/tla/barrier/STATE_AND_LOCKING.md
@@ -1,3 +1,20 @@
+<!--
+Copyright 2026 Stanford University, NVIDIA Corporation
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # BarrierImpl — State Layout and Locking Discipline
 
 > ## §0. DECISIONS — these supersede anything below

--- a/tla/barrier/Seven.cfg
+++ b/tla/barrier/Seven.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Nodes     <- MCNodes
+    Owner     <- MCOwner
+    MaxGen    <- MCMaxGen
+    Pattern   <- MCPattern
+    NumPlans  <- MCNumPlans
+    Plans     <- MCPlans
+    PlanStart <- MCPlanStart
+    BaseCount <- MCBaseCount
+    AlterOps  <- MCAlterOps
+
+INVARIANTS
+    TypeOK
+    TriggerInOrder
+    TriggerCorrect
+    NoOverCount
+    ReachableWhileHolding
+    BoundedRetention

--- a/tla/barrier/Seven.cfg
+++ b/tla/barrier/Seven.cfg
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 SPECIFICATION Spec
 
 CONSTANTS

--- a/tla/barrier/Small.cfg
+++ b/tla/barrier/Small.cfg
@@ -1,0 +1,14 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Nodes       <- MCNodes
+    MaxGen      <- MCMaxGen
+    PoisonGens  <- MCPoisonGens
+    WaitPattern <- MCWaitPattern
+
+INVARIANTS
+    TypeOK
+    NeverOverstate
+    PoisonAccurate
+    NoStranded
+    MembershipPublished

--- a/tla/barrier/Small.cfg
+++ b/tla/barrier/Small.cfg
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 SPECIFICATION Spec
 
 CONSTANTS

--- a/tla/barrier/Stale.cfg
+++ b/tla/barrier/Stale.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Nodes     <- MCNodes
+    Owner     <- MCOwner
+    MaxGen    <- MCMaxGen
+    Pattern   <- MCPattern
+    NumPlans  <- MCNumPlans
+    Plans     <- MCPlans
+    PlanStart <- MCPlanStart
+    BaseCount <- MCBaseCount
+    AlterOps  <- MCAlterOps
+
+INVARIANTS
+    TypeOK
+    TriggerInOrder
+    TriggerCorrect
+    NoOverCount
+    ReachableWhileHolding
+    BoundedRetention

--- a/tla/barrier/Stale.cfg
+++ b/tla/barrier/Stale.cfg
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 SPECIFICATION Spec
 
 CONSTANTS

--- a/tla/barrier/Strand.cfg
+++ b/tla/barrier/Strand.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Nodes     <- MCNodes
+    Owner     <- MCOwner
+    MaxGen    <- MCMaxGen
+    Pattern   <- MCPattern
+    NumPlans  <- MCNumPlans
+    Plans     <- MCPlans
+    PlanStart <- MCPlanStart
+    BaseCount <- MCBaseCount
+    AlterOps  <- MCAlterOps
+
+INVARIANTS
+    TypeOK
+    TriggerInOrder
+    TriggerCorrect
+    NoOverCount
+    ReachableWhileHolding
+    BoundedRetention

--- a/tla/barrier/Strand.cfg
+++ b/tla/barrier/Strand.cfg
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 SPECIFICATION Spec
 
 CONSTANTS

--- a/tla/barrier/Strand2.cfg
+++ b/tla/barrier/Strand2.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Nodes     <- MCNodes
+    Owner     <- MCOwner
+    MaxGen    <- MCMaxGen
+    Pattern   <- MCPattern
+    NumPlans  <- MCNumPlans
+    Plans     <- MCPlans
+    PlanStart <- MCPlanStart
+    BaseCount <- MCBaseCount
+    AlterOps  <- MCAlterOps
+
+INVARIANTS
+    TypeOK
+    TriggerInOrder
+    TriggerCorrect
+    NoOverCount
+    ReachableWhileHolding
+    BoundedRetention

--- a/tla/barrier/Strand2.cfg
+++ b/tla/barrier/Strand2.cfg
@@ -1,3 +1,18 @@
+\* Copyright 2026 Stanford University, NVIDIA Corporation
+\* SPDX-License-Identifier: Apache-2.0
+\*
+\* Licensed under the Apache License, Version 2.0 (the "License");
+\* you may not use this file except in compliance with the License.
+\* You may obtain a copy of the License at
+\*
+\*     http://www.apache.org/licenses/LICENSE-2.0
+\*
+\* Unless required by applicable law or agreed to in writing, software
+\* distributed under the License is distributed on an "AS IS" BASIS,
+\* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+\* See the License for the specific language governing permissions and
+\* limitations under the License.
+
 SPECIFICATION Spec
 
 CONSTANTS

--- a/tla/barrier/battery.py
+++ b/tla/barrier/battery.py
@@ -70,7 +70,12 @@ ARRIVAL = [
                                           to |-> c, epoch |-> m.epoch ] : c \\in kids }""", "")]),
  ("accept stale reports (running total may go down)", "Double.cfg", "MCDouble", "CATCH",
   [("    /\\ m.val > childAcc[m.to][m.from][m.gen]\n", "")]),
- ("case 3 sends its count but NO flush signal", "Stale.cfg", "MCStale", "CATCH",
+ # SUBSUMED BY THE OWNER VALVE (BarrierArrive rule 6): under quota-gated
+ #  forwarding the mask probe found NO scenario that strands without the
+ #  case-3 flush signal - the owner's non-kid/value tests recover every one.
+ #  The signal stays in the implementation regardless: its flush traffic is
+ #  the plan-learning evidence (ARRIVAL_PROTOCOL.md section 11).
+ ("case 3 sends its count but NO flush signal (subsumed)", "Stale.cfg", "MCStale", "BENIGN",
   [("""                /\\ msgs' = msgs \\cup Send(n, g, sub)
                            \\cup {[ kind |-> "flush", from |-> n, to |-> Owner, gen |-> g ]}""",
     """                /\\ msgs' = msgs \\cup Send(n, g, sub)""")]),
@@ -85,12 +90,16 @@ ARRIVAL = [
  ("no install guard: newplan installed after its retirement was seen", "Strand2.cfg", "MCStrand2", "CATCH",
   [("    /\\ IF (myEpoch[m.to] >= m.epoch) \\/ (invalEpoch[m.to] >= m.epoch)",
     "    /\\ IF myEpoch[m.to] >= m.epoch")]),
- ("no planless-outsider", "Stale.cfg", "MCStale", "CATCH",
+ # REPOINTED under quota-gated forwarding: the owner valve rescues MCStale's
+ #  strand, but five other scenarios still catch this one.
+ ("no planless-outsider", "Double.cfg", "MCDouble", "CATCH",
   [("""                                            ELSE [curPlan EXCEPT ![m.to] =
                                                     [quota |-> 0, inplan |-> FALSE,
                                                      kids |-> {}]]""",
     """                                            ELSE curPlan""")]),
- ("no retroactive case 3", "Stale.cfg", "MCStale", "CATCH",
+ # SUBSUMED BY THE OWNER VALVE, same verdict and same caveat as the
+ #  immediate case-3 signal above: retained for plan learning.
+ ("no retroactive case 3 (subsumed)", "Stale.cfg", "MCStale", "BENIGN",
   [("""                                 \\cup (IF ~live /\\ (m.to # Owner)
                                          THEN { [ kind |-> "flush", from |-> m.to,
                                                   to |-> Owner, gen |-> g ] :
@@ -121,6 +130,77 @@ ARRIVAL = [
     """                                           IF (g = watermark + 1) /\\ ~triggered[g]
                                                 /\\ SubtreeKnown(m.to, g) > 0
                                              THEN TRUE""")]),
+]
+
+# QUOTA-GATED FORWARDING (BarrierArrive rules 1 and 6).  Each row removes one
+#  of the gate's mechanisms; the MCGate* scenarios were each built to strand
+#  without exactly one of them (the iteration record is SCALE_TEST_PLAN.md).
+#  MCGatePark catches two different mechanisms through its two interleavings:
+#  counts arriving before the parked install need the re-fan, counts arriving
+#  after it need the stale-edge signal.
+GATE = [
+ ("audit: switch-time value/orphan audit removed", "GateMove.cfg", "MCGateMove", "CATCH",
+  [("""                                     /\\ \\/ flushing[Owner][h]
+                                        \\/ \\E s \\in Nodes \\ {Owner} :
+                                             \\/ childAcc[Owner][s][h] > SubQ(k, s)
+                                             \\/ /\\ childAcc[Owner][s][h] > 0
+                                                /\\ s \\notin Plans[k][Owner].kids }""",
+    """                                     /\\ flushing[Owner][h] }""")]),
+ ("valve: receipt-time value-exceeds test removed", "GateOver.cfg", "MCGateOver", "CATCH",
+  [("""OwnerDeviant(m) == /\\ m.to = Owner
+                   /\\ \\/ m.from \\notin KidsOf(Owner)
+                      \\/ m.val > SubQ(myEpoch[Owner], m.from)""",
+    """OwnerDeviant(m) == /\\ m.to = Owner
+                   /\\ m.from \\notin KidsOf(Owner)""")]),
+ ("valve: receipt-time non-kid test removed", "GateDemote.cfg", "MCGateDemote", "CATCH",
+  [("""OwnerDeviant(m) == /\\ m.to = Owner
+                   /\\ \\/ m.from \\notin KidsOf(Owner)
+                      \\/ m.val > SubQ(myEpoch[Owner], m.from)""",
+    """OwnerDeviant(m) == /\\ m.to = Owner
+                   /\\ m.val > SubQ(myEpoch[Owner], m.from)""")]),
+ ("audit: orphaned-sender branch removed", "GateDemote.cfg", "MCGateDemote", "CATCH",
+  [("""                                             \\/ /\\ childAcc[Owner][s][h] > 0
+                                                /\\ s \\notin Plans[k][Owner].kids }""",
+    """                                             }""")]),
+ ("re-fan: newplan install does not re-announce flush", "GateDemote.cfg", "MCGateDemote", "CATCH",
+  [("""                                        \\cup UNION { { [ kind |-> "flush", from |-> m.to,
+                                                         to |-> c, gen |-> h ] :
+                                                         c \\in Plans[m.epoch][m.to].kids } :
+                                                       h \\in { x \\in Gens :
+                                                                 ~triggered[x]
+                                                                 /\\ flushing[m.to][x] } }
+""", "")]),
+ ("re-fan: parked install does not re-announce flush", "GatePark.cfg", "MCGatePark", "CATCH",
+  [("""                                              \\cup
+                                              UNION { { [ kind |-> "flush", from |-> m.to,
+                                                          to |-> c, gen |-> x ] :
+                                                          c \\in Plans[dk][m.to].kids } :
+                                                        x \\in { h \\in Gens :
+                                                                  ~triggered[h]
+                                                                  /\\ (flushing[m.to][h]
+                                                                       \\/ SubtreeKnown(m.to, h) > 0) } }
+""", "")]),
+ ("stale-edge receipt sends no owner flush signal", "GatePark.cfg", "MCGatePark", "CATCH",
+  [("""                      \\cup (IF (m.from \\notin KidsOf(m.to)) /\\ (m.to # Owner)
+                              THEN {[ kind |-> "flush", from |-> m.to, to |-> Owner,
+                                      gen |-> m.gen ]} ELSE {})
+""", "")]),
+ ("gate: closes on exact equality (>= becomes =)", "GateJump.cfg", "MCGateJump", "CATCH",
+  [("""                /\\ \\/ /\\ sub >= SubQCur(n)                          \\* case 1: subtree done""",
+    """                /\\ \\/ /\\ sub = SubQCur(n)                           \\* case 1: subtree done"""),
+   ("""                   \\/ /\\ sub < SubQCur(n)""",
+    """                   \\/ /\\ ~( sub = SubQCur(n) )"""),
+   ("""                         /\\ sub2 >= SubQCur(m.to)""",
+    """                         /\\ sub2 = SubQCur(m.to)""")]),
+ # the gate itself is an OPTIMIZATION: removing it reverts to the previously
+ #  verified eager design, so its removal is documented-benign.
+ ("gate removed entirely (reverts to verified eager design)", "GateMove.cfg", "MCGateMove", "BENIGN",
+  [("""                /\\ \\/ /\\ sub >= SubQCur(n)                          \\* case 1: subtree done""",
+    """                /\\ \\/ /\\ TRUE                                       \\* eager: no gate"""),
+   ("""                   \\/ /\\ sub < SubQCur(n)""",
+    """                   \\/ /\\ FALSE"""),
+   ("""                         /\\ sub2 >= SubQCur(m.to)""",
+    """                         /\\ localTotal[m.to][m.gen] = curPlan[m.to].quota""")]),
 ]
 
 ALTER = [
@@ -176,6 +256,7 @@ NOTIFY = [
 
 SUITES = {
     "arrival": ("BarrierArrive.tla", ARRIVAL),
+    "gate": ("BarrierArrive.tla", GATE),
     "alter": ("BarrierArrive.tla", ALTER),
     "notify": ("BarrierNotify.tla", NOTIFY),
 }

--- a/tla/barrier/battery.py
+++ b/tla/barrier/battery.py
@@ -1,4 +1,19 @@
 #!/usr/bin/env python3
+# Copyright 2026 Stanford University, NVIDIA Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # The MUTATION BATTERY for the scalable-barrier specifications.
 #
 # Both protocol documents end with the same instruction: "if you change any of

--- a/tla/barrier/battery.py
+++ b/tla/barrier/battery.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+# The MUTATION BATTERY for the scalable-barrier specifications.
+#
+# Both protocol documents end with the same instruction: "if you change any of
+# these rules, re-run the battery."  This is the battery.  Each row disables
+# one protocol rule and model-checks a scenario CHOSEN TO CATCH exactly that
+# mutation - the pairing is load-bearing, not cosmetic: this project produced
+# two false verification results from mutations paired with scenarios that
+# lacked the structure to catch them (see ARRIVAL_PROTOCOL.md section 7, the
+# masking note).
+#
+# Verdicts:
+#   OK  caught      - the scenario rejects the mutated spec, as expected
+#   OK  benign      - a deliberate negative control passed, as expected
+#   XX  ...         - a mismatch: either a rule has silently become redundant
+#                     (investigate before celebrating - see the child-wait and
+#                     stale-edge histories, which went opposite ways) or a
+#                     scenario has lost its teeth
+#   EDIT-FAIL       - a mutation pattern no longer matches the spec exactly
+#                     once; the battery REFUSES to run rather than silently
+#                     testing the wrong site (this exact failure produced a
+#                     false result once)
+#
+# Usage:  python3 battery.py [arrival|alter|notify|all]
+# Needs:  java on PATH or at JAVA below; tools/tla2tools.jar (see README.md).
+# Time:   ~15-30 min for 'all'.  Rows that catch stop at the violation and are
+#         fast; NOT-CAUGHT rows and negative controls explore the whole state
+#         space.  TLC scratch can reach tens of GB - it is confined to a
+#         temp dir and removed per row.
+#
+# NEVER point this at the canonical .tla files in place: every row runs on a
+# COPY in a scratch directory.  A killed run must not be able to leave a
+# mutated spec on disk (that also happened once).
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+JAVA = os.environ.get("TLA_JAVA", "/opt/homebrew/opt/openjdk/bin/java")
+if not os.path.exists(JAVA):
+    JAVA = "java"
+JAR = os.path.join(HERE, "tools", "tla2tools.jar")
+
+# (name, spec, config, module, expect, [(old, new), ...])
+#   expect: "CATCH" or "BENIGN"
+ARRIVAL = [
+ ("no deferral: park condition disabled", "Park.cfg", "MCPark", "CATCH",
+  [("         ELSE IF curPlan[m.to].inplan /\\ (invalEpoch[m.to] < myEpoch[m.to])",
+    "         ELSE IF FALSE")]),
+ ("forget the child list BEFORE forwarding the invalidation", "Park.cfg", "MCPark", "CATCH",
+  [("""                                 \\cup { [ kind |-> "invalidate", from |-> m.to,
+                                          to |-> c, epoch |-> m.epoch ] : c \\in kids }""", "")]),
+ ("accept stale reports (running total may go down)", "Double.cfg", "MCDouble", "CATCH",
+  [("    /\\ m.val > childAcc[m.to][m.from][m.gen]\n", "")]),
+ ("case 3 sends its count but NO flush signal", "Stale.cfg", "MCStale", "CATCH",
+  [("""                /\\ msgs' = msgs \\cup Send(n, g, sub)
+                           \\cup {[ kind |-> "flush", from |-> n, to |-> Owner, gen |-> g ]}""",
+    """                /\\ msgs' = msgs \\cup Send(n, g, sub)""")]),
+ ("no eager flush on over-arrival", "Over.cfg", "MCOver", "CATCH",
+  [("                /\\ lt > curPlan[n].quota                            \\* case 2: over-arrival",
+    "                /\\ FALSE")]),
+ ("no pinning: reports follow the current plan", "Double.cfg", "MCDouble", "CATCH",
+  [("TargetOf(n, g) == IF reportTo[n][g] # NoTarget THEN reportTo[n][g] ELSE ParentOf(n)",
+    "TargetOf(n, g) == ParentOf(n)")]),
+ ("no live guard: parked plan installed by its own retirement", "Strand2.cfg", "MCStrand2", "CATCH",
+  [("                      live == dk > m.epoch", "                      live == dk > 0")]),
+ ("no install guard: newplan installed after its retirement was seen", "Strand2.cfg", "MCStrand2", "CATCH",
+  [("    /\\ IF (myEpoch[m.to] >= m.epoch) \\/ (invalEpoch[m.to] >= m.epoch)",
+    "    /\\ IF myEpoch[m.to] >= m.epoch")]),
+ ("no planless-outsider", "Stale.cfg", "MCStale", "CATCH",
+  [("""                                            ELSE [curPlan EXCEPT ![m.to] =
+                                                    [quota |-> 0, inplan |-> FALSE,
+                                                     kids |-> {}]]""",
+    """                                            ELSE curPlan""")]),
+ ("no retroactive case 3", "Stale.cfg", "MCStale", "CATCH",
+  [("""                                 \\cup (IF ~live /\\ (m.to # Owner)
+                                         THEN { [ kind |-> "flush", from |-> m.to,
+                                                  to |-> Owner, gen |-> g ] :
+                                                  g \\in { h \\in Gens :
+                                                            ~triggered[h]
+                                                            /\\ localTotal[m.to][h] > 0 } }
+                                         ELSE {})""", "")]),
+ ("case 3 loses priority to the flushing flag", "Stale.cfg", "MCStale", "CATCH",
+  [("""             \\/ /\\ ~curPlan[n].inplan                                \\* case 3""",
+    """             \\/ /\\ ~flushing[n][g] /\\ ~curPlan[n].inplan            \\* case 3""")]),
+ ("a plan install clears flush (the race)", "Stale.cfg", "MCStale", "CATCH",
+  [("""                             \\* a plan install NEVER clears flush: a flushed
+                             \\*  generation stays eager until it triggers (see
+                             \\*  RecvInvalidate).  Planned mode is what governs
+                             \\*  the generations that are NOT flushed.
+                             /\\ UNCHANGED flushing""",
+    """                             /\\ flushing' = [flushing EXCEPT ![m.to] =
+                                               [g \\in Gens |-> IF ~triggered[g] THEN FALSE
+                                                                        ELSE flushing[m.to][g]]]""")]),
+ ("no stale-edge forwarding", "Double.cfg", "MCDouble", "CATCH",
+  [("                      \\/ (m.from \\notin KidsOf(m.to))", "")]),
+ # SUBSUMED, kept as a documented negative result (ARRIVAL_PROTOCOL rule 6):
+ #  the rule-10 machinery covers what invalidate-time all-generation flushing
+ #  used to.  If this row ever starts CATCHING, rule 6's honesty note is stale.
+ ("flush only the switch generation at invalidate (subsumed)", "Strand2.cfg", "MCStrand2", "BENIGN",
+  [("""                                           IF ~triggered[g] /\\ SubtreeKnown(m.to, g) > 0
+                                             THEN TRUE""",
+    """                                           IF (g = watermark + 1) /\\ ~triggered[g]
+                                                /\\ SubtreeKnown(m.to, g) > 0
+                                             THEN TRUE""")]),
+]
+
+ALTER = [
+ ("owner counts a ts arrival WITHOUT applying its alteration", "Alter.cfg", "MCAlter", "CATCH",
+  [("    /\\ m.ts \\in appliedTs\n    /\\ m.val > tsAcc[m.from][m.gen]\n",
+    "    /\\ m.val > tsAcc[m.from][m.gen]\n")]),
+ ("timestamped arrivals aggregate through the TREE (ts erased)", "Alter.cfg", "MCAlter", "CATCH",
+  [("          /\\ myTs[n][g] > 0\n", "          /\\ FALSE\n"),
+   ("       \\/ /\\ myTs[n][g] = 0\n", "       \\/ /\\ TRUE\n")]),
+ ("altering node does NOT enter eager flush (stops relaying)", "Alter.cfg", "MCAlter", "CATCH",
+  [("""       IN  /\\ flushing' = [flushing EXCEPT ![a.node] =
+                             [g \\in Gens |-> IF g \\in aff THEN TRUE
+                                                          ELSE flushing[a.node][g]]]""",
+    """       IN  /\\ flushing' = flushing""")]),
+ ("no reserved-arrival contract guard", "Alter.cfg", "MCAlter", "CATCH",
+  [("    /\\ unissued[a.node][a.gen] > 0\n", "")]),
+]
+
+NOTIFY = [
+ ("apply a delta notification DESPITE a gap", "Notify.cfg", "MCNotify", "CATCH",
+  [("           gap   == m.prev > known[m.to]", "           gap   == FALSE")]),
+ ("no recovery: removed node with a live waiter does NOT re-subscribe", "Notify.cfg", "MCNotify", "CATCH",
+  [('           resub == (mem0 = "NO") /\\ (w2 # {})', "           resub == FALSE")]),
+ ("no version gate: stale notify may resurrect membership", "Notify.cfg", "MCNotify", "CATCH",
+  [('''           mem0  == IF newv THEN (IF m.inset THEN "YES" ELSE "NO")
+                            ELSE member[m.to]''',
+    '''           mem0  == IF m.inset THEN "YES" ELSE "NO"''')]),
+ ("shrink published to the POST-shrink set", "Notify.cfg", "MCNotify", "CATCH",
+  [("inset |-> (c \\notin R), sv |-> sv2 ] : c \\in subSet }",
+    "inset |-> (c \\notin R), sv |-> sv2 ] : c \\in (subSet \\ R) }")]),
+ ("adds are discretionary (owner may refuse a subscribe)", "Notify.cfg", "MCNotify", "CATCH",
+  [("""    /\\ LET sv2 == IF m.from \\in subSet THEN setVer ELSE setVer + 1
+       IN  /\\ subSet'  = subSet \\cup {m.from}""",
+    """    /\\ \\E addit \\in BOOLEAN :
+       LET sv2 == IF (m.from \\in subSet) \\/ ~addit THEN setVer ELSE setVer + 1
+       IN  /\\ subSet'  = IF addit THEN subSet \\cup {m.from} ELSE subSet""")]),
+ ("subscribe reply carries no watermark", "Notify.cfg", "MCNotify", "CATCH",
+  [('{[ kind |-> "reply", to |-> m.from, wm |-> watermark,',
+    '{[ kind |-> "reply", to |-> m.from, wm |-> 0,')]),
+ # anchored on the RecvReply comment: RecvNotify contains an identically-worded
+ #  merge line, and an unanchored replace once silently mutated the wrong site
+ ("delta reply SUBSTITUTED rather than merged", "Notify.cfg", "MCNotify", "CATCH",
+  [("""\\*  is unioned in - substituting it would drop older poison
+           np    == IF fresh THEN knownPois[m.to] \\cup m.pois ELSE knownPois[m.to]""",
+    """\\*  is unioned in - substituting it would drop older poison
+           np    == IF fresh THEN m.pois ELSE knownPois[m.to]""")]),
+ # NEGATIVE CONTROL: the depart guard is an optimisation; rule 6's recovery is
+ #  the correctness rule.  Runs on the SMALL scenario - a guard removal grows
+ #  the state space, and MCNotify cannot finish it.
+ ("may depart while holding a waiter (control)", "Small.cfg", "MCNotifySmall", "BENIGN",
+  [("    /\\ waiting[n] = {}\n", "")]),
+]
+
+SUITES = {
+    "arrival": ("BarrierArrive.tla", ARRIVAL),
+    "alter": ("BarrierArrive.tla", ALTER),
+    "notify": ("BarrierNotify.tla", NOTIFY),
+}
+
+
+def classify(out):
+    # NOTE the 'Error:' prefix: grepping for the bare 'Invariant ... is
+    #  violated' misses it, which once degraded every verdict to a fallback.
+    if "Error: Invariant" in out:
+        return "caught: " + out.split("Error: Invariant")[1].split("is violated")[0].strip()
+    if "Deadlock reached" in out:
+        return "caught: deadlock"
+    if "No error has been found" in out:
+        return "not caught"
+    return "ERROR/UNPARSED"
+
+
+def run_row(specfile, name, cfg, module, expect, edits):
+    spec = open(os.path.join(HERE, specfile)).read()
+    for old, new in edits:
+        n = spec.count(old)
+        if n != 1:
+            return ("EDIT-FAIL", "pattern matches %d sites (need exactly 1)" % n)
+        spec = spec.replace(old, new, 1)
+    with tempfile.TemporaryDirectory(prefix="battery_") as d:
+        os.makedirs(os.path.join(d, "jtmp"))
+        shutil.copy(os.path.join(HERE, cfg), d)
+        shutil.copy(os.path.join(HERE, module + ".tla"), d)
+        open(os.path.join(d, specfile), "w").write(spec)
+        r = subprocess.run(
+            [JAVA, "-Xmx8g", "-XX:+UseParallelGC",
+             "-Djava.io.tmpdir=" + os.path.join(d, "jtmp"),
+             "-cp", JAR, "tlc2.TLC", "-workers", "8", "-config", cfg,
+             module + ".tla"],
+            capture_output=True, text=True, cwd=d, timeout=7200)
+        v = classify(r.stdout)
+    if expect == "CATCH":
+        return ("OK" if v.startswith("caught") else "XX", v)
+    return ("OK" if v == "not caught" else "XX", v + " (expected benign)")
+
+
+def main():
+    which = sys.argv[1] if len(sys.argv) > 1 else "all"
+    names = list(SUITES) if which == "all" else [which]
+    failures = 0
+    for suite in names:
+        specfile, rows = SUITES[suite]
+        print("== %s (%s) ==" % (suite, specfile))
+        for name, cfg, module, expect, edits in rows:
+            tag, verdict = run_row(specfile, name, cfg, module, expect, edits)
+            if tag != "OK":
+                failures += 1
+            print("  %-3s %-13s %-36s %s" % (tag, module, verdict, name), flush=True)
+    print("battery:", "PASS" if failures == 0 else "%d FAILURES" % failures)
+    return 0 if failures == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Rewrites Realm's barrier internals around two tree-structured protocols designed to scale to thousands of nodes, replacing the all-ranks-message-the-owner scheme. Both protocols were designed and formally verified in TLA+ before implementation; the specs, model-checking scenarios, and design documents ship in tla/barrier/ as the normative record.

Design

- Arrival (BarrierArrive.tla, ARRIVAL_PROTOCOL.md): the owner learns an arrival plan from observed traffic and pushes it out; nodes aggregate cumulative counts up the plan tree, staying O(radix) per node in steady state. Deviations (over-arrival, arrivals at unplanned nodes, run-ahead into future generations) trigger per-generation eager flush so no arrival is ever silently stranded; plan changes use an invalidate/new-plan pair with local deferral to resolve their race. Entirely feed-forward: no timers, no polling, no background work.
- Notification (BarrierNotify.tla, NOTIFICATION_PROTOCOL.md): the owner keeps a subscriber set (no learned tree — the multicast layer plans fan-out per send), publishes version-gated membership, and sends trigger notifications as gap-checked deltas; a node that can't apply a delta pulls. Includes departure hysteresis (K=8, adaptive) so the set tracks waiting patterns without timers.

Verification

Every protocol rule (10 arrival + 8 notification) is backed by a mutation battery: disable the rule, and a model-checking scenario chosen for exactly that failure catches it (tla/barrier/battery.py, 26 rows, ~20 min). The models found real bugs before the code did — including a double-count safety bug where re-parenting a node mid-generation counted its arrivals twice, and several liveness strands in plan-switch races — and drove the fixes (pinned report edges, dead-plan install guards, retroactive outsider signaling). They also surfaced one pre-existing bug: alter_arrival_count is documented as persistent across generations but was applied to a single generation; this PR fixes it to match the documented contract (note: behavioral change, and the API previously had zero test coverage anywhere).

Implementation notes

- Barrier migration is removed; reduction barriers keep the existing eager path unchanged.
- One mutex per BarrierImpl; every spec action is one critical section (documented per-action in STATE_AND_LOCKING.md); has_triggered stays lock-free.
- Deviation-path instrumentation counters dump at destroy_barrier — a run's coverage is checkable, not assumed.

Testing

- tests/barrier_scale_test: a 9-phase deviation driver (over-arrival, outsiders, run-ahead, per-generation plan churn, alters, disjoint waiters, poison, seeded chaos) with counter-based exercise proofs; green at 1/2/4 ranks over MPI, TSAN-clean, full suite 839/839.
- New -ll:barrier_plan_radix (default 8, unchanged behavior) lets small-rank runs form deep plan trees, making the plan-switch race windows reachable on a workstation; with radix 2, the deferral and stale-edge paths execute and pass at 4–6 ranks.
- Remaining scale work (2→128 node ladder, two race-window cases that need ≥8 ranks) is specified in tla/barrier/SCALE_TEST_PLAN.md.