### PR TITLE
Dynamically link CUDA when using HIP NVIDIA platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -470,6 +470,9 @@ if(REALM_ENABLE_HIP)
       hip::host PROPERTIES INTERFACE_COMPILE_DEFINITIONS "__HIP_PLATFORM_NVIDIA__"
                            INTERFACE_LINK_LIBRARIES CUDA::cudart
     )
+    if(NOT DEFINED CMAKE_HIP_RUNTIME_LIBRARY)
+      set(CMAKE_HIP_RUNTIME_LIBRARY "Shared")
+    endif()
   endif()
   if(NOT HIP_ROOT_DIR)
     set(HIP_ROOT_DIR "${ROCM_PATH}")


### PR DESCRIPTION
HIP apparently defaults to statically linking CUDA when using the NVIDIA platform, and that causes bad things to happen when the application (or Legion) also uses HIP.