### PR TITLE
Make realm_kokkos look for generated headers in project binary dir

### DIFF
--- a/src/realm/kokkos/CMakeLists.txt
+++ b/src/realm/kokkos/CMakeLists.txt
@@ -40,7 +40,7 @@ target_include_directories(
     realm_kokkos
     PUBLIC
         $<BUILD_INTERFACE:${REALM_SOURCE_DIR}/..>
-        $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
     PRIVATE
         $<$<TARGET_EXISTS:CUDA::cuda_driver>:${CUDAToolkit_CUPTI_INCLUDE_DIR}>
         $<$<TARGET_EXISTS:CUDA::cuda_driver>:${CUDAToolkit_INCLUDE_DIR}>


### PR DESCRIPTION
realm_kokkos looks for the generated headers (realm_defines.h) in ${CMAKE_BINARY_DIR}/include, i.e. the top-level project's binary dir. The headers are generated into Realm's own binary dir (${PROJECT_BINARY_DIR}/include, see src/CMakeLists.txt), which every other Realm target references via ${CMAKE_CURRENT_BINARY_DIR}/include. The two coincide when Realm is the top-level project, but differ when Realm is built as a subproject — e.g. Legion's integrated build, which adds the vendored realm/ subtree via CPM into _deps/realm-build. In that configuration any build with REALM_ENABLE_KOKKOS=ON fails:

  realm/src/realm/../realm/realm_config.h:25:10: fatal error:
  realm_defines.h: No such file or directory

Use PROJECT_BINARY_DIR to agree with where the headers are generated regardless of project nesting.